### PR TITLE
refactor: remove documentation focus from prompts, refocus on code generation

### DIFF
--- a/prompts/app-configuration/data-plane/dotnet/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/dotnet/config-values.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the .NET SDK documentation?
+  in Azure App Configuration using the .NET SDK?
 sdk_package: Azure.Data.AppConfiguration
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/data.appconfiguration-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that manages
+Write a C# program that manages
 configuration settings in Azure App Configuration:
 1. Create a ConfigurationClient using a connection string
 2. Set a configuration setting with key "app:Settings:FontSize" and value "24"
@@ -37,7 +37,7 @@ Show required NuGet packages and proper error handling with RequestFailedExcepti
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.Data.AppConfiguration` NuGet package
 - `ConfigurationClient` creation with connection string or `DefaultAzureCredential`
 - `SetConfigurationSetting()` with key, value, and optional label

--- a/prompts/app-configuration/data-plane/java/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/java/config-values.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the Java SDK documentation?
+  in Azure App Configuration using the Java SDK?
 sdk_package: azure-data-appconfiguration
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/data-appconfiguration-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java program that manages
+Write a Java program that manages
 configuration settings in Azure App Configuration:
 1. Create a ConfigurationClient using ConfigurationClientBuilder with a connection string
 2. Set a configuration setting with key "app:Settings:FontSize" and value "24"
@@ -38,7 +38,7 @@ proper error handling with HttpResponseException.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-data-appconfiguration` Maven dependency
 - `ConfigurationClientBuilder` and `ConfigurationClient`
 - `setConfigurationSetting()` with key, value, label
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The Java App Configuration SDK uses the Azure SDK builder pattern. This tests
-whether the Java docs cover the builder setup, labeled settings, and the
+whether the generated code covers the builder setup, labeled settings, and the
 feature flag model using FeatureFlagConfigurationSetting.

--- a/prompts/app-configuration/data-plane/js-ts/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/js-ts/config-values.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the JavaScript/TypeScript SDK documentation?
+  in Azure App Configuration using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/app-configuration"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/app-configuration-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that manages configuration settings in Azure App Configuration:
 1. Create an AppConfigurationClient using a connection string
 2. Set a configuration setting with key "app:Settings:FontSize" and value "24"
@@ -38,7 +38,7 @@ proper error handling with RestError.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/app-configuration` npm package
 - `AppConfigurationClient` constructor with connection string
 - `setConfigurationSetting()` with key, value, label
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript App Configuration SDK uses async iterators for listing.
-This tests whether the JS/TS docs cover the async iteration pattern and
+This tests whether the generated code covers the async iteration pattern and
 the feature flag content type approach.

--- a/prompts/app-configuration/data-plane/python/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/python/config-values.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the Python SDK documentation?
+  in Azure App Configuration using the Python SDK?
 sdk_package: azure-appconfiguration
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/appconfiguration-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that manages
+Write a Python script that manages
 configuration settings in Azure App Configuration:
 1. Create an AzureAppConfigurationClient using from_connection_string()
 2. Set a configuration setting with key "app:Settings:FontSize" and value "24"
@@ -37,7 +37,7 @@ Show required pip packages and proper error handling with HttpResponseError.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-appconfiguration` pip package
 - `AzureAppConfigurationClient.from_connection_string()`
 - `set_configuration_setting()` with `ConfigurationSetting` objects
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 The Python App Configuration SDK uses a factory method pattern for client creation.
-This tests whether the Python docs cover the configuration setting model including
+This tests whether the generated code covers the configuration setting model including
 labels and the FeatureFlagConfigurationSetting class.

--- a/prompts/cosmos-db/data-plane/dotnet/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/crud-items.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the .NET SDK documentation?
+  container using the .NET SDK?
 sdk_package: Microsoft.Azure.Cosmos
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that performs
+Write a C# program that performs
 CRUD operations on items in an Azure Cosmos DB NoSQL container:
 1. Create a CosmosClient using a connection string
 2. Create a database named "TestDB" and a container named "Items" with partition key "/category"
@@ -37,7 +37,7 @@ Show required NuGet packages and proper error handling with CosmosException.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Microsoft.Azure.Cosmos` NuGet package
 - `CosmosClient` creation and configuration
 - `Database.CreateDatabaseIfNotExistsAsync()`
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 Cosmos DB is one of the most popular Azure data services. CRUD operations test
-whether the .NET docs cover the full item lifecycle including partitioning
+whether the generated code covers the full item lifecycle including partitioning
 and SQL-like query syntax in the NoSQL API.

--- a/prompts/cosmos-db/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: dotnet
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle Cosmos DB errors including
+  Can a developer handle Cosmos DB errors including
   throttling (429), conflicts (409), and not-found (404) in .NET?
 sdk_package: Microsoft.Azure.Cosmos
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
@@ -44,5 +44,5 @@ and 409 (conflict) responses. Use the Microsoft.Azure.Cosmos SDK v3.
 ## Context
 
 Cosmos DB's Request Unit model means 429 throttling is expected behavior
-under load, not an error to panic about. Developers need docs that clearly
+under load, not an error to panic about. The generated code needs to clearly
 explain how to handle rate limiting gracefully with proper retry logic.

--- a/prompts/cosmos-db/data-plane/dotnet/pagination-query-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/pagination-query-items.prompt.md
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that queries
+Write a C# program that queries
 items in a Cosmos DB container with proper pagination:
 1. Execute a SQL query "SELECT * FROM c WHERE c.category = 'electronics'" against a container
 2. Process results page-by-page using FeedIterator, limiting each page to 50 items

--- a/prompts/cosmos-db/data-plane/java/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/java/crud-items.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the Java SDK documentation?
+  container using the Java SDK?
 sdk_package: azure-cosmos
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/cosmos-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java program that performs
+Write a Java program that performs
 CRUD operations on items in an Azure Cosmos DB NoSQL container:
 1. Create a CosmosClient using endpoint and key with CosmosClientBuilder
 2. Create a database "TestDB" and container "Items" with partition key "/category"
@@ -37,7 +37,7 @@ Show required Maven dependency and handle CosmosException appropriately.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-cosmos` Maven dependency (com.azure:azure-cosmos)
 - `CosmosClientBuilder` and `CosmosClient`
 - `CosmosDatabase` and `CosmosContainer` creation
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 Cosmos DB Java SDK uses a builder pattern and typed POJO-based operations. This tests
-whether the Java docs properly cover the fluent API and parameterized queries,
+whether the generated code properly covers the fluent API and parameterized queries,
 which differ significantly from the .NET SDK approach.

--- a/prompts/cosmos-db/data-plane/js-ts/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/js-ts/crud-items.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the JavaScript/TypeScript SDK documentation?
+  container using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/cosmos"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/cosmos-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that performs CRUD operations on items in an Azure Cosmos DB NoSQL container:
 1. Create a CosmosClient using endpoint and key
 2. Create a database "TestDB" and container "Items" with partition key "/category"
