### PR TITLE
Add Java SDK validation reviewer skill and trim common criteria

### DIFF
--- a/configs/baseline-codex.yaml
+++ b/configs/baseline-codex.yaml
@@ -7,3 +7,5 @@ configs:
       - "claude-opus-4.6"
       - "gemini-3-pro-preview"
       - "gpt-4.1"
+    reviewer_skill_directories:
+      - "./skills/reviewer"

--- a/configs/baseline-opus-skills.yaml
+++ b/configs/baseline-opus-skills.yaml
@@ -15,3 +15,5 @@ configs:
       - "gpt-4.1"
     generator_skill_directories:
       - "./skills/generator"
+    reviewer_skill_directories:
+      - "./skills/reviewer"

--- a/configs/baseline-opus.yaml
+++ b/configs/baseline-opus.yaml
@@ -7,3 +7,5 @@ configs:
       - "claude-opus-4.6"
       - "gemini-3-pro-preview"
       - "gpt-4.1"
+    reviewer_skill_directories:
+      - "./skills/reviewer"

--- a/configs/baseline-sonnet.yaml
+++ b/configs/baseline-sonnet.yaml
@@ -7,3 +7,5 @@ configs:
       - "claude-opus-4.6"
       - "gemini-3-pro-preview"
       - "gpt-4.1"
+    reviewer_skill_directories:
+      - "./skills/reviewer"

--- a/prompts/app-configuration/data-plane/java/feature-flags.prompt.md
+++ b/prompts/app-configuration/data-plane/java/feature-flags.prompt.md
@@ -45,21 +45,7 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-data-appconfiguration` (correct package name)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
-
-### Authentication
-- Uses `DefaultAzureCredential` — not connection strings or access keys
-- Reads App Configuration endpoint from environment variable
-
-### Client Construction
-- Uses `ConfigurationClientBuilder` (sync) / `ConfigurationAsyncClient` builder (async)
-- Builder chain includes `.endpoint()` and `.credential()`
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Retrieves settings with a specific label parameter using `SettingSelector`
 - Lists settings filtered by key prefix using `setKeyFilter()`
 - Implements conditional reads with `matchConditions` / `setIfNoneMatch()` using the setting's ETag
@@ -69,20 +55,6 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Implements deterministic percentage rollout (consistent hash, not `Math.random()`)
 - Implements sentinel key watching with configurable polling interval
 - Detects sentinel value change via ETag or value comparison and triggers full refresh
-
-### Error Handling
-- Handles missing settings gracefully (returns null, Optional, or default)
-- Catches `HttpResponseException` or SDK-specific exceptions
-
-### Async Quality
-- Uses `ConfigurationAsyncClient` (not sync on background thread)
-- Uses Project Reactor types (`Mono`, `Flux`)
-- Does not call `.block()` inside the async implementation
-
-### Anti-Patterns (should NOT appear)
-- Connection string-based authentication
-- Fabricated/hallucinated class names that don't exist in the SDK
-- `com.microsoft.azure.*` imports
 
 ## Context
 

--- a/prompts/cosmos-db/data-plane/java/todo-repository.prompt.md
+++ b/prompts/cosmos-db/data-plane/java/todo-repository.prompt.md
@@ -48,21 +48,7 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-cosmos` (not `com.microsoft.azure:azure-documentdb` or `com.microsoft.azure:azure-cosmosdb`)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
-
-### Authentication
-- Uses `DefaultAzureCredential` — no master keys or connection strings
-- Reads Cosmos DB endpoint from environment variable
-
-### Client Construction
-- Uses `CosmosClientBuilder` with `.endpoint()` and `.credential()`
-- Uses `CosmosClient` (sync) and `CosmosAsyncClient` (async)
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Correct partition key usage: `/category` path, `PartitionKey` in all point operations
 - ETag-based optimistic concurrency: captures ETag from read, passes `ifMatchETag` on update
 - Handles 412 Precondition Failed as a specific error case for conflicts
