### PR TITLE
feat: add skills and plugins installation via eval config

### DIFF
--- a/tool/cmd/azsdk-prompt-eval/main.go
+++ b/tool/cmd/azsdk-prompt-eval/main.go
@@ -290,6 +290,11 @@ func runCmd() *cobra.Command {
 			// Resolve relative skill_directories in configs to absolute paths
 			resolveConfigSkillDirs(configs, f.prompts)
 
+			// Install declared skills and plugins (npx skills add)
+			if err := config.InstallSkillsAndPlugins(configs); err != nil {
+				return fmt.Errorf("installing skills/plugins: %w", err)
+			}
+
 			// Load and filter prompts
 			prompts, err := prompt.LoadPrompts(f.prompts)
 			if err != nil {

--- a/tool/internal/config/config.go
+++ b/tool/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 "fmt"
 "os"
+"os/exec"
 "path/filepath"
 
 "gopkg.in/yaml.v3"
@@ -32,6 +33,8 @@ GeneratorSkillDirectories  []string              `yaml:"generator_skill_director
 ReviewerSkillDirectories   []string              `yaml:"reviewer_skill_directories" json:"reviewer_skill_directories"`
 AvailableTools             []string              `yaml:"available_tools" json:"available_tools"`
 ExcludedTools              []string              `yaml:"excluded_tools" json:"excluded_tools"`
+Skills                     []string              `yaml:"skills" json:"skills"`
+Plugins                    []string              `yaml:"plugins" json:"plugins"`
 }
 
 // EffectiveReviewerModels returns the list of reviewer models to use.
@@ -153,4 +156,47 @@ missing = append(missing, n)
 return nil, fmt.Errorf("configs not found: %v", missing)
 }
 return result, nil
+}
+
+// InstallSkillsAndPlugins runs "npx skills add <entry>" for each declared
+// skill and plugin across the given configs. It deduplicates entries so each
+// package is only installed once.
+func InstallSkillsAndPlugins(configs []ToolConfig) error {
+seen := make(map[string]bool)
+type entry struct {
+kind  string
+value string
+}
+var entries []entry
+
+for _, c := range configs {
+for _, s := range c.Skills {
+if !seen["skill:"+s] {
+seen["skill:"+s] = true
+entries = append(entries, entry{"skill", s})
+}
+}
+for _, p := range c.Plugins {
+if !seen["plugin:"+p] {
+seen["plugin:"+p] = true
+entries = append(entries, entry{"plugin", p})
+}
+}
+}
+
+if len(entries) == 0 {
+return nil
+}
+
+for _, e := range entries {
+fmt.Printf("Installing %s: %s\n", e.kind, e.value)
+cmd := exec.Command("npx", "skills", "add", e.value)
+cmd.Stdout = os.Stdout
+cmd.Stderr = os.Stderr
+if err := cmd.Run(); err != nil {
+return fmt.Errorf("installing %s %q: %w", e.kind, e.value, err)
+}
+}
+
+return nil
 }

--- a/tool/internal/config/config_test.go
+++ b/tool/internal/config/config_test.go
@@ -265,3 +265,66 @@ if err == nil {
 t.Fatal("expected error for nonexistent file")
 }
 }
+
+func TestParseSkillsAndPlugins(t *testing.T) {
+data := []byte(`
+configs:
+  - name: with-skills
+    description: "Config with skills and plugins"
+    model: "gpt-4"
+    skills:
+      - "@anthropic/tool-use"
+      - "github:org/repo"
+    plugins:
+      - "@azure/functions"
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+c := cfg.Configs[0]
+if len(c.Skills) != 2 {
+t.Errorf("expected 2 skills, got %d", len(c.Skills))
+}
+if c.Skills[0] != "@anthropic/tool-use" {
+t.Errorf("expected skill '@anthropic/tool-use', got %q", c.Skills[0])
+}
+if c.Skills[1] != "github:org/repo" {
+t.Errorf("expected skill 'github:org/repo', got %q", c.Skills[1])
+}
+if len(c.Plugins) != 1 {
+t.Errorf("expected 1 plugin, got %d", len(c.Plugins))
+}
+if c.Plugins[0] != "@azure/functions" {
+t.Errorf("expected plugin '@azure/functions', got %q", c.Plugins[0])
+}
+}
+
+func TestParseNoSkillsOrPlugins(t *testing.T) {
+data := []byte(`
+configs:
+  - name: no-extras
+    description: "Config without skills or plugins"
+    model: "gpt-4"
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+c := cfg.Configs[0]
+if len(c.Skills) != 0 {
+t.Errorf("expected 0 skills, got %d", len(c.Skills))
+}
+if len(c.Plugins) != 0 {
+t.Errorf("expected 0 plugins, got %d", len(c.Plugins))
+}
+}
+
+func TestInstallSkillsAndPluginsEmpty(t *testing.T) {
+configs := []ToolConfig{
+{Name: "empty", Description: "No skills", Model: "gpt-4"},
+}
+if err := InstallSkillsAndPlugins(configs); err != nil {
+t.Fatalf("expected no error for empty skills/plugins, got: %v", err)
+}
+}


### PR DESCRIPTION
## Summary

Adds support for declaring Copilot skills and plugins in eval config YAML files. Before an eval run begins, the tool resolves and installs the declared packages via `npx skills add`.

### Changes

- **`tool/internal/config/config.go`** — Added `Skills` and `Plugins` string-slice fields to `ToolConfig`. Added `InstallSkillsAndPlugins()` which deduplicates entries across configs and runs `npx skills add <entry>` for each.
- **`tool/cmd/azsdk-prompt-eval/main.go`** — Added pre-run step calling `InstallSkillsAndPlugins` after config loading and before prompt evaluation.
- **`tool/internal/config/config_test.go`** — Added tests for parsing configs with/without skills/plugins and for the empty-install no-op path.

### Config format

```yaml
configs:
  - name: with-skills
    model: gpt-4
    skills:
      - "@anthropic/tool-use"
      - "github:org/repo"
    plugins:
      - "@azure/functions"
```

### Acceptance criteria
- [x] Config schema supports `skills` and `plugins` lists
- [x] Packages resolve and install via `npx skills add` before eval
- [x] Existing configs without skills/plugins work unchanged
- [x] Build passes: `cd tool && go build ./...`
- [x] Tests pass: `cd tool && go test ./...`

Closes #1