### PR TITLE
Add re-run command to eval report files

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -571,6 +571,9 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		}
 	}
 
+	// Build re-run command so users can reproduce this evaluation
+	evalReport.RerunCommand = buildRerunCommand(task.Prompt.ID, task.Config.Name, e.opts)
+
 	// Write JSON report
 	reportPath, err := report.WriteReport(evalReport, e.opts.OutputDir, runID, task.Prompt)
 	if err != nil {
@@ -598,6 +601,37 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	}
 
 	return evalReport
+}
+
+// buildRerunCommand constructs the CLI command to reproduce a single evaluation.
+func buildRerunCommand(promptID, configName string, opts EngineOptions) string {
+	parts := []string{"hyoka run"}
+	parts = append(parts, "--prompt-id", promptID)
+	parts = append(parts, "--config", configName)
+
+	if opts.SkipTests {
+		parts = append(parts, "--skip-tests")
+	}
+	if opts.SkipReview {
+		parts = append(parts, "--skip-review")
+	}
+	if opts.VerifyBuild {
+		parts = append(parts, "--verify-build")
+	}
+
+	// Include non-default timeouts.
+	// Default generate timeout is 10m (600s), verify and review are 5m (300s).
+	if opts.GenerateTimeout != 10*time.Minute {
+		parts = append(parts, fmt.Sprintf("--generate-timeout=%d", int(opts.GenerateTimeout.Seconds())))
+	}
+	if opts.VerifyTimeout != 5*time.Minute {
+		parts = append(parts, fmt.Sprintf("--verify-timeout=%d", int(opts.VerifyTimeout.Seconds())))
+	}
+	if opts.ReviewTimeout != 5*time.Minute {
+		parts = append(parts, fmt.Sprintf("--review-timeout=%d", int(opts.ReviewTimeout.Seconds())))
+	}
+
+	return strings.Join(parts, " ")
 }
 
 func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {

--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -939,6 +939,17 @@ const reportTemplate = `<!DOCTYPE html>
 </div>
 {{end}}
 
+<!-- ━━ Re-run Command ━━ -->
+{{if .RerunCommand}}
+<div class="section">
+  <div class="section-header"><span class="icon">🔄</span><h2>Re-run Command</h2></div>
+  <div class="section-body">
+    <p style="font-size:0.85rem;color:var(--text-muted)">Copy and paste this command to reproduce this evaluation:</p>
+    <pre>{{.RerunCommand}}</pre>
+  </div>
+</div>
+{{end}}
+
 </body>
 </html>`
 

--- a/hyoka/internal/report/markdown.go
+++ b/hyoka/internal/report/markdown.go
@@ -254,6 +254,12 @@ func WriteMarkdownReport(r *EvalReport, outputDir string, runID string, service,
 		}
 	}
 
+	// Re-run command
+	if r.RerunCommand != "" {
+		b.WriteString("## Re-run Command\n\n")
+		fmt.Fprintf(&b, "```bash\n%s\n```\n\n", r.RerunCommand)
+	}
+
 	// Footer
 	b.WriteString("---\n\n")
 	b.WriteString("[← Back to Summary](../../../../../../summary.md)\n")

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -67,6 +67,7 @@ type EvalReport struct {
 	Error          string               `json:"error,omitempty"`
 	ErrorDetails   string               `json:"error_details,omitempty"`
 	IsStub         bool                 `json:"is_stub,omitempty"`
+	RerunCommand   string               `json:"rerunCommand,omitempty"`
 }
 
 // RunSummary contains aggregate statistics for an evaluation run.


### PR DESCRIPTION
## Summary

Adds a `RerunCommand` field to eval reports so users can see the exact CLI command to reproduce a specific evaluation run.

### Changes

- **types.go**: Added `RerunCommand string` field to `EvalReport` struct
- **engine.go**: Added `buildRerunCommand()` that constructs the command from prompt ID, config name, and non-default engine options (timeouts, skip flags, verify-build)
- **markdown.go**: Added "Re-run Command" section with a copy-pasteable bash code block
- **html.go**: Added "Re-run Command" section with styled display
- **JSON report**: Automatically includes the field via struct marshaling

### Example output (Markdown)

```markdown
## Re-run Command
\`\`\`bash
hyoka run --prompt-id event-hubs-dp-js-streaming --config baseline
\`\`\`
```

Closes #19