@@ -75,21 +61,12 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Indexing policy excludes `/description` path
 - RU cost extracted from response via `getRequestCharge()` and logged per operation
 
-### Error Handling
+### Scenario-Specific Error Handling
 - Catches `CosmosException` with status code checks (404, 409, 412)
 - Handles 412 separately for ETag conflicts
-- Does not use bare `Exception` catches
 
-### Async Quality
-- Uses `CosmosAsyncClient` / `CosmosAsyncDatabase` / `CosmosAsyncContainer`
-- Uses Project Reactor types (`Mono`, `Flux`)
-- Does not call `.block()` inside the async implementation
-
-### Anti-Patterns (should NOT appear)
-- `DocumentClient` or `DocumentClientException` (old v2 API)
-- Connection strings with `AccountKey=...`
-- `com.microsoft.azure.*` imports
-- Flattened query results (`.stream()` / `.forEach()` without page iteration)
+### Anti-Patterns (scenario-specific)
+- Does NOT flatten query results (`.stream()` / `.forEach()` without page iteration)
 
 ## Context
 

--- a/prompts/identity/data-plane/java/credential-chain.prompt.md
+++ b/prompts/identity/data-plane/java/credential-chain.prompt.md
@@ -45,27 +45,17 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Does NOT pull in service SDKs (this is identity-only)
-- Specifies Java 17
-
-### Authentication
-- No hardcoded client secrets, certificates, or tenant IDs in source code
-- User-assigned managed identity client ID comes from environment variable
-
 ### Credential Chain Construction
 - Uses `ChainedTokenCredentialBuilder` to compose multiple credentials
 - Credentials added via `.addLast()` — order matters
 
 ### Environment-Specific Chains
-- **Dev chain**: includes `AzureCliCredential` (most common); may include `IntelliJCredential`, `VisualStudioCodeCredential`, or `AzurePowerShellCredential`
+- **Dev chain**: includes `AzureCliCredential`; may include `IntelliJCredential`, `VisualStudioCodeCredential`, `AzurePowerShellCredential`
 - **CI chain**: uses `EnvironmentCredential` or `AzurePipelinesCredential` (not just `DefaultAzureCredential`)
 - **Production chain**: `ManagedIdentityCredential` first (supports user-assigned via `clientId()`), `WorkloadIdentityCredential` as fallback
 
 ### CAE Support
-- Enables Continuous Access Evaluation via `TokenRequestContext.setCaeEnabled(true)` or `enableCae()` on credential builders
+- Enables CAE via `TokenRequestContext.setCaeEnabled(true)` or `enableCae()` on credential builders
 
 ### Environment Detection
 - Detects CI (checks `CI`, `TF_BUILD`, `AZURE_PIPELINE_WORKSPACE`, or similar)
@@ -77,19 +67,11 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Calls `getToken()` and prints token expiry from `AccessToken.getExpiresAt()`
 - Handles failure with specific exception info
 
-### Error Handling
-- Catches `CredentialUnavailableException` for missing credentials
-- Catches `AuthenticationRequiredException` where appropriate
-- Provides actionable error messages
-
-### Async Quality
+### Scenario-Specific Async
 - Async tester uses reactive `getToken()` returning `Mono<AccessToken>`
-- Does not call `.block()` inside the async implementation
 
-### Anti-Patterns (should NOT appear)
-- `DefaultAzureCredential` used as the CI credential (too broad)
-- `com.microsoft.azure.*` imports
-- Hardcoded secrets or tenant IDs
+### Anti-Patterns (scenario-specific)
+- NOT using `DefaultAzureCredential` as the CI credential (too broad)
 
 ## Context
 

