### PR TITLE
fix: isolate workspace directories per prompt ID

### DIFF
--- a/tool/internal/report/generator.go
+++ b/tool/internal/report/generator.go
@@ -11,10 +11,12 @@ import (
 )
 
 // ReportDir returns the directory path for a specific evaluation report.
+// The path includes the prompt ID so that different prompts sharing the same
+// service/plane/language/category get isolated workspace directories.
 func ReportDir(outputDir string, runID string, p *prompt.Prompt) string {
 	return filepath.Join(
 		outputDir, runID, "results",
-		p.Service, p.Plane, p.Language, p.Category,
+		p.Service, p.Plane, p.Language, p.Category, p.ID,
 	)
 }
 

--- a/tool/internal/report/generator_test.go
+++ b/tool/internal/report/generator_test.go
@@ -68,8 +68,8 @@ if !parsed.Success {
 t.Error("expected success to be true")
 }
 
-// Verify directory structure
-expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "baseline")
+// Verify directory structure — includes prompt ID for workspace isolation
+expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "test-prompt", "baseline")
 if _, err := os.Stat(expectedDir); err != nil {
 t.Errorf("expected directory %s to exist", expectedDir)
 }


### PR DESCRIPTION
## Summary

Each prompt eval now gets its own isolated workspace subdirectory by including the prompt ID in the `ReportDir` path.

**Before:** `outputDir/runID/results/service/plane/language/category/configName/generated-code/`
**After:** `outputDir/runID/results/service/plane/language/category/**promptID**/configName/generated-code/`

This prevents file collisions when multiple prompts share the same service/plane/language/category (e.g., two Python identity/authentication prompts no longer overwrite each other's `requirements.txt`).

### Changes
- `tool/internal/report/generator.go` — Added `p.ID` to `ReportDir` path
- `tool/internal/report/generator_test.go` — Updated expected directory to include prompt ID

### Verification
- `go build ./...` ✅
- `go test ./...` ✅

Fixes #2