@@ -37,7 +37,7 @@ Show required npm package and handle errors with appropriate status code checks.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/cosmos` npm package
 - `CosmosClient` constructor with endpoint and key
 - `client.databases.createIfNotExists()` and `database.containers.createIfNotExists()`
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript Cosmos DB SDK uses a fluent chain pattern (container.item().read()).
-This tests whether the JS/TS docs cover the chained resource model and the
+This tests whether the generated code covers the chained resource model and the
 FeedResponse pattern for query results.

--- a/prompts/cosmos-db/data-plane/python/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/crud-items.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the Python SDK documentation?
+  container using the Python SDK?
 sdk_package: azure-cosmos
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that performs
+Write a Python script that performs
 CRUD operations on items in an Azure Cosmos DB NoSQL container:
 1. Create a CosmosClient using endpoint and key
 2. Create a database "TestDB" and container "Items" with partition key "/category"
@@ -37,7 +37,7 @@ Show required pip packages and handle exceptions from azure.cosmos.exceptions.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-cosmos` pip package
 - `CosmosClient` creation
 - `database_client.create_database_if_not_exists()`
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 The Python Cosmos DB SDK uses dictionary-based items rather than typed models.
-This tests whether the Python docs cover the dict-based API and the differences
+This tests whether the generated code covers the dict-based API and the differences
 in query behavior (especially cross-partition queries).

--- a/prompts/cosmos-db/data-plane/python/error-handling.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: python
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle Cosmos DB errors including
+  Can a developer handle Cosmos DB errors including
   throttling (429), conflicts (409), and not-found (404) in Python?
 sdk_package: azure-cosmos
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
@@ -44,6 +44,6 @@ Use the azure-cosmos Python SDK.
 ## Context
 
 Python Cosmos DB developers frequently encounter rate limiting under load.
-The docs need to clearly explain the exception model and how to implement
+The generated code needs to clearly demonstrate the exception model and how to implement
 proper retry logic, especially the distinction between transient 429s
 and permanent 404/403 errors.

--- a/prompts/cosmos-db/data-plane/python/pagination-query-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/pagination-query-items.prompt.md
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that queries
+Write a Python script that queries
 items in a Cosmos DB container with proper pagination:
 1. Execute a SQL query "SELECT * FROM c WHERE c.status = 'active'" against a container
 2. Process results in pages of 25 items using max_item_count

--- a/prompts/cosmos-db/data-plane/python/retry-configuration.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/retry-configuration.prompt.md
@@ -50,4 +50,4 @@ and explain the interaction between SDK retries and provisioned throughput.
 
 Cosmos DB's consumption model means 429 errors are expected, not exceptional.
 Developers need to tune retry policies to balance throughput against cost.
-The docs should explain how SDK retries interact with provisioned RU/s.
+The generated code should explain how SDK retries interact with provisioned RU/s.

--- a/prompts/event-hubs/data-plane/dotnet/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/dotnet/send-receive-events.prompt.md
@@ -7,7 +7,7 @@ category: streaming
 difficulty: intermediate
 description: >
   Can a developer send and receive events using Azure Event Hubs
-  with the .NET SDK documentation?
+  with the .NET SDK?
 sdk_package: Azure.Messaging.EventHubs
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.eventhubs-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that demonstrates
+Write a C# program that demonstrates
 sending and receiving events with Azure Event Hubs:
 1. Create an EventHubProducerClient using a connection string
 2. Create a batch of events using CreateBatchAsync()
@@ -39,7 +39,7 @@ Azure.Messaging.EventHubs.Processor) and proper disposal patterns.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.Messaging.EventHubs` and `Azure.Messaging.EventHubs.Processor` NuGet packages
 - `EventHubProducerClient` and `EventHubConsumerClient`
 - `CreateBatchAsync()` and `EventDataBatch.TryAdd()`
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 Event Hubs is Azure's high-throughput event streaming service. The producer/consumer
-pattern with checkpointing is the core usage model. This tests whether the .NET docs
-cover both sides of the pipeline with proper checkpoint storage.
+pattern with checkpointing is the core usage model. This tests whether the generated code
+covers both sides of the pipeline with proper checkpoint storage.

--- a/prompts/event-hubs/data-plane/java/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/java/send-receive-events.prompt.md
@@ -7,7 +7,7 @@ category: streaming
 difficulty: intermediate
 description: >
   Can a developer send and receive events using Azure Event Hubs
-  with the Java SDK documentation?
+  with the Java SDK?
 sdk_package: azure-messaging-eventhubs
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-eventhubs-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java program that demonstrates
+Write a Java program that demonstrates
 sending and receiving events with Azure Event Hubs:
 1. Create an EventHubProducerClient using EventHubClientBuilder with a connection string
 2. Create an EventDataBatch and add 10 events with custom properties
@@ -38,7 +38,7 @@ azure-messaging-eventhubs-checkpointstore-blob) and proper resource cleanup.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-messaging-eventhubs` and `azure-messaging-eventhubs-checkpointstore-blob` Maven deps
 - `EventHubClientBuilder` and `EventHubProducerClient`
 - `createBatch()` and `EventDataBatch.tryAdd()`
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The Java Event Hubs SDK uses a builder pattern and functional-style event handlers.
-This tests whether the Java docs cover the producer/consumer pattern with checkpoint
+This tests whether the generated code covers the producer/consumer pattern with checkpoint
 store integration using Azure Blob Storage.

--- a/prompts/event-hubs/data-plane/js-ts/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/js-ts/send-receive-events.prompt.md
@@ -7,7 +7,7 @@ category: streaming
 difficulty: intermediate
 description: >
   Can a developer send and receive events using Azure Event Hubs
-  with the JavaScript/TypeScript SDK documentation?
+  with the JavaScript/TypeScript SDK?
 sdk_package: "@azure/event-hubs"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/event-hubs-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that demonstrates sending and receiving events with Azure Event Hubs:
 1. Create an EventHubProducerClient using a connection string
 2. Create a batch with createBatch() and add 10 events with custom properties