--- a/prompts/key-vault/data-plane/java/secret-config.prompt.md
+++ b/prompts/key-vault/data-plane/java/secret-config.prompt.md
@@ -49,21 +49,7 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-security-keyvault-secrets` (not `com.microsoft.azure:azure-keyvault`)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
-
-### Authentication
-- Uses `DefaultAzureCredential` — no client secrets, certificates, or tenant IDs in code
-- Reads Key Vault URL from environment variable
-
-### Client Construction
-- Uses `SecretClientBuilder` (sync) / `SecretAsyncClient` builder (async)
-- Builder chain includes `.vaultUrl()` and `.credential()`
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Secret versioning: retrieves specific version via `getSecret(name, version)`
 - Secret expiry: accesses `properties().getExpiresOn()` on `SecretProperties`
 - Configurable warning window for near-expiry detection
@@ -73,22 +59,11 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Async uses `PollerFlux` to wait for delete completion
 - Creates new secret only after delete completes (not concurrently)
 
-### Error Handling
-- Catches `ResourceNotFoundException` or `HttpResponseException` with 404 for missing secrets
+### Scenario-Specific Error Handling
 - Returns a default value when secret is not found (does not crash)
-- Does not use bare `Exception` catches
 
-### Async Quality
-- Uses `SecretAsyncClient` (not sync on background thread)
-- Uses Project Reactor types (`Mono`, `Flux`)
-- LRO uses `PollerFlux` (not `SyncPoller`)
-- Does not call `.block()` inside the async implementation
-
-### Anti-Patterns (should NOT appear)
-- `KeyVaultClient` (old v7 API)
-- `ServiceClientCredentials` or `AuthenticationCallback`
-- `com.microsoft.azure.*` imports
-- Fire-and-forget `deleteSecret()` without waiting for completion
+### Anti-Patterns (scenario-specific)
+- NOT using fire-and-forget `deleteSecret()` without waiting for completion
 
 ## Context
 

--- a/prompts/service-bus/data-plane/java/order-processor.prompt.md
+++ b/prompts/service-bus/data-plane/java/order-processor.prompt.md
@@ -44,24 +44,11 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-messaging-servicebus` (not `com.microsoft.azure:azure-servicebus`)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
+### Scenario-Specific Client Construction
+- Sender uses `.sender().queueName().buildClient()` chain (or async equivalent)
+- Processor uses `.processor().queueName().processMessage().processError()` chain
 
-### Authentication
-- Uses `DefaultAzureCredential` with fully-qualified namespace (not connection string)
-- No hardcoded connection strings or SAS tokens
-- Reads namespace from environment variable
-
-### Client Construction
-- Uses `ServiceBusClientBuilder` as the entry point
-- Sender: `.sender().queueName().buildClient()` chain (or async equivalent)
-- Processor: `.processor().queueName().processMessage().processError()` chain
-- Builder includes `.fullyQualifiedNamespace()` and `.credential()`
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Batch sending: creates `ServiceBusMessageBatch`, checks `tryAddMessage()` return value
 - Handles the case where a message doesn't fit in the current batch
 - Scheduled delivery: uses `scheduleMessage()` or `setScheduledEnqueueTime()` (~30s delay)
@@ -71,20 +58,9 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Session-aware processing: uses `.sessionProcessor()` or session-enabled receiver
 - Session ID keyed by customer name for ordered processing
 
-### Error Handling
-- Catches `ServiceBusException` (not just `Exception`)
+### Scenario-Specific Error Handling
 - Error handler in processor logs entity path and error source
 - Distinguishes transient vs non-transient errors via `isTransient()` or `getReason()`
-
-### Async Quality
-- Uses `ServiceBusSenderAsyncClient` / `ServiceBusProcessorClient` (processor is inherently async)
-- Uses Project Reactor types (`Mono`, `Flux`) where applicable
-- Does not call `.block()` inside the async implementation
-
-### Anti-Patterns (should NOT appear)
-- `QueueClient`, `IMessage`, `IMessageHandler` (old SDK)
-- `ConnectionStringBuilder`
-- `com.microsoft.azure.*` imports
 
 ## Context
 

