### PR TITLE
fix: recoverMisplacedFiles now handles directories

### DIFF
--- a/tool/internal/eval/workspace.go
+++ b/tool/internal/eval/workspace.go
@@ -154,24 +154,44 @@ var codeFileExts = map[string]bool{
 	".cfg": true, ".ini": true, ".env": true, ".dockerfile": true,
 }
 
-// snapshotDir returns a set of non-hidden file names in a directory (non-recursive).
+// junkDirs lists directory names that are build/runtime artifacts and should
+// be deleted rather than recovered into the workspace.
+var junkDirs = map[string]bool{
+	"__pycache__":  true,
+	"node_modules": true,
+	"venv":         true,
+	".venv":        true,
+	"env":          true,
+	".tox":         true,
+	"dist":         true,
+	"build":        true,
+	"target":       true,
+	"bin":          true,
+	"obj":          true,
+}
+
+// snapshotDir returns a set of non-hidden entry names (files AND directories) in
+// a directory (non-recursive). Capturing directories lets recoverMisplacedFiles
+// detect new directories created during an eval run.
 func snapshotDir(dir string) map[string]bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}
-	files := make(map[string]bool, len(entries))
+	names := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if !e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
-			files[e.Name()] = true
+		if !strings.HasPrefix(e.Name(), ".") {
+			names[e.Name()] = true
 		}
 	}
-	return files
+	return names
 }
 