@@ -38,7 +38,7 @@ Show required npm packages (@azure/event-hubs and
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/event-hubs` and `@azure/eventhubs-checkpointstore-blob` npm packages
 - `EventHubProducerClient` constructor
 - `createBatch()` and `EventDataBatch.tryAdd()`
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript Event Hubs SDK uses a subscribe pattern with handler objects.
-This tests whether the JS/TS docs cover the subscription model and proper
+This tests whether the generated code covers the subscription model and proper
 checkpoint integration for reliable event processing.

--- a/prompts/event-hubs/data-plane/python/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/python/send-receive-events.prompt.md
@@ -7,7 +7,7 @@ category: streaming
 difficulty: intermediate
 description: >
   Can a developer send and receive events using Azure Event Hubs
-  with the Python SDK documentation?
+  with the Python SDK?
 sdk_package: azure-eventhub
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/eventhub-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that
+Write a Python script that
 demonstrates sending and receiving events with Azure Event Hubs:
 1. Create an EventHubProducerClient using from_connection_string()
 2. Create an EventDataBatch and add 10 events with custom properties
@@ -39,7 +39,7 @@ azure-eventhub-checkpointstoreblob-aio) and async patterns.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-eventhub` and `azure-eventhub-checkpointstoreblob-aio` pip packages
 - `EventHubProducerClient.from_connection_string()`
 - `create_batch()` and `EventDataBatch.add()`
@@ -52,5 +52,5 @@ The documentation should cover:
 ## Context
 
 The Python Event Hubs SDK supports both sync and async patterns. This tests
-whether the Python docs cover the async-first approach with proper checkpoint
+whether the generated code covers the async-first approach with proper checkpoint
 store integration and the callback-based consumer model.

--- a/prompts/identity/data-plane/cpp/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/cpp/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the C++ SDK documentation?
+  using the C++ SDK?
 sdk_package: azure-identity-cpp
 doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for C++ documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential. Explain:
 1. What vcpkg/CMake dependencies are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -35,7 +35,7 @@ DefaultAzureCredential with proper exception handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - vcpkg/CMake setup for `azure-identity-cpp`
 - `Azure::Identity::DefaultAzureCredential` class
 - Credential chain order in C++ SDK
@@ -46,4 +46,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the C++ docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/cpp/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/cpp/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the C++ SDK documentation?
+  using the C++ SDK?
 sdk_package: azure-identity-cpp
 doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for C++ documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in C++. Cover:
 1. System-assigned vs user-assigned managed identity
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide C++ examples for both identity types.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure::Identity::ManagedIdentityCredential` class
 - System-assigned: default constructor
 - User-assigned: passing client ID
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-C++ docs explain both system-assigned and user-assigned identity clearly,
+generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/cpp/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/cpp/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the C++ SDK documentation?
+  using the C++ SDK?
 sdk_package: azure-identity-cpp
 doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for C++ documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in C++. I need:
 1. Required vcpkg/CMake packages
 2. How to create a ClientSecretCredential with tenant ID, client ID, and secret
@@ -34,7 +34,7 @@ Provide a complete C++ example with proper exception handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - vcpkg/CMake setup for `azure-identity-cpp`
 - `Azure::Identity::ClientSecretCredential` class
 - Constructor parameters: tenantId, clientId, clientSecret
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the C++ docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/dotnet/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/dotnet/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the .NET SDK documentation?
+  using the .NET SDK?
 sdk_package: Azure.Identity
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential in C#. Explain:
 1. What NuGet packages are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -35,7 +35,7 @@ DefaultAzureCredential.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.Identity` NuGet package installation
 - `DefaultAzureCredential` constructor and options
 - Credential chain: Environment → Workload Identity → Managed Identity → Azure CLI → etc.
@@ -46,4 +46,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the .NET docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/dotnet/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/dotnet/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the .NET SDK documentation?
+  using the .NET SDK?
 sdk_package: Azure.Identity
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in C#. Cover:
 1. System-assigned vs user-assigned managed identity differences
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide examples for both system-assigned and user-assigned identity.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `ManagedIdentityCredential` class and constructors
 - System-assigned: no parameters needed
 - User-assigned: passing the client ID
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-.NET docs explain both system-assigned and user-assigned identity clearly,
+.generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/dotnet/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/dotnet/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the .NET SDK documentation?
+  using the .NET SDK?
 sdk_package: Azure.Identity
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in C#. I need:
 1. Required NuGet packages
 2. How to create a ClientSecretCredential with tenant ID, client ID, and client secret
@@ -34,7 +34,7 @@ Provide a complete example with proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.Identity` package with `ClientSecretCredential` class
 - Constructor parameters: tenantId, clientId, clientSecret
 - Passing credential to Azure SDK clients
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the .NET docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/go/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/go/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Go SDK documentation?
+  using the Go SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential. Explain:
 1. What Go modules are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -35,7 +35,7 @@ DefaultAzureCredential.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azidentity` module import
 - `azidentity.NewDefaultAzureCredential()` function
 - Credential chain order in Go SDK
@@ -46,4 +46,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the Go docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/go/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/go/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Go SDK documentation?
+  using the Go SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in Go. Cover:
 1. System-assigned vs user-assigned managed identity
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide Go examples for both identity types.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azidentity.NewManagedIdentityCredential()` function
 - System-assigned: nil options
 - User-assigned: `ManagedIdentityCredentialOptions{ID: azidentity.ClientID("...")}`
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-Go docs explain both system-assigned and user-assigned identity clearly,
+generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/go/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/go/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the Go SDK documentation?
+  using the Go SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in Go. I need:
 1. Required Go modules
 2. How to create a ClientSecretCredential with NewClientSecretCredential
@@ -34,7 +34,7 @@ Provide a complete Go example with proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azidentity` module with `NewClientSecretCredential()` function
 - Parameters: tenantID, clientID, clientSecret, options
 - Passing credential to Azure SDK client constructors
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the Go docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/java/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/java/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Java SDK documentation?
+  using the Java SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential in Java. Explain:
 1. What Maven dependencies are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -34,7 +34,7 @@ Provide a complete example that creates a SecretClient using DefaultAzureCredent
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Maven dependency for `azure-identity`
 - `DefaultAzureCredentialBuilder` pattern
 - Credential chain order in Java SDK
@@ -45,4 +45,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the Java docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/java/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/java/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Java SDK documentation?
+  using the Java SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in Java. Cover:
 1. System-assigned vs user-assigned managed identity
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide examples for both system-assigned and user-assigned identity.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `ManagedIdentityCredentialBuilder` class
 - System-assigned: default builder with no client ID
 - User-assigned: `.clientId()` on the builder
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-Java docs explain both system-assigned and user-assigned identity clearly,
+generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/java/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/java/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the Java SDK documentation?
+  using the Java SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in Java. I need:
 1. Required Maven dependencies
 2. How to create a ClientSecretCredential with ClientSecretCredentialBuilder
@@ -34,7 +34,7 @@ Provide a complete example with proper exception handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Maven dependency for `azure-identity`
 - `ClientSecretCredentialBuilder` with tenantId, clientId, clientSecret
 - Passing credential to Azure SDK client builders
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the Java docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/js-ts/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/js-ts/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the JavaScript/TypeScript SDK documentation?
+  using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/identity"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript/TypeScript documentation, show me how to
+Show me how to
 authenticate an Azure SDK client using DefaultAzureCredential. Explain:
 1. What npm packages are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -35,7 +35,7 @@ DefaultAzureCredential.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/identity` npm package installation
 - `DefaultAzureCredential` constructor and options
 - Credential chain: Environment → Workload Identity → Managed Identity → Azure CLI → etc.
@@ -46,4 +46,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the JavaScript/TypeScript docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/js-ts/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/js-ts/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the JavaScript/TypeScript SDK documentation?
+  using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/identity"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript/TypeScript documentation, show me how to
+Show me how to
 use Managed Identity to authenticate Azure SDK clients in Node.js. Cover:
 1. System-assigned vs user-assigned managed identity
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide TypeScript examples for both identity types.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `ManagedIdentityCredential` class from `@azure/identity`
 - System-assigned: no parameters needed
 - User-assigned: passing the client ID in options
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-JavaScript/TypeScript docs explain both system-assigned and user-assigned identity clearly,
+JavaScript/generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/js-ts/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/js-ts/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the JavaScript/TypeScript SDK documentation?
+  using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/identity"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript/TypeScript documentation, show me how to
+Show me how to
 authenticate to Azure using a Service Principal with client secret. I need:
 1. Required npm packages
 2. How to create a ClientSecretCredential with tenant ID, client ID, and secret
@@ -34,7 +34,7 @@ Provide a complete TypeScript example.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/identity` package with `ClientSecretCredential` class
 - Constructor parameters: tenantId, clientId, clientSecret
 - Passing credential to Azure SDK clients
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the JavaScript/TypeScript docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/python/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/python/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Python SDK documentation?
+  using the Python SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential. Explain:
 1. What pip packages are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -34,7 +34,7 @@ Provide a complete example that creates a SecretClient using DefaultAzureCredent
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-identity` pip package installation
 - `DefaultAzureCredential()` constructor and keyword arguments
 - Credential chain: Environment → Workload Identity → Managed Identity → Azure CLI → etc.
@@ -45,4 +45,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the Python docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/python/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/python/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Python SDK documentation?
+  using the Python SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in Python. Cover:
 1. System-assigned vs user-assigned managed identity differences
 2. How to create a ManagedIdentityCredential for each type
@@ -34,7 +34,7 @@ Provide examples for both system-assigned and user-assigned identity.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `ManagedIdentityCredential` class from `azure.identity`
 - System-assigned: no parameters needed
 - User-assigned: passing `client_id` keyword argument
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-Python docs explain both system-assigned and user-assigned identity clearly,
+generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/python/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/python/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the Python SDK documentation?
+  using the Python SDK?
 sdk_package: azure-identity
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in Python. I need:
 1. Required pip packages
 2. How to create a ClientSecretCredential with tenant_id, client_id, and client_secret
@@ -34,7 +34,7 @@ Provide a complete example with proper exception handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-identity` package with `ClientSecretCredential` class
 - Constructor keyword arguments: tenant_id, client_id, client_secret
 - Passing credential to Azure SDK clients
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the Python docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/identity/data-plane/rust/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/rust/default-azure-credential.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: basic
 description: >
   Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Rust SDK documentation?
+  using the Rust SDK?
 sdk_package: azure_identity
 doc_url: https://docs.rs/azure_identity/latest/azure_identity/
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Rust documentation, show me how to authenticate
+Show me how to authenticate
 an Azure SDK client using DefaultAzureCredential. Explain:
 1. What Cargo dependencies are needed
 2. How to create and use a DefaultAzureCredential instance
@@ -35,7 +35,7 @@ DefaultAzureCredential with proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Cargo.toml dependencies for `azure_identity`
 - `DefaultAzureCredential::new()` or builder pattern
 - Credential chain order in Rust SDK
@@ -46,4 +46,4 @@ The documentation should cover:
 
 DefaultAzureCredential is the recommended starting point for Azure SDK authentication.
 It abstracts away the complexity of credential selection and works across environments.
-This tests whether the Rust docs explain it clearly enough for first-time users.
+This tests whether the generated code demonstrates it clearly enough for first-time users.

--- a/prompts/identity/data-plane/rust/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/rust/managed-identity-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Rust SDK documentation?
+  using the Rust SDK?
 sdk_package: azure_identity
 doc_url: https://docs.rs/azure_identity/latest/azure_identity/
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Rust documentation, show me how to use
+Show me how to use
 Managed Identity to authenticate Azure SDK clients in Rust. Cover:
 1. System-assigned vs user-assigned managed identity
 2. How to create credentials for each type
@@ -34,7 +34,7 @@ Provide Rust examples for both identity types.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Managed identity credential types in `azure_identity`
 - System-assigned: default construction
 - User-assigned: passing client ID
@@ -46,5 +46,5 @@ The documentation should cover:
 
 Managed Identity is the recommended auth pattern for code running in Azure.
 It eliminates the need for managing secrets entirely. This tests whether the
-Rust docs explain both system-assigned and user-assigned identity clearly,
+generated code demonstrates both system-assigned and user-assigned identity clearly,
 including the critical local development fallback story.

--- a/prompts/identity/data-plane/rust/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/rust/service-principal-auth.prompt.md
@@ -7,7 +7,7 @@ category: auth
 difficulty: intermediate
 description: >
   Can a developer authenticate with a Service Principal (client secret)
-  using the Rust SDK documentation?
+  using the Rust SDK?
 sdk_package: azure_identity
 doc_url: https://docs.rs/azure_identity/latest/azure_identity/
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Rust documentation, show me how to authenticate
+Show me how to authenticate
 to Azure using a Service Principal with client secret in Rust. I need:
 1. Required Cargo dependencies
 2. How to create a ClientSecretCredential
@@ -34,7 +34,7 @@ Provide a complete Rust example with proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure_identity` crate with `ClientSecretCredential`
 - Constructor with tenant_id, client_id, client_secret
 - Passing credential to Azure SDK clients
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Service Principal authentication with client secrets is the most common pattern
-for application-to-application auth in Azure. This tests whether the Rust docs
-cover the full setup including credential creation, usage, and secret management best practices.
+for application-to-application auth in Azure. This tests whether the generated code
+covers the full setup including credential creation, usage, and secret management best practices.

--- a/prompts/key-vault/data-plane/cpp/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/cpp/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the C++ SDK based on the documentation alone?
+  using the C++ SDK?
 sdk_package: azure-security-keyvault-secrets-cpp
 doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-secrets
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for C++ documentation, write a C++ program that performs
+Write a C++ program that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -35,7 +35,7 @@ Include proper exception handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - vcpkg/CMake setup for `azure-security-keyvault-secrets-cpp` and `azure-identity-cpp`
 - Creating a `SecretClient` with vault URL and credential
 - `SetSecret()`, `GetSecret()`, `StartDeleteSecret()`, `PurgeDeletedSecret()`
@@ -45,5 +45,5 @@ The documentation should cover:
 ## Context
 
 The C++ SDK requires more setup (CMake, vcpkg) than other languages.
-Testing CRUD coverage validates that the docs cover both the build system
+Testing CRUD coverage validates that the generated code covers both the build system
 configuration and the API usage for the most fundamental Key Vault scenario.

--- a/prompts/key-vault/data-plane/dotnet/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the .NET SDK based on the documentation alone?
+  using the .NET SDK?
 sdk_package: Azure.Security.KeyVault.Secrets
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# console application that performs
+Write a C# console application that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ and show required NuGet packages.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Installing `Azure.Security.KeyVault.Secrets` and `Azure.Identity` NuGet packages
 - Creating a `SecretClient` with vault URI and credential
 - `SetSecret()`, `GetSecret()`, `StartDeleteSecret()`, `PurgeDeletedSecret()`
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 CRUD operations on secrets are the most fundamental Key Vault use case.
-This tests whether the .NET docs provide a complete, runnable flow
+This tests whether the generated code provides a complete, runnable flow
 covering the full lifecycle including soft-delete and async polling patterns.

--- a/prompts/key-vault/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: dotnet
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle Key Vault errors including
+  Can a developer handle Key Vault errors including
   access denied (403), secret not found (404), and throttling (429) in .NET?
 sdk_package: Azure.Security.KeyVault.Secrets
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
@@ -43,5 +43,5 @@ how to extract the error code and HTTP status from RequestFailedException.
 ## Context
 
 Key Vault errors are often caused by misconfigured access policies or RBAC roles,
-which are notoriously difficult to debug. Developers need docs that explain
+which are notoriously difficult to debug. The generated code needs to demonstrate
 not just how to catch exceptions but how to diagnose the root cause of 403 errors.

--- a/prompts/key-vault/data-plane/dotnet/pagination-list-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/pagination-list-secrets.prompt.md
@@ -7,7 +7,7 @@ category: pagination
 difficulty: intermediate
 description: >
   Can a developer paginate through a large list of Key Vault secrets
-  using the .NET SDK documentation?
+  using the .NET SDK?
 sdk_package: Azure.Security.KeyVault.Secrets
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that lists all
+Write a C# program that lists all
 secrets in an Azure Key Vault that contains hundreds of secrets. The program should:
 1. Use SecretClient with DefaultAzureCredential
 2. Iterate through secrets page-by-page using AsyncPageable

--- a/prompts/key-vault/data-plane/go/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/go/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Go SDK based on the documentation alone?
+  using the Go SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, write a Go program that performs
+Write a Go program that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ Show the go module imports and include proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Importing `github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets`
 - Importing `github.com/Azure/azure-sdk-for-go/sdk/azidentity`
 - Creating a client with `azsecrets.NewClient()`
@@ -44,6 +44,6 @@ The documentation should cover:
 ## Context
 
 CRUD operations on secrets are the most fundamental Key Vault use case.
-This tests whether the Go docs provide a complete, runnable flow covering
+This tests whether the generated code provides a complete, runnable flow covering
 the full lifecycle. Go's error handling pattern (checking returned errors)
-makes this a good test of documentation completeness.
+makes this a good test of code generation completeness.

--- a/prompts/key-vault/data-plane/java/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/java/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Java SDK based on the documentation alone?
+  using the Java SDK?
 sdk_package: azure-security-keyvault-secrets
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/security-keyvault-secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java application that performs
+Write a Java application that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ for azure-security-keyvault-secrets and azure-identity. Include proper exception
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Maven dependency for `azure-security-keyvault-secrets` and `azure-identity`
 - Creating a `SecretClient` with `SecretClientBuilder`
 - `setSecret()`, `getSecret()`, `beginDeleteSecret()`, `purgeDeletedSecret()`
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 CRUD operations on secrets are the most fundamental Key Vault use case.
-This tests whether the Java docs provide a complete, runnable flow
+This tests whether the generated code provides a complete, runnable flow
 covering the full lifecycle including the SyncPoller pattern for long-running deletes.

--- a/prompts/key-vault/data-plane/js-ts/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/js-ts/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the JavaScript/TypeScript SDK based on the documentation alone?
+  using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/keyvault-secrets"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript/TypeScript documentation, write a Node.js script
+Write a Node.js script
 (TypeScript preferred) that performs all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ and include proper error handling with try/catch.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Installing `@azure/keyvault-secrets` and `@azure/identity` npm packages
 - Creating a `SecretClient` with vault URL and credential
 - `setSecret()`, `getSecret()`, `beginDeleteSecret()`, `purgeDeletedSecret()`
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 CRUD operations on secrets are the most fundamental Key Vault use case.
-This tests whether the JavaScript/TypeScript docs provide a complete, runnable flow
+This tests whether the generated code provides a complete, runnable flow
 covering the full lifecycle including the async poller pattern for soft-delete.

--- a/prompts/key-vault/data-plane/python/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/python/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Python SDK based on the documentation alone?
+  using the Python SDK?
 sdk_package: azure-keyvault-secrets
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a script that performs
+Write a script that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ and show required pip packages.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Installing `azure-keyvault-secrets` and `azure-identity` packages
 - Creating a `SecretClient` with vault URL and credential
 - `set_secret()`, `get_secret()`, `begin_delete_secret()`, `purge_deleted_secret()`
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 CRUD operations on secrets are the most fundamental Key Vault use case.
-This tests whether the Python docs provide a complete, runnable flow
+This tests whether the generated code provides a complete, runnable flow
 covering the full lifecycle including soft-delete behavior.

--- a/prompts/key-vault/data-plane/python/error-handling.prompt.md
+++ b/prompts/key-vault/data-plane/python/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: python
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle Key Vault errors including
+  Can a developer handle Key Vault errors including
   access denied (403), secret not found (404), and throttling (429) in Python?
 sdk_package: azure-keyvault-secrets
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme

--- a/prompts/key-vault/data-plane/python/pagination-list-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/python/pagination-list-secrets.prompt.md
@@ -7,7 +7,7 @@ category: pagination
 difficulty: intermediate
 description: >
   Can a developer paginate through a large list of Key Vault secrets
-  using the Python SDK documentation?
+  using the Python SDK?
 sdk_package: azure-keyvault-secrets
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that lists all
+Write a Python script that lists all
 secrets in an Azure Key Vault that contains hundreds of secrets. The script should:
 1. Use SecretClient with DefaultAzureCredential
 2. Iterate through secrets using the ItemPaged pattern

--- a/prompts/key-vault/data-plane/rust/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/rust/crud-secrets.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Rust SDK based on the documentation alone?
+  using the Rust SDK?
 sdk_package: azure_security_keyvault_secrets
 doc_url: https://docs.rs/azure_security_keyvault_secrets/latest/azure_security_keyvault_secrets/
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Rust documentation, write a Rust program that performs
+Write a Rust program that performs
 all four CRUD operations on Azure Key Vault secrets:
 1. Create a new secret called "my-secret" with value "my-secret-value"
 2. Read the secret back and print its value
@@ -34,7 +34,7 @@ Show the Cargo.toml dependencies and include proper error handling with Result t
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Cargo.toml dependencies for `azure_security_keyvault_secrets` and `azure_identity`
 - Creating a `SecretClient` with vault URL and credential
 - Methods for set, get, delete, and purge operations

--- a/prompts/key-vault/management-plane/dotnet/polling-create-vault.prompt.md
+++ b/prompts/key-vault/management-plane/dotnet/polling-create-vault.prompt.md
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that creates
+Write a C# program that creates
 an Azure Key Vault using the management plane SDK and handles the long-running
 operation:
 1. Authenticate using DefaultAzureCredential

--- a/prompts/key-vault/management-plane/python/polling-create-vault.prompt.md
+++ b/prompts/key-vault/management-plane/python/polling-create-vault.prompt.md
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that creates
+Write a Python script that creates
 an Azure Key Vault using the management plane SDK and handles the long-running
 operation:
 1. Authenticate using DefaultAzureCredential

--- a/prompts/resource-manager/management-plane/dotnet/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/dotnet/resource-group-crud.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, list, update, and delete Azure Resource Groups
-  using the .NET management SDK documentation?
+  using the .NET management SDK?
 sdk_package: Azure.ResourceManager
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that manages
+Write a C# program that manages
 Azure Resource Groups using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a new resource group in "eastus" region
@@ -37,7 +37,7 @@ Use the Azure.ResourceManager SDK (not the older Microsoft.Azure.Management pack
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.ResourceManager` NuGet package
 - `ArmClient` creation with `DefaultAzureCredential`
 - `GetDefaultSubscription()` and `GetResourceGroups()` collection
@@ -48,5 +48,5 @@ The documentation should cover:
 ## Context
 
 Resource group management is the foundation of Azure management plane operations.
-This tests whether the .NET docs cover the modern Azure.ResourceManager SDK
+This tests whether the generated code covers the modern Azure.ResourceManager SDK
 (track 2) rather than the older Microsoft.Azure.Management packages.

--- a/prompts/resource-manager/management-plane/go/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/go/resource-group-crud.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, list, update, and delete Azure Resource Groups
-  using the Go management SDK documentation?
+  using the Go management SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, write a Go program that manages
+Write a Go program that manages
 Azure Resource Groups using the management plane SDK:
 1. Authenticate using DefaultAzureCredential from azidentity
 2. Create a ResourceGroupsClient
@@ -38,7 +38,7 @@ Use the armresources package from the azure-sdk-for-go/sdk module.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources` module
 - `azidentity.NewDefaultAzureCredential()` for authentication
 - `armresources.NewResourceGroupsClient()` with subscription ID and credential
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 The Go Azure SDK uses a module-per-service pattern with poller-based LROs.
-This tests whether the Go docs cover the armresources module and the
+This tests whether the generated code covers the armresources module and the
 pager/poller patterns that are central to Go management plane operations.

--- a/prompts/resource-manager/management-plane/java/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/java/resource-group-crud.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, list, update, and delete Azure Resource Groups
-  using the Java management SDK documentation?
+  using the Java management SDK?
 sdk_package: azure-resourcemanager-resources
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-resources-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java application that manages
+Write a Java application that manages
 Azure Resource Groups using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a new resource group in "eastus" region
@@ -37,7 +37,7 @@ Use the modern azure-resourcemanager SDK.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Maven dependency for `azure-resourcemanager` and `azure-identity`
 - `AzureResourceManager.authenticate()` with credential and profile
 - `resourceGroups().define().withRegion().create()`
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 Resource group management is the foundation of Azure management plane operations.
-This tests whether the Java docs cover the fluent management SDK pattern
+This tests whether the generated code covers the fluent management SDK pattern
 which differs significantly from the data plane client builder pattern.

--- a/prompts/resource-manager/management-plane/js-ts/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/js-ts/resource-group-crud.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, list, update, and delete Azure Resource Groups
-  using the JavaScript/TypeScript management SDK documentation?
+  using the JavaScript/TypeScript management SDK?
 sdk_package: "@azure/arm-resources"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-resources-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that manages Azure Resource Groups using the management plane SDK:
 1. Authenticate using DefaultAzureCredential from @azure/identity
 2. Create a ResourceManagementClient with the credential and subscription ID
@@ -38,7 +38,7 @@ Use the @azure/arm-resources package.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/arm-resources` and `@azure/identity` npm packages
 - `DefaultAzureCredential` for authentication
 - `ResourceManagementClient` constructor with credential and subscriptionId
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript management SDK uses a client-per-service pattern. This tests
-whether the JS/TS docs cover the ARM client creation, async iteration for
+whether the generated code covers the ARM client creation, async iteration for
 listing operations, and the beginAndWait pattern for LROs.

--- a/prompts/resource-manager/management-plane/python/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/python/resource-group-crud.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer create, list, update, and delete Azure Resource Groups
-  using the Python management SDK documentation?
+  using the Python management SDK?
 sdk_package: azure-mgmt-resource
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-resource-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that manages
+Write a Python script that manages
 Azure Resource Groups using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a new resource group in "eastus" region
@@ -36,7 +36,7 @@ Show required pip packages and include proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-mgmt-resource` and `azure-identity` pip packages
 - `ResourceManagementClient` creation with credential and subscription_id
 - `resource_groups.create_or_update()` with `ResourceGroup` model
@@ -48,5 +48,5 @@ The documentation should cover:
 ## Context
 
 Resource group management is the foundation of Azure management plane operations.
-This tests whether the Python docs clearly explain the management client pattern
+This tests whether the generated code clearly demonstrates the management client pattern
 including subscription ID requirements and the long-running delete operation.

--- a/prompts/service-bus/data-plane/dotnet/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/dotnet/send-receive-messages.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: intermediate
 description: >
   Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the .NET SDK documentation?
+  queues and topics with the .NET SDK?
 sdk_package: Azure.Messaging.ServiceBus
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that demonstrates
+Write a C# program that demonstrates
 messaging with Azure Service Bus:
 1. Create a ServiceBusClient using a connection string
 2. Create a ServiceBusSender for a queue and send a single message
@@ -37,7 +37,7 @@ Show required NuGet packages and proper disposal with await using.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.Messaging.ServiceBus` NuGet package
 - `ServiceBusClient` creation with connection string or `DefaultAzureCredential`
 - `ServiceBusSender` and `ServiceBusMessage` for sending

--- a/prompts/service-bus/data-plane/java/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/java/send-receive-messages.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: intermediate
 description: >
   Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the Java SDK documentation?
+  queues and topics with the Java SDK?
 sdk_package: azure-messaging-servicebus
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java program that demonstrates
+Write a Java program that demonstrates
 messaging with Azure Service Bus:
 1. Create a ServiceBusSenderClient using ServiceBusClientBuilder for a queue
 2. Send a single message with ServiceBusMessage
@@ -38,7 +38,7 @@ proper resource cleanup with close().
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-messaging-servicebus` Maven dependency
 - `ServiceBusClientBuilder` with connection string
 - `ServiceBusSenderClient` and `ServiceBusMessage`
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The Java Service Bus SDK uses the Azure SDK builder pattern with separate clients
-for sending and receiving. This tests whether the Java docs cover the full
+for sending and receiving. This tests whether the generated code covers the full
 message lifecycle including the processor client for continuous processing.

--- a/prompts/service-bus/data-plane/js-ts/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/js-ts/send-receive-messages.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: intermediate
 description: >
   Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the JavaScript/TypeScript SDK documentation?
+  queues and topics with the JavaScript/TypeScript SDK?
 sdk_package: "@azure/service-bus"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/service-bus-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that demonstrates messaging with Azure Service Bus:
 1. Create a ServiceBusClient using a connection string
 2. Create a sender for a queue and send a single message
@@ -37,7 +37,7 @@ Show required npm package (@azure/service-bus) and proper close() cleanup.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/service-bus` npm package
 - `ServiceBusClient` constructor with connection string
 - `createSender()` for queue or topic
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript Service Bus SDK supports both pull-based (receiveMessages) and
-push-based (subscribe) receiving patterns. This tests whether the JS/TS docs
-cover both patterns and proper resource cleanup.
+push-based (subscribe) receiving patterns. This tests whether the generated code
+covers both patterns and proper resource cleanup.

--- a/prompts/service-bus/data-plane/python/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/python/send-receive-messages.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: intermediate
 description: >
   Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the Python SDK documentation?
+  queues and topics with the Python SDK?
 sdk_package: azure-servicebus
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/servicebus-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that
+Write a Python script that
 demonstrates messaging with Azure Service Bus:
 1. Create a ServiceBusClient using from_connection_string()
 2. Get a sender for a queue and send a single ServiceBusMessage
@@ -37,7 +37,7 @@ Show required pip packages and proper context manager patterns (with statements)
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-servicebus` pip package
 - `ServiceBusClient.from_connection_string()`
 - `ServiceBusSender` via `get_queue_sender()` or `get_topic_sender()`
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The Python Service Bus SDK supports both sync and async patterns with context managers.
-This tests whether the Python docs cover both patterns and the queue vs.
+This tests whether the generated code covers both patterns and the queue vs.
 topic/subscription distinction.

--- a/prompts/storage/data-plane/cpp/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/cpp/crud-blobs.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the C++ SDK based on the documentation alone?
+  using the C++ SDK?
 sdk_package: azure-storage-blobs-cpp
 doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for C++ documentation, write a C++ program that performs
+Write a C++ program that performs
 the following blob storage operations:
 1. Create a blob container called "my-container" if it does not already exist
 2. Upload a local file "example.txt" as a block blob named "uploads/example.txt"
@@ -37,7 +37,7 @@ or blob not found.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - vcpkg/CMake setup for `azure-storage-blobs-cpp` and `azure-identity-cpp`
 - Creating a `BlobServiceClient` with the storage account URL and credential
 - `BlobContainerClient::CreateIfNotExists()` for container creation
@@ -51,5 +51,5 @@ The documentation should cover:
 
 Blob storage is the most common Azure Storage service. The C++ SDK requires
 CMake and vcpkg setup that differs significantly from other language SDKs.
-Testing CRUD coverage validates that the docs explain both the build system
+Testing CRUD coverage validates that the generated code covers both the build system
 integration and the full lifecycle of blob operations for C++ developers.

--- a/prompts/storage/data-plane/dotnet/authentication.prompt.md
+++ b/prompts/storage/data-plane/dotnet/authentication.prompt.md
@@ -6,7 +6,7 @@ language: dotnet
 category: authentication
 difficulty: basic
 description: >
-  Can the docs help a developer authenticate to Azure Blob Storage
+  Can a developer authenticate to Azure Blob Storage
   using DefaultAzureCredential in .NET?
 sdk_package: Azure.Storage.Blobs
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
@@ -29,7 +29,7 @@ Show me the complete setup including required NuGet packages.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Installing `Azure.Identity` and `Azure.Storage.Blobs` packages
 - Creating a `DefaultAzureCredential` instance
 - Passing the credential to `BlobServiceClient`
@@ -39,4 +39,4 @@ The documentation should cover:
 ## Context
 
 This is one of the most common first tasks for a developer using Azure Storage.
-The docs should make this easy to find and follow without prior Azure SDK experience.
+The generated code should be easy to follow without prior Azure SDK experience.

--- a/prompts/storage/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/storage/data-plane/dotnet/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: dotnet
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle common Azure Blob Storage errors
+  Can a developer handle common Azure Blob Storage errors
   including 404, 403, and 429 responses in .NET?
 sdk_package: Azure.Storage.Blobs
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme

--- a/prompts/storage/data-plane/dotnet/retry-configuration.prompt.md
+++ b/prompts/storage/data-plane/dotnet/retry-configuration.prompt.md
@@ -50,4 +50,4 @@ Use the Azure.Storage.Blobs SDK.
 
 Default retry policies work for simple scenarios, but production applications
 need fine-tuned retry behavior. Developers building resilient storage pipelines
-need docs that explain the full retry model and when to override defaults.
+need to understand the full retry model and when to override defaults.

--- a/prompts/storage/data-plane/go/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/go/crud-blobs.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Go SDK documentation?
+  using the Go SDK?
 sdk_package: azblob
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, write a Go program that performs
+Write a Go program that performs
 CRUD operations on Azure Blob Storage:
 1. Create a service client using DefaultAzureCredential from azidentity
 2. Create a container named "my-container"
@@ -48,4 +48,4 @@ Show required Go modules and proper error handling using ResponseError.
 
 Go is increasingly popular for cloud-native Azure applications. The Go SDK
 uses a different pattern (pagers, streaming) than other languages, making it
-important to test whether the docs clearly explain Go-idiomatic blob operations.
+important to test whether the generated code clearly demonstrates Go-idiomatic blob operations.

--- a/prompts/storage/data-plane/java/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/java/crud-blobs.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Java SDK documentation?
+  using the Java SDK?
 sdk_package: azure-storage-blob
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java application that performs
+Write a Java application that performs
 CRUD operations on Azure Blob Storage:
 1. Create a BlobServiceClient using DefaultAzureCredential
 2. Create a container named "my-container" if it doesn't exist
@@ -46,5 +46,5 @@ Show required Maven dependencies and proper error handling with BlobStorageExcep
 ## Context
 
 Blob Storage is Azure's most widely used data service. Java is a top enterprise
-language. CRUD operations test whether the Java docs provide a complete,
+language. CRUD operations test whether the generated code provides a complete,
 runnable workflow covering the full blob lifecycle.

--- a/prompts/storage/data-plane/js-ts/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/js-ts/crud-blobs.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the JavaScript/TypeScript SDK documentation?
+  using the JavaScript/TypeScript SDK?
 sdk_package: "@azure/storage-blob"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/storage-blob-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program that
+Write a TypeScript program that
 performs CRUD operations on Azure Blob Storage:
 1. Create a BlobServiceClient using DefaultAzureCredential
 2. Create a container named "my-container" if it doesn't exist
@@ -48,5 +48,5 @@ Use async/await throughout.
 ## Context
 
 JavaScript/TypeScript is the most used language on npm and critical for
-full-stack Azure developers. This tests whether the JS docs provide clear
+full-stack Azure developers. This tests whether the generated code provides clear
 guidance on blob CRUD including the async streaming download pattern.

--- a/prompts/storage/data-plane/python/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/python/crud-blobs.prompt.md
@@ -7,7 +7,7 @@ category: crud
 difficulty: basic
 description: >
   Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Python SDK documentation?
+  using the Python SDK?
 sdk_package: azure-storage-blob
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that performs
+Write a Python script that performs
 CRUD operations on Azure Blob Storage:
 1. Create a BlobServiceClient using DefaultAzureCredential
 2. Create a container named "my-container" if it doesn't exist
@@ -47,5 +47,5 @@ Show required pip packages and proper error handling with HttpResponseError.
 ## Context
 
 Python is the most popular language for data engineering and ML workflows
-that use Azure Blob Storage. This tests whether the Python docs provide a
+that use Azure Blob Storage. This tests whether the generated code provides a
 complete blob lifecycle tutorial that a data engineer can follow end-to-end.

--- a/prompts/storage/data-plane/python/error-handling.prompt.md
+++ b/prompts/storage/data-plane/python/error-handling.prompt.md
@@ -6,7 +6,7 @@ language: python
 category: error-handling
 difficulty: intermediate
 description: >
-  Can the docs help a developer handle common Azure Blob Storage errors
+  Can a developer handle common Azure Blob Storage errors
   including 404, 403, and 429 responses in Python?
 sdk_package: azure-storage-blob
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme

--- a/prompts/storage/data-plane/python/pagination-list-blobs.prompt.md
+++ b/prompts/storage/data-plane/python/pagination-list-blobs.prompt.md
@@ -7,7 +7,7 @@ category: pagination
 difficulty: intermediate
 description: >
   Can a developer correctly paginate through a large list of blobs in
-  Azure Storage using the Python SDK based on docs alone?
+  Azure Storage using the Python SDK?
 sdk_package: azure-storage-blob
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
 tags:
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using the Azure SDK for Python documentation, write a script that lists all blobs
+Write a script that lists all blobs
 in a container that has over 10,000 blobs. The script should:
 1. Use page-by-page iteration (not loading all results into memory)
 2. Process blobs in pages of 100
@@ -34,7 +34,7 @@ Use DefaultAzureCredential for authentication. Show all required pip packages.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - Using `list_blobs()` with `results_per_page` parameter
 - Iterating by page using `.by_page()` or async iteration
 - Continuation token usage for resumable listing
@@ -44,5 +44,5 @@ The documentation should cover:
 ## Context
 
 Pagination is a core SDK pattern that many developers get wrong by loading
-all results into a list. This tests whether the docs guide developers toward
+all results into a list. This tests whether the generated code demonstrates developers toward
 the efficient page-by-page approach for large-scale blob listing.

--- a/prompts/storage/management-plane/dotnet/polling-create-account.prompt.md
+++ b/prompts/storage/management-plane/dotnet/polling-create-account.prompt.md
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that creates
+Write a C# program that creates
 an Azure Storage Account using the management plane SDK and properly handles the
 long-running operation (LRO):
 1. Start the create operation using CreateOrUpdateAsync

--- a/prompts/storage/management-plane/dotnet/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/dotnet/storage-account-mgmt.prompt.md
@@ -7,7 +7,7 @@ category: provisioning
 difficulty: intermediate
 description: >
   Can a developer create, configure, and manage Azure Storage Accounts
-  using the .NET management SDK documentation?
+  using the .NET management SDK?
 sdk_package: Azure.ResourceManager.Storage
 doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.storage-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for .NET documentation, write a C# program that manages
+Write a C# program that manages
 Azure Storage Accounts using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a new Storage Account with Standard_LRS SKU in "eastus"
@@ -36,7 +36,7 @@ Use the Azure.ResourceManager.Storage SDK.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `Azure.ResourceManager.Storage` NuGet package
 - `ArmClient` and subscription/resource group navigation
 - `StorageAccountCollection.CreateOrUpdate()` with `StorageAccountCreateOrUpdateContent`
@@ -48,5 +48,5 @@ The documentation should cover:
 ## Context
 
 Storage Account management is one of the most common management plane tasks.
-This tests whether the .NET docs cover the full lifecycle of a Storage Account
+This tests whether the generated code covers the full lifecycle of a Storage Account
 including the more complex configuration options like SKU, kind, and feature toggles.

--- a/prompts/storage/management-plane/go/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/go/storage-account-mgmt.prompt.md
@@ -7,7 +7,7 @@ category: provisioning
 difficulty: intermediate
 description: >
   Can a developer create, configure, and manage Azure Storage Accounts
-  using the Go management SDK documentation?
+  using the Go management SDK?
 sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
 doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Go documentation, write a Go program that manages
+Write a Go program that manages
 Azure Storage Accounts using the management plane SDK:
 1. Authenticate using DefaultAzureCredential from azidentity
 2. Create an AccountsClient from the armstorage package
@@ -37,7 +37,7 @@ Show required Go module imports and proper error handling with poller patterns.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage` module
 - `azidentity.NewDefaultAzureCredential()` for authentication
 - `armstorage.NewAccountsClient()` with subscription ID and credential
@@ -51,5 +51,5 @@ The documentation should cover:
 ## Context
 
 The Go storage management SDK uses the standard LRO poller pattern and pager
-iteration. This tests whether the Go docs cover the armstorage module and the
+iteration. This tests whether the generated code covers the armstorage module and the
 creation parameters that require SKU and Kind configuration.

--- a/prompts/storage/management-plane/java/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/java/storage-account-mgmt.prompt.md
@@ -7,7 +7,7 @@ category: provisioning
 difficulty: intermediate
 description: >
   Can a developer create, configure, and manage Azure Storage Accounts
-  using the Java management SDK documentation?
+  using the Java management SDK?
 sdk_package: azure-resourcemanager-storage
 doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-storage-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Java documentation, write a Java program that manages
+Write a Java program that manages
 Azure Storage Accounts using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a StorageManager instance with the credential and subscription
@@ -37,7 +37,7 @@ and proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-resourcemanager-storage` Maven dependency
 - `StorageManager.authenticate()` with credential and profile
 - `storageAccounts().define().withRegion().withExistingResourceGroup().withSku().create()`
@@ -50,5 +50,5 @@ The documentation should cover:
 ## Context
 
 The Java management SDK uses a fluent builder pattern (define/create/update) that
-differs significantly from other languages. This tests whether the Java docs cover
+differs significantly from other languages. This tests whether the generated code covers
 the fluent API for storage account lifecycle management.

--- a/prompts/storage/management-plane/js-ts/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/js-ts/storage-account-mgmt.prompt.md
@@ -7,7 +7,7 @@ category: provisioning
 difficulty: intermediate
 description: >
   Can a developer create, configure, and manage Azure Storage Accounts
-  using the JavaScript/TypeScript management SDK documentation?
+  using the JavaScript/TypeScript management SDK?
 sdk_package: "@azure/arm-storage"
 doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-storage-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for JavaScript documentation, write a TypeScript program
+Write a TypeScript program
 that manages Azure Storage Accounts using the management plane SDK:
 1. Authenticate using DefaultAzureCredential from @azure/identity
 2. Create a StorageManagementClient with the credential and subscription ID
@@ -36,7 +36,7 @@ Show required npm packages (@azure/arm-storage) and proper async/await patterns.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `@azure/arm-storage` and `@azure/identity` npm packages
 - `StorageManagementClient` constructor with credential and subscriptionId
 - `storageAccounts.beginCreateAndWait()` with `StorageAccountCreateParameters`
@@ -49,5 +49,5 @@ The documentation should cover:
 ## Context
 
 The JavaScript storage management SDK uses the ARM client pattern with beginAndWait
-for LROs. This tests whether the JS/TS docs cover the full storage account lifecycle
+for LROs. This tests whether the generated code covers the full storage account lifecycle
 including the async creation pattern.

--- a/prompts/storage/management-plane/python/polling-create-account.prompt.md
+++ b/prompts/storage/management-plane/python/polling-create-account.prompt.md
@@ -23,7 +23,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that creates
+Write a Python script that creates
 an Azure Storage Account using the management plane SDK and properly handles the
 long-running operation (LRO):
 1. Start the create operation using begin_create

--- a/prompts/storage/management-plane/python/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/python/storage-account-mgmt.prompt.md
@@ -7,7 +7,7 @@ category: provisioning
 difficulty: intermediate
 description: >
   Can a developer create, configure, and manage Azure Storage Accounts
-  using the Python management SDK documentation?
+  using the Python management SDK?
 sdk_package: azure-mgmt-storage
 doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-storage-readme
 tags:
@@ -22,7 +22,7 @@ author: ronniegeraghty
 
 ## Prompt
 
-Using only the Azure SDK for Python documentation, write a Python script that manages
+Write a Python script that manages
 Azure Storage Accounts using the management plane SDK:
 1. Authenticate using DefaultAzureCredential
 2. Create a new Storage Account with Standard_LRS SKU in "eastus"
@@ -35,7 +35,7 @@ Show required pip packages and include proper error handling.
 
 ## Evaluation Criteria
 
-The documentation should cover:
+The generated code should include:
 - `azure-mgmt-storage` and `azure-identity` pip packages
 - `StorageManagementClient` creation with credential and subscription_id
 - `storage_accounts.begin_create()` with `StorageAccountCreateParameters`
@@ -48,5 +48,5 @@ The documentation should cover:
 ## Context
 
 Storage Account management is one of the most common management plane tasks.
-This tests whether the Python docs cover the full lifecycle including
+This tests whether the generated code covers the full lifecycle including
 the long-running create operation and model configuration for SKUs and features.


### PR DESCRIPTION
## Summary

Refactors all prompt files to remove documentation-centric language and refocus on code generation evaluation.

### Changes (77 of 79 files modified)

**Prompt sections:**
- Removed `Using only the Azure SDK for <lang> documentation` prefix — prompts now directly ask for the code
- Example: `Using only the Azure SDK for Python documentation, write a Python script...` → `Write a Python script...`

**Evaluation Criteria:**
- Changed `The documentation should cover:` → `The generated code should include:`

**Frontmatter descriptions:**
- Removed doc-quality framing like `using the ... SDK documentation?` and `based on the documentation alone?`
- Changed `Can the docs help a developer...` → `Can a developer...`

**Context sections:**
- Rewrote doc-testing language to code-generation-testing language
- Example: `This tests whether the Python docs provide...` → `This tests whether the generated code provides...`

### What was preserved
- All core technical asks unchanged
- `doc_url` metadata field kept (structural reference, not a request)
- Inline code comments guidance unchanged
- 2 files had no doc references and were untouched

### Validation
- All 79 prompts pass `go run ./tool/cmd/azsdk-prompt-eval validate` ✅
- No remaining `documentation` or `docs` references in prompt content (outside `doc_url` metadata)

Closes #7