--- a/prompts/storage/data-plane/java/blob-event-notifier.prompt.md
+++ b/prompts/storage/data-plane/java/blob-event-notifier.prompt.md
@@ -45,23 +45,7 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-messaging-eventgrid`
-- Uses `com.azure:azure-storage-blob`
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
-
-### Authentication
-- Uses `DefaultAzureCredential` — no access keys, connection strings, or SAS tokens
-- Reads endpoints from environment variables
-
-### Client Construction
-- Uses `BlobServiceClientBuilder` for Blob Storage
-- Uses `EventGridPublisherClientBuilder` for Event Grid publishing
-- Both builders use `.endpoint()` and `.credential()`
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Handles Event Grid native schema via `EventGridEvent.fromString()` deserialization
 - Handles CloudEvents 1.0 schema via `CloudEvent.fromString()` deserialization
 - Does NOT manually parse JSON without the SDK's deserialization helpers
@@ -71,20 +55,9 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Publishes custom events with subject hierarchy for filtering
 - Retrieves and prints blob access tier from blob properties
 
-### Error Handling
+### Scenario-Specific Error Handling
 - Handles race condition: blob may no longer exist (catches `BlobStorageException` with 404 status)
 - Catches Event Grid-specific exceptions for publishing errors
-- Does not use bare `Exception` catches
-
-### Async Quality
-- Uses `BlobAsyncClient` and `EventGridPublisherAsyncClient`
-- Uses Project Reactor types (`Mono`, `Flux`)
-- Does not call `.block()` inside the async implementation
-
-### Anti-Patterns (should NOT appear)
-- `CloudStorageAccount` or `CloudBlobClient` (deprecated v8 API)
-- Fabricated Event Grid classes that don't exist in the SDK
-- `com.microsoft.azure.*` imports
 
 ## Context
 

--- a/prompts/storage/data-plane/java/blob-storage-manager.prompt.md
+++ b/prompts/storage/data-plane/java/blob-storage-manager.prompt.md
@@ -43,43 +43,14 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies (pom.xml)
-- Uses `com.azure:azure-storage-blob` (not `com.microsoft.azure:azure-storage`)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
-
-### Authentication
-- Uses `DefaultAzureCredential` or another `com.azure.identity` credential — not connection strings
-- No hardcoded account keys, connection strings, or SAS tokens
-- Reads storage endpoint from environment variable
-
-### Client Construction
-- Uses `BlobServiceClientBuilder` with `.endpoint()` and `.credential()`
-- Async uses `BlobServiceAsyncClient` (not sync wrapped in a thread pool)
-
-### SDK Patterns
+### Scenario-Specific Patterns
 - Configures custom retry policy (exponential backoff, max retries, delay)
 - Sets per-request or per-operation timeout
 - Enables HTTP logging (`HttpLogOptions`)
 - Implements blob lease acquisition before overwrite (lease-specific API)
 - Implements parallel/block upload for large files (`ParallelTransferOptions`, not manual chunking)
 - Sets blob index tags on upload (not just metadata) — `Map<String, String>` via upload options
-
-### Error Handling
-- Catches `BlobStorageException` (not just `Exception` or `RuntimeException`)
-- Handles or logs HTTP status code from storage errors
-
-### Async Quality
-- Uses Project Reactor types (`Mono`, `Flux`) — the Azure SDK async surface is Reactor-based
-- Does not call `.block()` inside the async service implementation
 - Properly composes reactive chains in the demo
-
-### Anti-Patterns (should NOT appear)
-- `CloudStorageAccount`, `CloudBlobClient`, `CloudBlobContainer` (deprecated v8 API)
-- `StorageCredentialsAccountAndKey`
-- `com.microsoft.azure.*` imports
-- `CompletableFuture` for async (wrong for Azure SDK Java — should use Reactor)
 
 ## Context
 

--- a/prompts/storage/data-plane/java/encrypted-uploader.prompt.md
+++ b/prompts/storage/data-plane/java/encrypted-uploader.prompt.md
@@ -46,31 +46,19 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 
 ## Evaluation Criteria
 
-### Dependencies
-- Uses `com.azure:azure-storage-blob`
-- Uses `com.azure:azure-security-keyvault-keys` (Keys, NOT Secrets)
-- Uses `com.azure:azure-identity`
-- No `com.microsoft.azure` groupId anywhere
-- Specifies Java 17
+### Dependencies (scenario-specific)
+- Uses `com.azure:azure-security-keyvault-keys` (Keys, NOT Secrets) — critical distinction
 - Uses `javax.crypto` or `java.security` for local AES-GCM encryption
 
-### Authentication
-- Uses `DefaultAzureCredential` shared between Blob Storage and Key Vault clients
-- No hardcoded keys, connection strings, or SAS tokens
-- Reads endpoints from environment variables
-
-### Client Construction
-- Uses `BlobServiceClientBuilder` for Blob Storage
+### Client Construction (scenario-specific)
 - Uses `KeyClient` / `CryptographyClient` builder for Key Vault Keys (NOT `SecretClient`)
-- Both use `.endpoint()` / `.vaultUrl()` and `.credential()`
 
-### SDK Patterns — Key Vault Keys (critical)
-- Uses Key Vault **Keys** service, NOT Secrets
+### Key Vault Keys Patterns (critical)
 - Uses `CryptographyClient` for `wrapKey()` and `unwrapKey()` operations
 - Specifies RSA key wrap algorithm (`KeyWrapAlgorithm.RSA_OAEP` or `RSA_OAEP_256`)
 - Key material never leaves Key Vault (wrap/unwrap is server-side)
 
-### SDK Patterns — Envelope Encryption (critical)
+### Envelope Encryption Patterns (critical)
 - Generates a random AES-256 DEK locally (32 bytes)
 - Encrypts data with AES-GCM locally using the DEK
 - Wraps the DEK via Key Vault `wrapKey()`
@@ -83,22 +71,16 @@ Include a complete `pom.xml` with the necessary Azure SDK dependencies.
 - Uses AES-GCM (not AES-CBC, AES-ECB, or other modes)
 - Generates random IV for each encryption (typically 12 bytes for GCM)
 
-### Error Handling
-- Handles `BlobStorageException` for blob errors
+### Scenario-Specific Error Handling
 - Handles Key Vault errors (key disabled, key not found)
-- Catches specific exceptions rather than generic `Exception`
 
-### Async Quality
-- Uses `BlobAsyncClient` and `CryptographyAsyncClient`
-- Uses Project Reactor types (`Mono`, `Flux`)
-- Does not call `.block()` inside the async implementation
+### Scenario-Specific Async
+- Uses `BlobAsyncClient` and `CryptographyAsyncClient` for async
 
-### Anti-Patterns (should NOT appear)
-- Using `SecretClient` instead of `KeyClient`/`CryptographyClient`
-- Encrypting data directly with the vault key (should be envelope encryption)
-- Storing raw DEK in plaintext
-- AES-CBC or AES-ECB mode
-- `com.microsoft.azure.*` imports
+### Anti-Patterns (scenario-specific)
+- NOT using `SecretClient` instead of `KeyClient`/`CryptographyClient`
+- NOT encrypting data directly with the vault key (should be envelope encryption)
+- NOT storing raw DEK in plaintext
 
 ## Context
 

--- a/skills/reviewer/java-sdk-validation/SKILL.md
+++ b/skills/reviewer/java-sdk-validation/SKILL.md
@@ -1,0 +1,211 @@
+# Java SDK Validation Skill
+
+You are a **Java Azure SDK validation reviewer** for generated code samples. Your job is to check whether generated Java code follows modern Azure SDK for Java conventions and flag violations of common anti-patterns that LLMs frequently produce.
+
+## Rules
+
+1. **NEVER modify generated code.** You are evaluating, not fixing.
+2. Report all findings honestly — pass or fail with specific evidence.
+3. Check every rule below. A single violation in a category means that category fails.
+4. If a check cannot be determined from the available code (e.g., no pom.xml present), mark it as `"skipped"` with a reason.
+
+## Checks
+
+### 1. Dependency Checks (pom.xml / build.gradle)
+
+Azure SDK for Java uses the `com.azure` group ID. The legacy `com.microsoft.azure` group ID is the old SDK and must not be used.
+
+| Pass | Fail |
+|------|------|
+| `com.azure:azure-storage-blob` | `com.microsoft.azure:azure-storage` |
+| `com.azure:azure-cosmos` | `com.microsoft.azure:azure-documentdb` |
+| `com.azure:azure-security-keyvault-secrets` | `com.microsoft.azure:azure-keyvault` |
+| `com.azure:azure-messaging-servicebus` | `com.microsoft.azure:azure-servicebus` |
+| `com.azure:azure-messaging-eventgrid` | `com.microsoft.azure:azure-eventgrid` |
+| `com.azure:azure-data-appconfiguration` | `com.microsoft.azure:azure-appconfiguration` |
+| `com.azure:azure-identity` | (no old equivalent — must always be present) |
+
+Also check:
+- Java source/target version is 8 or above (17 preferred for new projects)
+- No `com.microsoft.azure` groupId appears anywhere in dependency declarations
+
+### 2. Import Checks
+
+Scan all `.java` files for import statements:
+
+- **Pass**: imports from `com.azure.*` packages (e.g., `com.azure.storage.blob`, `com.azure.identity`, `com.azure.cosmos`)
+- **Fail**: imports from `com.microsoft.azure.*` (legacy SDK)
+- **Fail**: imports from `com.azure.*.implementation.*` (internal packages not meant for public use)
+
+### 3. Authentication Pattern
+
+Azure SDK for Java uses `DefaultAzureCredential` (or other `com.azure.identity` credentials) with token-based auth. Connection strings and account keys are discouraged for production.
+
+- **Pass**: Uses `DefaultAzureCredential` or another `com.azure.identity` credential class
+- **Pass**: Reads endpoint/vault URL from environment variable
+- **Fail**: Hardcoded connection strings (e.g., `DefaultEndpointsProtocol=https;AccountName=...`)
+- **Fail**: Hardcoded account keys, SAS tokens, client secrets, or certificates in source code
+- **Fail**: Uses `StorageCredentialsAccountAndKey` or `ConnectionStringBuilder` (legacy patterns)
+
+### 4. Client Construction
+
+Azure SDK for Java v12+ uses the builder pattern for all clients:
+
+- **Pass**: Uses `*ClientBuilder` classes (e.g., `BlobServiceClientBuilder`, `CosmosClientBuilder`, `SecretClientBuilder`, `ServiceBusClientBuilder`)
+- **Pass**: Builder chain includes `.endpoint()` or `.vaultUrl()` and `.credential()`
+- **Fail**: Uses legacy client constructors (`CloudStorageAccount`, `DocumentClient`, `KeyVaultClient`, `QueueClient`)
+
+### 5. Deprecated / Legacy Class Anti-Patterns
+
+These classes are from the old Azure SDK and must NOT appear in generated code:
+
+| Service | Deprecated Classes (FAIL if found) | Modern Replacement |
+|---------|-----------------------------------|-------------------|
+| Storage | `CloudStorageAccount`, `CloudBlobClient`, `CloudBlobContainer` | `BlobServiceClient`, `BlobContainerClient` |
+| Cosmos DB | `DocumentClient`, `DocumentClientException` | `CosmosClient`, `CosmosException` |
+| Key Vault | `KeyVaultClient`, `ServiceClientCredentials`, `AuthenticationCallback` | `SecretClient`, `KeyClient`, `CertificateClient` |
+| Service Bus | `QueueClient`, `IMessage`, `IMessageHandler`, `ConnectionStringBuilder` | `ServiceBusClientBuilder`, `ServiceBusMessage` |
+| Identity | `ApplicationTokenCredentials`, `MSICredentials` | `DefaultAzureCredential`, `ManagedIdentityCredential` |
+
+### 6. Pagination & Collection Return Types
+
+Azure SDK for Java has dedicated types for paginated responses. Raw `List` or `Stream` returns are incorrect.
+
+- **Pass**: Sync methods return `PagedIterable<T>` (or use `iterableByPage()` for page-level iteration)
+- **Pass**: Async methods return `PagedFlux<T>` (with `.byPage()` support)
+- **Fail**: Returns raw `List<T>`, `Stream<T>`, or `Iterator<T>` from list/query operations
+- **Fail**: Flattens all pages into memory at once (defeats pagination purpose)
+
+If no collection/list methods exist, mark this check as `"not_applicable"`.
+
+### 7. Long-Running Operations (LROs)
+
+Azure SDK for Java uses `SyncPoller<T, U>` and `PollerFlux<T, U>` for long-running operations. Methods that start LROs are prefixed with `begin`.
+
+- **Pass**: LRO methods use `SyncPoller` (sync) or `PollerFlux` (async)
+- **Pass**: Method names start with `begin` (e.g., `beginDeleteSecret()`, `beginAnalyze()`)
+- **Fail**: Fire-and-forget calls without waiting for completion (e.g., `deleteSecret()` then immediately recreate)
+- **Fail**: Manual `Thread.sleep()` polling loops instead of using the SDK's poller types
+
+If no LROs exist, mark this check as `"not_applicable"`.
+
+### 8. Async Implementation Quality
+
+Azure SDK for Java uses Project Reactor for async operations. If async code is present:
+
+- **Pass**: Uses Reactor types (`Mono<T>`, `Flux<T>`) from `reactor.core.publisher`
+- **Pass**: Uses async client variants (`BlobAsyncClient`, `CosmosAsyncClient`, `SecretAsyncClient`, etc.)
+- **Pass**: Sync clients internally use sync-over-async (this is the SDK's design, not the user's problem)
+- **Fail**: Uses `CompletableFuture` for Azure SDK async operations (wrong — Azure SDK Java uses Reactor, not `CompletableFuture`)
+- **Fail**: Uses RxJava types (`Observable`, `Single`, `Completable`) — Azure SDK Java uses Reactor, not RxJava
+- **Fail**: Wraps sync client in a thread pool / `ExecutorService` to simulate async
+- **Fail**: Calls `.block()` inside an async service implementation (defeats the purpose of reactive)
+
+If no async code is present, mark this check as `"not_applicable"`.
+
+### 9. Error Handling
+
+Azure SDK for Java has service-specific exception types. Generated code should catch specific exceptions:
+
+| Service | Specific Exception (PASS) | Generic (WEAKER) |
+|---------|--------------------------|-------------------|
+| Storage | `BlobStorageException` | `Exception` |
+| Cosmos DB | `CosmosException` (with status code checks) | `Exception` |
+| Key Vault | `ResourceNotFoundException`, `HttpResponseException` | `Exception` |
+| Service Bus | `ServiceBusException` (with `isTransient()`) | `Exception` |
+| Identity | `CredentialUnavailableException`, `AuthenticationRequiredException` | `Exception` |
+| General | `HttpResponseException` (with status code) | `Exception` or `RuntimeException` |
+
+- **Pass**: Catches service-specific exceptions
+- **Weaker**: Catches only generic `Exception` or `RuntimeException` (not a hard fail, but note it)
+
+### 10. Build Verification
+
+If a build system is present:
+- **pom.xml**: Run `mvn compile` (do NOT run tests)
+- **build.gradle** / **build.gradle.kts**: Run `gradle compileJava`
+- Report whether compilation succeeds or fails with error details
+
+## Process
+
+1. Identify all generated Java source files and build files (pom.xml, build.gradle).
+2. Run each check (1–10) against the generated code.
+3. For each check, record pass/fail/skipped with specific evidence (line numbers, class names, package names).
+4. If build verification is possible, attempt it and record the result.
+5. Produce the structured JSON output.
+
+## Output Format
+
+```json
+{
+  "language": "java",
+  "checks": {
+    "dependencies": {
+      "status": "pass",
+      "details": "Uses com.azure:azure-* packages with com.azure:azure-identity. No com.microsoft.azure found.",
+      "evidence": []
+    },
+    "imports": {
+      "status": "fail",
+      "details": "Found legacy imports from com.microsoft.azure.*",
+      "evidence": ["ServiceClient.java:3 — import com.microsoft.azure.servicebus.QueueClient"]
+    },
+    "authentication": {
+      "status": "pass",
+      "details": "Uses DefaultAzureCredential, reads endpoint from environment variable.",
+      "evidence": []
+    },
+    "client_construction": {
+      "status": "pass",
+      "details": "Uses *ClientBuilder pattern with .endpoint()/.vaultUrl() and .credential()",
+      "evidence": []
+    },
+    "anti_patterns": {
+      "status": "pass",
+      "details": "No deprecated/legacy classes found, Connection string-based authentication not used. Does not use fabricated/hallucinated class names that don't exist in the SDK - `com.microsoft.azure.*` imports",
+      "evidence": []
+    },
+    "pagination": {
+      "status": "pass",
+      "details": "Uses PagedIterable for sync list operations and PagedFlux for async.",
+      "evidence": []
+    },
+    "lro": {
+      "status": "pass",
+      "details": "Uses SyncPoller/PollerFlux for long-running operations with begin* prefix.",
+      "evidence": []
+    },
+    "async_quality": {
+      "status": "pass",
+      "details": "Uses Project Reactor types (`Mono`, `Flux`), does not call `.block()` inside the async implementation",
+      "evidence": []
+    },
+    "error_handling": {
+      "status": "pass",
+      "details": "Catches service-specific exceptions with status code checks, does not use bare `Exception` catches",
+      "evidence": []
+    },
+    "build": {
+      "status": "pass",
+      "details": "mvn compile succeeded.",
+      "evidence": []
+    }
+  },
+  "summary": {
+    "total_checks": 10,
+    "passed": 9,
+    "failed": 1,
+    "skipped": 0,
+    "not_applicable": 0,
+    "critical_failures": ["imports — legacy com.microsoft.azure imports found"]
+  }
+}
+```
+
+## Important Reminders
+
+- This skill validates **Java Azure SDK conventions only**. Do not evaluate general Java code quality, formatting, or style.
+- The `com.azure` vs `com.microsoft.azure` distinction is the single most important check. LLMs frequently generate code using the legacy SDK.
+- `CompletableFuture` is NOT the correct async pattern for Azure SDK Java — it uses Project Reactor (`Mono`/`Flux`).
+- Connection strings work but are the wrong pattern for production. `DefaultAzureCredential` with managed identity is the correct approach.
+- If both sync and async implementations are present, validate each independently.


### PR DESCRIPTION
- Add skills/reviewer/java-sdk-validation/SKILL.md with 10 checks
- Remove common criteria from 8 Java prompt Evaluation Criteria sections
- Add reviewer_skill_directories to all 4 baseline configs
 
 ## Skill Checks (validated against azure-sdk-for-java source + Azure SDK guidelines)
 
 1. Dependencies (`com.azure` vs `com.microsoft.azure`)
 2. Imports (no legacy, no internal packages)
 3. Authentication (`DefaultAzureCredential`, no connection strings)
 4. Client construction (builder pattern)
 5. Deprecated class anti-patterns
 6. Pagination (`PagedIterable`/`PagedFlux` — from SDK guidelines)
 7. LROs (`SyncPoller`/`PollerFlux` with `begin*` prefix — from SDK guidelines)
 8. Async quality (Reactor only, no `CompletableFuture`/RxJava — from SDK guidelines)
 9. Error handling (service-specific exceptions)
 10. Build verification
 
 ## Known Limitation ???
 
 The skill enriches reviewer knowledge but does not add separate scored criteria to the evaluation report. See #30 for the tool change needed.
 need to investigate #30 