-// recoverMisplacedFiles moves files that appeared in dir since the snapshot
-// into destDir. Only moves files with recognized code extensions.
-// Returns the count of recovered files.
+// recoverMisplacedFiles moves files and directories that appeared in dir since
+// the snapshot into destDir. Files with recognized code extensions (or no
+// extension) are moved; new directories are either moved into the workspace or
+// deleted if they match a known junk pattern. Returns the count of recovered
+// items (files + directories moved or cleaned up).
 func recoverMisplacedFiles(dir string, preSnapshot map[string]bool, destDir string, debugPrefix string, debug bool) int {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -179,19 +199,50 @@ func recoverMisplacedFiles(dir string, preSnapshot map[string]bool, destDir stri
 	}
 	recovered := 0
 	for _, e := range entries {
-		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+		if strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
 		if preSnapshot[e.Name()] {
 			continue // existed before eval
 		}
+
+		src := filepath.Join(dir, e.Name())
+
+		if e.IsDir() {
+			// Junk directories → just delete
+			if junkDirs[e.Name()] {
+				if err := os.RemoveAll(src); err == nil {
+					recovered++
+					if debug {
+						log.Printf("[DEBUG] %s: Deleted junk directory: %s", debugPrefix, src)
+					}
+				}
+				continue
+			}
+			// Other new directories → move into workspace
+			dst := filepath.Join(destDir, e.Name())
+			if err := os.Rename(src, dst); err != nil {
+				// Rename may fail across filesystems; fall back to copy+delete
+				if err := copyDir(src, dst); err == nil {
+					os.RemoveAll(src)
+				} else {
+					continue
+				}
+			}
+			recovered++
+			if debug {
+				log.Printf("[DEBUG] %s: Recovered misplaced directory: %s → %s", debugPrefix, src, dst)
+			}
+			continue
+		}
+
+		// Regular file handling (unchanged logic)
 		ext := strings.ToLower(filepath.Ext(e.Name()))
 		// Also recover extensionless files like "Dockerfile", "Makefile"
 		if !codeFileExts[ext] && ext != "" {
 			continue
 		}
 
-		src := filepath.Join(dir, e.Name())
 		dst := filepath.Join(destDir, e.Name())
 		data, err := os.ReadFile(src)
 		if err != nil {

--- a/tool/internal/eval/workspace_test.go
+++ b/tool/internal/eval/workspace_test.go
@@ -1,0 +1,122 @@
+package eval
+
+import (
+"os"
+"path/filepath"
+"testing"
+)
+
+func TestSnapshotDir_CapturesFilesAndDirs(t *testing.T) {
+dir := t.TempDir()
+
+// Create a file and a subdirectory
+os.WriteFile(filepath.Join(dir, "hello.py"), []byte("print('hi')"), 0644)
+os.Mkdir(filepath.Join(dir, "subdir"), 0755)
+os.Mkdir(filepath.Join(dir, ".hidden"), 0755) // should be skipped
+
+snap := snapshotDir(dir)
+if snap == nil {
+t.Fatal("snapshotDir returned nil")
+}
+if !snap["hello.py"] {
+t.Error("snapshotDir should capture files")
+}
+if !snap["subdir"] {
+t.Error("snapshotDir should capture directories")
+}
+if snap[".hidden"] {
+t.Error("snapshotDir should skip hidden entries")
+}
+}
+
+func TestRecoverMisplacedFiles_RecoversNewFiles(t *testing.T) {
+home := t.TempDir()
+workspace := t.TempDir()
+
+// Pre-existing file
+os.WriteFile(filepath.Join(home, "existing.txt"), []byte("old"), 0644)
+snap := snapshotDir(home)
+
+// Simulate agent creating a new file
+os.WriteFile(filepath.Join(home, "main.py"), []byte("print('hello')"), 0644)
+
+recovered := recoverMisplacedFiles(home, snap, workspace, "test", false)
+if recovered != 1 {
+t.Fatalf("expected 1 recovered, got %d", recovered)
+}
+// File should exist in workspace
+if _, err := os.Stat(filepath.Join(workspace, "main.py")); err != nil {
+t.Error("main.py should be in workspace")
+}
+// File should be removed from home
+if _, err := os.Stat(filepath.Join(home, "main.py")); err == nil {
+t.Error("main.py should be removed from home")
+}
+}
+
+func TestRecoverMisplacedFiles_DeletesJunkDirs(t *testing.T) {
+home := t.TempDir()
+workspace := t.TempDir()
+
+snap := snapshotDir(home)
+
+// Simulate __pycache__ appearing
+pycache := filepath.Join(home, "__pycache__")
+os.Mkdir(pycache, 0755)
+os.WriteFile(filepath.Join(pycache, "mod.cpython-311.pyc"), []byte{0}, 0644)
+
+recovered := recoverMisplacedFiles(home, snap, workspace, "test", false)
+if recovered != 1 {
+t.Fatalf("expected 1 recovered (junk dir deleted), got %d", recovered)
+}
+if _, err := os.Stat(pycache); err == nil {
+t.Error("__pycache__ should be deleted")
+}
+// Should NOT appear in workspace
+if _, err := os.Stat(filepath.Join(workspace, "__pycache__")); err == nil {
+t.Error("__pycache__ should not be moved to workspace")
+}
+}
+
+func TestRecoverMisplacedFiles_MovesNewDirToWorkspace(t *testing.T) {
+home := t.TempDir()
+workspace := t.TempDir()
+
+snap := snapshotDir(home)
+
+// Simulate agent creating a project directory
+projDir := filepath.Join(home, "myproject")
+os.Mkdir(projDir, 0755)
+os.WriteFile(filepath.Join(projDir, "app.py"), []byte("app"), 0644)
+
+recovered := recoverMisplacedFiles(home, snap, workspace, "test", false)
+if recovered != 1 {
+t.Fatalf("expected 1 recovered, got %d", recovered)
+}
+// Directory should exist in workspace
+if _, err := os.Stat(filepath.Join(workspace, "myproject", "app.py")); err != nil {
+t.Error("myproject/app.py should be in workspace")
+}
+// Directory should be removed from home
+if _, err := os.Stat(projDir); err == nil {
+t.Error("myproject should be removed from home")
+}
+}
+
+func TestRecoverMisplacedFiles_SkipsPreExistingDirs(t *testing.T) {
+home := t.TempDir()
+workspace := t.TempDir()
+
+// Pre-existing directory
+os.Mkdir(filepath.Join(home, "Documents"), 0755)
+snap := snapshotDir(home)
+
+recovered := recoverMisplacedFiles(home, snap, workspace, "test", false)
+if recovered != 0 {
+t.Fatalf("expected 0 recovered, got %d", recovered)
+}
+// Documents should still exist in home
+if _, err := os.Stat(filepath.Join(home, "Documents")); err != nil {
+t.Error("Documents should still exist in home")
+}
+}


### PR DESCRIPTION
## Summary

Fixes #5 — `recoverMisplacedFiles` previously skipped directories entirely, leaving `__pycache__/`, `venv/`, `node_modules/`, etc. stranded in `~` after eval runs.

## Changes

**`snapshotDir`** — now captures both files and directories (was files-only), so new top-level directories created during eval are detected.

**`recoverMisplacedFiles`** — three-way handling for new directories:
1. **Junk dirs** (`__pycache__`, `node_modules`, `venv`, `.venv`, `.tox`, `dist`, `build`, `target`, `bin`, `obj`) → deleted via `os.RemoveAll`
2. **Other new dirs** → moved into workspace (`os.Rename` with `copyDir` cross-filesystem fallback)
3. **Files** → unchanged behavior (move recognized code extensions)

**New: `workspace_test.go`** — 5 unit tests covering snapshot capture, file recovery, junk deletion, directory moves, and pre-existing entry preservation.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all 16 packages pass)