### PR TITLE
Harden agent environment isolation — fix skill leakage and workspace boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ reports/runs/_tmp_eval/
 # Evaluation reports
 reports/
 *.test
+
+# Logs
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ reports/runs/_tmp_eval/
 # Tool evaluation output
 # Evaluation reports
 reports/
+*.test

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -113,18 +113,9 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 
 	sessionCfg := e.buildSessionConfig(cfg, workDir, configDir)
 
-	session, err := client.CreateSession(ctx, sessionCfg)
-	if err != nil {
-		return &EvalResult{
-			Error:        fmt.Sprintf("session creation failed: %v", err),
-			ErrorDetails: err.Error(),
-		}, fmt.Errorf("creating session: %w", err)
-	}
-	// No session.Disconnect() — that sends session.destroy which causes the
-	// CLI to delete generated files from WorkingDirectory. ForceStop above
-	// handles process cleanup without file deletion.
-
-	// Subscribe to events with detailed capture and debug logging
+	// Subscribe to events with detailed capture and debug logging.
+	// This MUST be set before CreateSession — the SDK reads OnEvent during
+	// session creation and won't pick up a callback assigned afterwards.
 	var events []copilot.SessionEvent
 	var sessionRecords []report.SessionEventRecord
 	var mu sync.Mutex
@@ -426,6 +417,17 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 			}
 		}
 	}
+
+	session, err := client.CreateSession(ctx, sessionCfg)
+	if err != nil {
+		return &EvalResult{
+			Error:        fmt.Sprintf("session creation failed: %v", err),
+			ErrorDetails: err.Error(),
+		}, fmt.Errorf("creating session: %w", err)
+	}
+	// No session.Disconnect() — that sends session.destroy which causes the
+	// CLI to delete generated files from WorkingDirectory. ForceStop above
+	// handles process cleanup without file deletion.
 
 	// Send the prompt
 	if e.progressFn != nil {

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -129,7 +129,11 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 	var sessionRecords []report.SessionEventRecord
 	var mu sync.Mutex
 	debugPrefix := p.ID + "/" + cfg.Name
-	unsub := session.On(func(event copilot.SessionEvent) {
+
+	// Capture turn counter for expanded events
+	var turnCounter int
+
+	sessionCfg.OnEvent = func(event copilot.SessionEvent) {
 		mu.Lock()
 		events = append(events, event)
 
@@ -177,6 +181,99 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		if event.Data.Path != nil {
 			rec.FilePath = *event.Data.Path
 		}
+
+		// Expanded event fields
+		switch event.Type {
+		case copilot.SessionEventTypeAssistantTurnStart:
+			turnCounter++
+			rec.TurnNumber = turnCounter
+			log.Printf("[EVENT] Turn %d started", turnCounter)
+		case copilot.SessionEventTypeAssistantTurnEnd:
+			rec.TurnNumber = turnCounter
+			if event.Data.Duration != nil {
+				log.Printf("[EVENT] Turn %d ended (%.0fms)", turnCounter, *event.Data.Duration)
+			}
+		case copilot.SessionEventTypeAssistantReasoning:
+			// Content already captured above
+		case copilot.SessionEventTypeAssistantIntent:
+			if event.Data.Intent != nil {
+				rec.Intent = *event.Data.Intent
+			}
+		case copilot.SessionEventTypeAssistantUsage:
+			if event.Data.InputTokens != nil {
+				rec.InputTokens = int(*event.Data.InputTokens)
+			}
+			if event.Data.OutputTokens != nil {
+				rec.OutputTokens = int(*event.Data.OutputTokens)
+			}
+		case copilot.SessionEventTypeSessionWorkspaceFileChanged:
+			if event.Data.Operation != nil {
+				rec.FileOperation = string(*event.Data.Operation)
+			}
+		case copilot.SessionEventTypeCommandExecute:
+			if event.Data.Command != nil {
+				rec.CommandText = *event.Data.Command
+			}
+		case copilot.SessionEventTypeCommandCompleted:
+			if event.Data.Command != nil {
+				rec.CommandText = *event.Data.Command
+			}
+		case copilot.SessionEventTypeSkillInvoked:
+			if event.Data.Name != nil {
+				rec.SkillName = *event.Data.Name
+			}
+		case copilot.SessionEventTypeExternalToolRequested, copilot.SessionEventTypeExternalToolCompleted:
+			if event.Data.ToolName != nil {
+				rec.ToolName = *event.Data.ToolName
+			}
+		case copilot.SessionEventTypeSessionTruncation:
+			rec.IsTruncation = true
+			log.Printf("[EVENT] ⚠ Context truncated")
+		case copilot.SessionEventTypeSessionCompactionStart:
+			log.Printf("[EVENT] Context compaction started")
+		case copilot.SessionEventTypeSessionCompactionComplete:
+			log.Printf("[EVENT] Context compaction complete")
+		case copilot.SessionEventTypeSessionWarning:
+			if event.Data.Message != nil {
+				rec.WarningText = *event.Data.Message
+				log.Printf("[EVENT] ⚠ Warning: %s", *event.Data.Message)
+			}
+		case copilot.SessionEventTypeAbort:
+			log.Printf("[EVENT] ✗ Session aborted")
+		case copilot.SessionEventTypePermissionRequested:
+			// Audit trail
+		case copilot.SessionEventTypePermissionCompleted:
+			// Audit trail
+		case copilot.SessionEventTypeSessionSkillsLoaded:
+			if len(event.Data.Skills) > 0 {
+				names := make([]string, 0, len(event.Data.Skills))
+				for _, s := range event.Data.Skills {
+					names = append(names, s.Name)
+				}
+				rec.Content = strings.Join(names, ", ")
+				log.Printf("[EVENT] Skills loaded: %s", rec.Content)
+			}
+		case copilot.SessionEventTypeSessionMcpServersLoaded:
+			if len(event.Data.Servers) > 0 {
+				names := make([]string, 0, len(event.Data.Servers))
+				for _, s := range event.Data.Servers {
+					names = append(names, s.Name)
+				}
+				rec.Content = strings.Join(names, ", ")
+				log.Printf("[EVENT] MCP servers loaded: %s", rec.Content)
+			}
+		case copilot.SessionEventTypeSessionToolsUpdated:
+			log.Printf("[EVENT] Tools updated")
+		case copilot.SessionEventTypeSubagentCompleted:
+			if event.Data.ToolCallID != nil {
+				rec.SubagentID = *event.Data.ToolCallID
+			}
+		case copilot.SessionEventTypeSubagentFailed:
+			if event.Data.ToolCallID != nil {
+				rec.SubagentID = *event.Data.ToolCallID
+			}
+		}
+
 		sessionRecords = append(sessionRecords, rec)
 		mu.Unlock()
 
@@ -239,6 +336,18 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 						Message: summary,
 					})
 				}
+			case copilot.SessionEventTypeAssistantTurnStart:
+				e.progressFn(progress.ProgressEvent{
+					EvalID: evalID, PromptID: p.ID, ConfigName: cfg.Name,
+					Type:    progress.EventReasoning,
+					Message: fmt.Sprintf("Turn %d started", turnCounter),
+				})
+			case copilot.SessionEventTypeSessionTruncation:
+				e.progressFn(progress.ProgressEvent{
+					EvalID: evalID, PromptID: p.ID, ConfigName: cfg.Name,
+					Type:    progress.EventReasoning,
+					Message: "⚠ Context truncated",
+				})
 			}
 		}
 
@@ -280,8 +389,31 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 					content = *event.Data.Content
 				}
 				log.Printf("[DEBUG] %s: ✗ Session error: %s", debugPrefix, content)
+			case copilot.SessionEventTypeAssistantTurnStart:
+				log.Printf("[DEBUG] %s: ▶ Turn %d started", debugPrefix, turnCounter)
+			case copilot.SessionEventTypeAssistantTurnEnd:
+				log.Printf("[DEBUG] %s: ◼ Turn %d ended", debugPrefix, turnCounter)
+			case copilot.SessionEventTypeAssistantUsage:
+				in, out := 0, 0
+				if event.Data.InputTokens != nil {
+					in = int(*event.Data.InputTokens)
+				}
+				if event.Data.OutputTokens != nil {
+					out = int(*event.Data.OutputTokens)
+				}
+				log.Printf("[DEBUG] %s: 📊 Tokens: in=%d out=%d", debugPrefix, in, out)
+			case copilot.SessionEventTypeSessionTruncation:
+				log.Printf("[DEBUG] %s: ⚠ Context truncated", debugPrefix)
+			case copilot.SessionEventTypeSkillInvoked:
+				name := ""
+				if event.Data.Name != nil {
+					name = *event.Data.Name
+				}
+				log.Printf("[DEBUG] %s: 🔮 Skill invoked: %s", debugPrefix, name)
+			case copilot.SessionEventTypeSubagentCompleted, copilot.SessionEventTypeSubagentFailed:
+				log.Printf("[DEBUG] %s:   Subagent %s", debugPrefix, event.Type)
 			default:
-				// Log all other events (session.start, session.idle, user.message, assistant.turn_end, etc.)
+				// Log all other events (session.start, session.idle, user.message, etc.)
 				content := ""
 				if event.Data.Content != nil {
 					content = truncateStr(*event.Data.Content, 100)
@@ -293,8 +425,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 				}
 			}
 		}
-	})
-	defer unsub()
+	}
 
 	// Send the prompt
 	if e.progressFn != nil {
@@ -457,6 +588,49 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Hooks: &copilot.SessionHooks{
+			OnPreToolUse: func(input copilot.PreToolUseHookInput, invocation copilot.HookInvocation) (*copilot.PreToolUseHookOutput, error) {
+				toolName := input.ToolName
+				// Validate file paths for file-write tools
+				if isFileWriteTool(toolName) {
+					if args, ok := input.ToolArgs.(map[string]interface{}); ok {
+						if p, ok := args["path"].(string); ok {
+							if !strings.HasPrefix(p, workDir) {
+								log.Printf("[HOOK] ⚠ %s path outside workspace: %s (expected prefix: %s)", toolName, p, workDir)
+								return &copilot.PreToolUseHookOutput{
+									PermissionDecision:       "deny",
+									PermissionDecisionReason: fmt.Sprintf("path %q is outside workspace %q", p, workDir),
+								}, nil
+							}
+						}
+					}
+				}
+				// Log bash/command tools
+				if toolName == "bash" || toolName == "shell" || toolName == "run_command" {
+					if args, ok := input.ToolArgs.(map[string]interface{}); ok {
+						if cmd, ok := args["command"].(string); ok {
+							log.Printf("[HOOK] 🖥 %s: %s", toolName, truncateStr(cmd, 120))
+						}
+					}
+				}
+				return &copilot.PreToolUseHookOutput{}, nil
+			},
+			OnPostToolUse: func(input copilot.PostToolUseHookInput, invocation copilot.HookInvocation) (*copilot.PostToolUseHookOutput, error) {
+				// Log completion
+				log.Printf("[HOOK] ✓ %s complete", input.ToolName)
+				// Check file sizes for file operations
+				if isFileWriteTool(input.ToolName) {
+					if args, ok := input.ToolArgs.(map[string]interface{}); ok {
+						if p, ok := args["path"].(string); ok {
+							if info, err := os.Stat(p); err == nil && info.Size() > 100*1024 {
+								log.Printf("[HOOK] ⚠ Large file created: %s (%d bytes)", p, info.Size())
+							}
+						}
+					}
+				}
+				return &copilot.PostToolUseHookOutput{}, nil
+			},
+		},
 		SkillDirectories:    skillDirs,
 	}
 

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -101,7 +102,16 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 	}()
 
 	// Build session config from tool config
-	sessionCfg := e.buildSessionConfig(cfg, workDir)
+	// Create isolated config directory to prevent user-level skills from
+	// leaking into the eval session (#21). Only skills explicitly listed
+	// in the eval config's SkillDirectories are loaded.
+	configDir, err := NewIsolatedConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("creating isolated config dir: %w", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	sessionCfg := e.buildSessionConfig(cfg, workDir, configDir)
 
 	session, err := client.CreateSession(ctx, sessionCfg)
 	if err != nil {
@@ -398,7 +408,7 @@ func (e *CopilotSDKEvaluator) Client(ctx context.Context, workDir string) (*copi
 	return client, nil
 }
 
-func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir string) *copilot.SessionConfig {
+func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir string, configDir string) *copilot.SessionConfig {
 	// Use generator-specific skills if configured, otherwise fall back to shared
 	skillDirs := cfg.GeneratorSkillDirectories
 	if len(skillDirs) == 0 {
@@ -444,6 +454,7 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 			Mode:    "append",
 			Content: systemMsg,
 		},
+		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    skillDirs,

--- a/hyoka/internal/eval/copilot_test.go
+++ b/hyoka/internal/eval/copilot_test.go
@@ -17,7 +17,7 @@ func TestBuildSessionConfig_EmptyAvailableToolsIsNil(t *testing.T) {
 		AvailableTools: []string{},
 		ExcludedTools:  []string{},
 	}
-	sc := e.buildSessionConfig(cfg, "/tmp/test")
+	sc := e.buildSessionConfig(cfg, "/tmp/test", "")
 
 	if sc.AvailableTools != nil {
 		t.Errorf("expected AvailableTools nil (all tools), got %v", sc.AvailableTools)
@@ -34,7 +34,7 @@ func TestBuildSessionConfig_NilAvailableToolsIsNil(t *testing.T) {
 		Name:  "test",
 		Model: "gpt-4",
 	}
-	sc := e.buildSessionConfig(cfg, "/tmp/test")
+	sc := e.buildSessionConfig(cfg, "/tmp/test", "")
 
 	if sc.AvailableTools != nil {
 		t.Errorf("expected AvailableTools nil, got %v", sc.AvailableTools)
@@ -53,7 +53,7 @@ func TestBuildSessionConfig_PopulatedAvailableToolsPreserved(t *testing.T) {
 		AvailableTools: []string{"create", "edit", "bash"},
 		ExcludedTools:  []string{"web_fetch"},
 	}
-	sc := e.buildSessionConfig(cfg, "/tmp/test")
+	sc := e.buildSessionConfig(cfg, "/tmp/test", "")
 
 	if len(sc.AvailableTools) != 3 {
 		t.Errorf("expected 3 AvailableTools, got %d", len(sc.AvailableTools))
@@ -67,10 +67,21 @@ func TestBuildSessionConfig_WorkingDirectory(t *testing.T) {
 	e := &CopilotSDKEvaluator{}
 
 	cfg := &config.ToolConfig{Name: "test", Model: "gpt-4"}
-	sc := e.buildSessionConfig(cfg, "/workspace/eval-123")
+	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "")
 
 	if sc.WorkingDirectory != "/workspace/eval-123" {
 		t.Errorf("expected WorkingDirectory '/workspace/eval-123', got %q", sc.WorkingDirectory)
+	}
+}
+
+func TestBuildSessionConfig_ConfigDir(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+
+	cfg := &config.ToolConfig{Name: "test", Model: "gpt-4"}
+	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "/isolated/config")
+
+	if sc.ConfigDir != "/isolated/config" {
+		t.Errorf("expected ConfigDir '/isolated/config', got %q", sc.ConfigDir)
 	}
 }
 
@@ -78,7 +89,7 @@ func TestBuildSessionConfig_PermissionHandler(t *testing.T) {
 	e := &CopilotSDKEvaluator{}
 
 	cfg := &config.ToolConfig{Name: "test", Model: "gpt-4"}
-	sc := e.buildSessionConfig(cfg, "/tmp/test")
+	sc := e.buildSessionConfig(cfg, "/tmp/test", "")
 
 	if sc.OnPermissionRequest == nil {
 		t.Error("expected OnPermissionRequest to be set (ApproveAll)")
@@ -99,7 +110,7 @@ func TestBuildSessionConfig_MCPServers(t *testing.T) {
 			},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/tmp/test")
+	sc := e.buildSessionConfig(cfg, "/tmp/test", "")
 
 	if len(sc.MCPServers) != 1 {
 		t.Errorf("expected 1 MCP server, got %d", len(sc.MCPServers))

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -418,8 +418,22 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		return evalReport
 	}
 
+	// Create an isolated temporary workspace for the generator (#26).
+	// The agent writes files here — not directly to the report tree.
+	// After generation, files are copied to the persistent report directory.
+	genDir, err := os.MkdirTemp("", "hyoka-gen-*")
+	if err != nil {
+		evalReport.Error = fmt.Sprintf("generator workspace setup failed: %v", err)
+		evalReport.ErrorDetails = err.Error()
+		evalReport.ErrorCategory = "generation_failure"
+		evalReport.FailureReason = fmt.Sprintf("Could not create isolated generator workspace: %v", err)
+		evalReport.Duration = time.Since(start).Seconds()
+		return evalReport
+	}
+	defer os.RemoveAll(genDir)
+
 	if e.opts.Debug {
-		log.Printf("[DEBUG] %s: Workspace: %s", debugPrefix, ws.Dir)
+		log.Printf("[DEBUG] %s: Workspace: %s (gen: %s)", debugPrefix, ws.Dir, genDir)
 	}
 
 	// Snapshot home directory and CWD before eval so we can recover misplaced files after
@@ -437,7 +451,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 
 	// Run evaluation (generation phase — uses its own timeout)
 	sendPhase(progress.PhaseGenerating)
-	result, err := e.evaluator.Evaluate(genCtx, task.Prompt, &task.Config, ws.Dir)
+	result, err := e.evaluator.Evaluate(genCtx, task.Prompt, &task.Config, genDir)
 	genCancel() // release generation timeout immediately
 	evalFailed := err != nil
 	if evalFailed {
@@ -476,17 +490,29 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// First, recover any files the agent wrote to the home directory instead of the workspace.
 	// The Copilot CLI sometimes creates files in ~ when the agent omits the path parameter.
 	if homeDir != "" && preEvalHomeFiles != nil {
-		recovered := recoverMisplacedFiles(homeDir, preEvalHomeFiles, ws.Dir, debugPrefix, e.opts.Debug)
+		recovered := recoverMisplacedFiles(homeDir, preEvalHomeFiles, genDir, debugPrefix, e.opts.Debug)
 		if recovered > 0 {
 			log.Printf("%s: Recovered %d misplaced files from home dir to workspace", debugPrefix, recovered)
+		}
+		// Post-recovery validation: flag anything recovery couldn't handle (#26)
+		if remaining := ValidateWorkspaceContainment(homeDir, preEvalHomeFiles); len(remaining) > 0 {
+			log.Printf("WARNING %s: %d items still outside workspace after recovery (home): %v", debugPrefix, len(remaining), remaining)
 		}
 	}
 	// Also recover from CWD
 	if cwdDir != "" && preEvalCwdFiles != nil {
-		recovered := recoverMisplacedFiles(cwdDir, preEvalCwdFiles, ws.Dir, debugPrefix, e.opts.Debug)
+		recovered := recoverMisplacedFiles(cwdDir, preEvalCwdFiles, genDir, debugPrefix, e.opts.Debug)
 		if recovered > 0 {
 			log.Printf("%s: Recovered %d misplaced files from CWD to workspace", debugPrefix, recovered)
 		}
+		if remaining := ValidateWorkspaceContainment(cwdDir, preEvalCwdFiles); len(remaining) > 0 {
+			log.Printf("WARNING %s: %d items still outside workspace after recovery (CWD): %v", debugPrefix, len(remaining), remaining)
+		}
+	}
+
+	// Copy generated files from isolated workspace to persistent report directory (#26)
+	if err := copyDir(genDir, ws.Dir); err != nil {
+		log.Printf("WARNING %s: failed to copy generated files to report dir: %v", debugPrefix, err)
 	}
 
 	generatedFiles, _ := ws.ListFiles()
@@ -637,6 +663,18 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Uses its own independent timeout context (fixes issue #3).
 	if !e.opts.SkipReview && len(generatedFiles) > 0 {
 		sendPhase(progress.PhaseReviewing)
+
+		// Create an isolated reviewer workspace with a copy of the generated
+		// files. Reviewers operate on this copy and cannot modify the original
+		// output in the report directory (#26).
+		reviewWorkDir, err := NewReviewerWorkspace(ws.Dir)
+		if err != nil {
+			log.Printf("WARNING %s: reviewer workspace creation failed, using original: %v", debugPrefix, err)
+			reviewWorkDir = ws.Dir
+		} else {
+			defer os.RemoveAll(reviewWorkDir)
+		}
+
 		reviewCtx, reviewCancel := context.WithTimeout(ctx, e.opts.ReviewTimeout)
 		referenceDir := ""
 		if task.Prompt.ReferenceAnswer != "" {
@@ -647,7 +685,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			if e.opts.Debug {
 				log.Printf("[DEBUG] %s: Starting review panel...", debugPrefix)
 			}
-			panel, consolidated, err := e.panelReviewer.ReviewPanel(reviewCtx, task.Prompt.PromptText, ws.Dir, referenceDir, task.Prompt.EvaluationCriteria)
+			panel, consolidated, err := e.panelReviewer.ReviewPanel(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria)
 			if err != nil {
 				if e.opts.Debug {
 					log.Printf("[DEBUG] %s: ERROR: review panel failed: %v", debugPrefix, err)
@@ -668,7 +706,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			if e.opts.Debug {
 				log.Printf("[DEBUG] %s: Starting single review session...", debugPrefix)
 			}
-			reviewResult, err := e.reviewer.Review(reviewCtx, task.Prompt.PromptText, ws.Dir, referenceDir, task.Prompt.EvaluationCriteria)
+			reviewResult, err := e.reviewer.Review(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria)
 			if err != nil {
 				if e.opts.Debug {
 					log.Printf("[DEBUG] %s: ERROR: code review failed: %v", debugPrefix, err)
@@ -685,8 +723,8 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			}
 		}
 
-		// Capture reviewed (annotated) files
-		reviewedFiles, err := readReviewedFiles(ws.Dir)
+		// Capture reviewed (annotated) files from the reviewer workspace
+		reviewedFiles, err := readReviewedFiles(reviewWorkDir)
 		if err == nil && len(reviewedFiles) > 0 {
 			evalReport.ReviewedFiles = reviewedFiles
 			if e.opts.Debug {

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -557,6 +557,42 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// the time the generator agent took, not the additional review time.
 	evalReport.Duration = time.Since(start).Seconds()
 
+	// Populate environment info from config and captured events
+	env := &report.EnvironmentInfo{
+		Model:            task.Config.EffectiveModel(),
+		SkillDirectories: task.Config.SkillDirectories,
+		AvailableTools:   task.Config.EffectiveAvailableTools(),
+		ExcludedTools:    task.Config.EffectiveExcludedTools(),
+		SafetyBoundaries: true,
+		AllowCloud:       false,
+		WorkingDirectory: ws.Dir,
+	}
+	// Extract MCP server names
+	for name := range task.Config.EffectiveMCPServers() {
+		env.MCPServers = append(env.MCPServers, name)
+	}
+	// Derive token usage, turn count, truncation, skills from events
+	for _, ev := range evalReport.SessionEvents {
+		switch ev.Type {
+		case "assistant.usage":
+			env.TotalInputTokens += ev.InputTokens
+			env.TotalOutputTokens += ev.OutputTokens
+		case "assistant.turn_start":
+			env.TurnCount++
+		case "session.truncation":
+			env.ContextTruncated = true
+		case "skill.invoked":
+			if ev.SkillName != "" {
+				env.SkillsInvoked = append(env.SkillsInvoked, ev.SkillName)
+			}
+		case "session.skills_loaded":
+			if ev.Content != "" {
+				env.SkillsLoaded = strings.Split(ev.Content, ", ")
+			}
+		}
+	}
+	evalReport.Environment = env
+
 	// Generator guardrail checks (#35)
 	if !evalFailed {
 		// Check turn count (count assistant turn-end events as turns)

--- a/hyoka/internal/eval/workspace.go
+++ b/hyoka/internal/eval/workspace.go
@@ -142,6 +142,60 @@ func copyDir(src, dst string) error {
 	})
 }
 
+// NewIsolatedConfigDir creates an empty temporary directory to serve as the
+// Copilot CLI configuration directory. By pointing ConfigDir at this empty
+// directory, user-level skills and settings from ~/.config/github-copilot/
+// are excluded from eval sessions. Only skills explicitly listed in the eval
+// config's SkillDirectories are loaded (fixes #21).
+// The caller must defer os.RemoveAll on the returned path.
+func NewIsolatedConfigDir() (string, error) {
+	dir, err := os.MkdirTemp("", "hyoka-config-*")
+	if err != nil {
+		return "", fmt.Errorf("creating isolated config dir: %w", err)
+	}
+	return dir, nil
+}
+
+// NewReviewerWorkspace creates an ephemeral temporary workspace and copies
+// all files from sourceDir into it. Reviewers operate on this copy so they
+// cannot modify the original generated output (fixes #26).
+// The caller must defer os.RemoveAll on the returned path.
+func NewReviewerWorkspace(sourceDir string) (string, error) {
+	dir, err := os.MkdirTemp("", "hyoka-review-*")
+	if err != nil {
+		return "", fmt.Errorf("creating reviewer workspace: %w", err)
+	}
+	if err := copyDir(sourceDir, dir); err != nil {
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("copying files to reviewer workspace: %w", err)
+	}
+	return dir, nil
+}
+
+// ValidateWorkspaceContainment checks whether any new items appeared in dir
+// since the pre-eval snapshot. Returns the names of items that escaped the
+// workspace boundary. Called after recoverMisplacedFiles as a safety net
+// to catch anything recovery could not handle (fixes #26).
+func ValidateWorkspaceContainment(dir string, preSnapshot map[string]bool) []string {
+	if preSnapshot == nil {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var escaped []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if !preSnapshot[e.Name()] {
+			escaped = append(escaped, e.Name())
+		}
+	}
+	return escaped
+}
+
 // codeFileExts lists extensions that indicate generated code files.
 var codeFileExts = map[string]bool{
 	".py": true, ".cs": true, ".java": true, ".go": true, ".rs": true,

--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -19,7 +19,7 @@ var (
 func WriteHTMLReport(r *EvalReport, outputDir string, runID string, service, plane, language, category string) (string, error) {
 	reportDir := filepath.Join(
 		outputDir, runID, "results",
-		service, plane, language, category, r.ConfigName,
+		service, plane, language, category, r.PromptID, r.ConfigName,
 	)
 	if err := os.MkdirAll(reportDir, 0755); err != nil {
 		return "", fmt.Errorf("creating HTML report directory: %w", err)
@@ -35,7 +35,13 @@ func WriteHTMLReport(r *EvalReport, outputDir string, runID string, service, pla
 
 	data := buildReportData(r)
 
-	// Read file contents from the generated-code directory for expandable display (Issue 3)
+	// Compute back-to-summary link dynamically: count path segments from
+	// runID dir to reportDir. ConfigName may contain '/' (e.g. "azure-mcp/claude-opus-4.6").
+	// Segments: results/service/plane/language/category/promptID + configName parts.
+	depth := 7 + strings.Count(r.ConfigName, "/")
+	data.BackPath = strings.Repeat("../", depth) + "summary.html"
+
+	// Read file contents from the generated-code directory for expandable display
 	codeDir := filepath.Join(reportDir, "generated-code")
 	data.FileContents = readFileContents(codeDir, r.GeneratedFiles, r.StarterFiles)
 
@@ -153,7 +159,7 @@ func buildMatrix(s *RunSummary) *MatrixData {
 		language, _ := r.PromptMeta["language"].(string)
 		category, _ := r.PromptMeta["category"].(string)
 		if service != "" && plane != "" && language != "" && category != "" {
-			cell.ReportLink = filepath.Join("results", service, plane, language, category, r.ConfigName, "report.html")
+			cell.ReportLink = filepath.Join("results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html")
 		}
 		m.Cells[r.PromptID][r.ConfigName] = cell
 	}
@@ -171,6 +177,7 @@ type ReportTemplateData struct {
 	TimelineSteps []TimelineStep
 	FileCount     int
 	FileContents  map[string]string // filename → content for expandable display
+	BackPath      string            // relative path from report.html back to summary.html
 }
 
 // ToolAction represents one tool invocation extracted from session events.
@@ -513,7 +520,7 @@ func htmlFuncMap() template.FuncMap {
 			if service == "" || plane == "" || language == "" || category == "" {
 				return ""
 			}
-			return filepath.Join("results", service, plane, language, category, r.ConfigName, "report.html")
+			return filepath.Join("results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html")
 		},
 	}
 }
@@ -656,7 +663,7 @@ const reportTemplate = `<!DOCTYPE html>
 </head>
 <body>
 
-<div class="nav"><a href="../../../../../../summary.html">← Back to Summary</a></div>
+<div class="nav"><a href="{{.BackPath}}">← Back to Summary</a></div>
 
 <div class="report-header">
   <h1>📋 {{.PromptID}}</h1>
@@ -1019,7 +1026,10 @@ const reportTemplate = `<!DOCTYPE html>
   <div class="section-header"><span class="icon">🔄</span><h2>Re-run Command</h2></div>
   <div class="section-body">
     <p style="font-size:0.85rem;color:var(--text-muted)">Copy and paste this command to reproduce this evaluation:</p>
-    <pre>{{.RerunCommand}}</pre>
+    <div style="position:relative">
+      <pre id="rerun-cmd">{{.RerunCommand}}</pre>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('rerun-cmd').textContent).then(()=>{this.textContent='✅ Copied!';setTimeout(()=>{this.textContent='📋 Copy'},2000)})" style="position:absolute;top:8px;right:8px;padding:4px 12px;background:var(--accent,var(--blue));color:white;border:none;border-radius:4px;cursor:pointer;font-size:0.8rem">📋 Copy</button>
+    </div>
   </div>
 </div>
 {{end}}

--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -706,6 +706,27 @@ const reportTemplate = `<!DOCTYPE html>
 </div>
 {{end}}
 
+{{if .Environment}}
+<div class="section">
+  <div class="section-header"><span class="icon">🔧</span><h2>Environment & Configuration</h2></div>
+  <div class="section-body">
+  <table class="meta-table">
+    <tr><td>Model</td><td>{{.Environment.Model}}</td></tr>
+    {{if .Environment.SkillsLoaded}}<tr><td>Skills Loaded</td><td>{{join .Environment.SkillsLoaded ", "}}</td></tr>{{end}}
+    {{if .Environment.SkillsInvoked}}<tr><td>Skills Invoked</td><td>{{join .Environment.SkillsInvoked ", "}}</td></tr>{{end}}
+    {{if .Environment.AvailableTools}}<tr><td>Available Tools</td><td>{{join .Environment.AvailableTools ", "}}</td></tr>{{end}}
+    {{if .Environment.ExcludedTools}}<tr><td>Excluded Tools</td><td>{{join .Environment.ExcludedTools ", "}}</td></tr>{{end}}
+    {{if .Environment.MCPServers}}<tr><td>MCP Servers</td><td>{{join .Environment.MCPServers ", "}}</td></tr>{{end}}
+    <tr><td>Safety Boundaries</td><td>{{if .Environment.SafetyBoundaries}}✅ Active{{else}}❌ Off{{end}}</td></tr>
+    <tr><td>Cloud Access</td><td>{{if .Environment.AllowCloud}}✅ Allowed{{else}}❌ Denied{{end}}</td></tr>
+    {{if or .Environment.TotalInputTokens .Environment.TotalOutputTokens}}<tr><td>Token Usage</td><td>in={{.Environment.TotalInputTokens}} out={{.Environment.TotalOutputTokens}}</td></tr>{{end}}
+    {{if .Environment.TurnCount}}<tr><td>Turn Count</td><td>{{.Environment.TurnCount}}</td></tr>{{end}}
+    {{if .Environment.ContextTruncated}}<tr><td>Context Truncated</td><td>⚠️ Yes</td></tr>{{end}}
+  </table>
+  </div>
+</div>
+{{end}}
+
 <!-- ━━ Generation Timeline ━━ -->
 {{if .TimelineSteps}}
 <div class="phase phase-gen">

--- a/hyoka/internal/report/html_test.go
+++ b/hyoka/internal/report/html_test.go
@@ -93,7 +93,7 @@ func TestWriteHTMLReport(t *testing.T) {
 		}
 	}
 
-	expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "baseline")
+	expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "test-prompt", "baseline")
 	if _, err := os.Stat(expectedDir); err != nil {
 		t.Errorf("expected directory %s to exist", expectedDir)
 	}

--- a/hyoka/internal/report/markdown.go
+++ b/hyoka/internal/report/markdown.go
@@ -12,7 +12,7 @@ import (
 func WriteMarkdownReport(r *EvalReport, outputDir string, runID string, service, plane, language, category string) (string, error) {
 	reportDir := filepath.Join(
 		outputDir, runID, "results",
-		service, plane, language, category, r.ConfigName,
+		service, plane, language, category, r.PromptID, r.ConfigName,
 	)
 	if err := os.MkdirAll(reportDir, 0755); err != nil {
 		return "", fmt.Errorf("creating markdown report directory: %w", err)

--- a/hyoka/internal/report/markdown.go
+++ b/hyoka/internal/report/markdown.go
@@ -60,6 +60,53 @@ func WriteMarkdownReport(r *EvalReport, outputDir string, runID string, service,
 		b.WriteString("\n")
 	}
 
+	// Environment & Configuration
+	if r.Environment != nil {
+		env := r.Environment
+		b.WriteString("## Environment & Configuration\n\n")
+		b.WriteString("| Setting | Value |\n")
+		b.WriteString("|---------|-------|\n")
+		fmt.Fprintf(&b, "| Model | %s |\n", env.Model)
+		if len(env.SkillDirectories) > 0 {
+			fmt.Fprintf(&b, "| Skill Directories | %s |\n", strings.Join(env.SkillDirectories, ", "))
+		}
+		if len(env.SkillsLoaded) > 0 {
+			fmt.Fprintf(&b, "| Skills Loaded | %s |\n", strings.Join(env.SkillsLoaded, ", "))
+		}
+		if len(env.SkillsInvoked) > 0 {
+			fmt.Fprintf(&b, "| Skills Invoked | %s |\n", strings.Join(env.SkillsInvoked, ", "))
+		}
+		if len(env.AvailableTools) > 0 {
+			fmt.Fprintf(&b, "| Available Tools | %s |\n", strings.Join(env.AvailableTools, ", "))
+		}
+		if len(env.ExcludedTools) > 0 {
+			fmt.Fprintf(&b, "| Excluded Tools | %s |\n", strings.Join(env.ExcludedTools, ", "))
+		}
+		if len(env.MCPServers) > 0 {
+			fmt.Fprintf(&b, "| MCP Servers | %s |\n", strings.Join(env.MCPServers, ", "))
+		}
+		safetyStr := "❌ Off"
+		if env.SafetyBoundaries {
+			safetyStr = "✅ Active"
+		}
+		fmt.Fprintf(&b, "| Safety Boundaries | %s |\n", safetyStr)
+		cloudStr := "❌ Denied"
+		if env.AllowCloud {
+			cloudStr = "✅ Allowed"
+		}
+		fmt.Fprintf(&b, "| Cloud Access | %s |\n", cloudStr)
+		if env.TotalInputTokens > 0 || env.TotalOutputTokens > 0 {
+			fmt.Fprintf(&b, "| Token Usage | in=%d out=%d |\n", env.TotalInputTokens, env.TotalOutputTokens)
+		}
+		if env.TurnCount > 0 {
+			fmt.Fprintf(&b, "| Turn Count | %d |\n", env.TurnCount)
+		}
+		if env.ContextTruncated {
+			b.WriteString("| Context Truncated | ⚠️ Yes |\n")
+		}
+		b.WriteString("\n")
+	}
+
 	// Error (if failed)
 	if r.Error != "" {
 		b.WriteString("## Error\n\n")

--- a/hyoka/internal/report/markdown_test.go
+++ b/hyoka/internal/report/markdown_test.go
@@ -100,7 +100,7 @@ func TestWriteMarkdownReport(t *testing.T) {
 		}
 	}
 
-	expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "baseline")
+	expectedDir := filepath.Join(dir, "20240115-100000", "results", "storage", "data-plane", "dotnet", "authentication", "test-prompt", "baseline")
 	if _, err := os.Stat(expectedDir); err != nil {
 		t.Errorf("expected directory %s to exist", expectedDir)
 	}

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -19,6 +19,18 @@ type SessionEventRecord struct {
 	MCPServerName string  `json:"mcp_server_name,omitempty"`
 	MCPToolName   string  `json:"mcp_tool_name,omitempty"`
 	FilePath      string  `json:"file_path,omitempty"`
+	// Expanded event fields
+	TurnNumber    int    `json:"turnNumber,omitempty"`
+	InputTokens   int    `json:"inputTokens,omitempty"`
+	OutputTokens  int    `json:"outputTokens,omitempty"`
+	SkillName     string `json:"skillName,omitempty"`
+	CommandText   string `json:"commandText,omitempty"`
+	FileOperation string `json:"fileOperation,omitempty"`
+	FileSize      int64  `json:"fileSize,omitempty"`
+	SubagentID    string `json:"subagentId,omitempty"`
+	IsTruncation  bool   `json:"isTruncation,omitempty"`
+	Intent        string `json:"intent,omitempty"`
+	WarningText   string `json:"warningText,omitempty"`
 }
 
 // VerifyResult holds the outcome of Copilot-based code verification.
@@ -44,6 +56,24 @@ type ReviewedFile struct {
 	Content string `json:"content"`
 }
 
+// EnvironmentInfo captures session environment and configuration metadata.
+type EnvironmentInfo struct {
+	Model              string   `json:"model"`
+	SkillDirectories   []string `json:"skillDirectories,omitempty"`
+	SkillsInvoked      []string `json:"skillsInvoked,omitempty"`
+	SkillsLoaded       []string `json:"skillsLoaded,omitempty"`
+	AvailableTools     []string `json:"availableTools,omitempty"`
+	ExcludedTools      []string `json:"excludedTools,omitempty"`
+	MCPServers         []string `json:"mcpServers,omitempty"`
+	SafetyBoundaries   bool     `json:"safetyBoundaries"`
+	AllowCloud         bool     `json:"allowCloud"`
+	WorkingDirectory   string   `json:"workingDirectory"`
+	TotalInputTokens   int      `json:"totalInputTokens,omitempty"`
+	TotalOutputTokens  int      `json:"totalOutputTokens,omitempty"`
+	TurnCount          int      `json:"turnCount,omitempty"`
+	ContextTruncated   bool     `json:"contextTruncated,omitempty"`
+}
+
 // EvalReport contains the results of a single prompt evaluation.
 type EvalReport struct {
 	PromptID       string               `json:"prompt_id"`
@@ -63,6 +93,7 @@ type EvalReport struct {
 	SessionEvents  []SessionEventRecord `json:"session_events,omitempty"`
 	EventCount     int                  `json:"event_count"`
 	ToolCalls      []string             `json:"tool_calls"`
+	Environment    *EnvironmentInfo     `json:"environment,omitempty"`
 	Success        bool                 `json:"success"`
 	Error          string               `json:"error,omitempty"`
 	ErrorDetails   string               `json:"error_details,omitempty"`

--- a/hyoka/internal/rerender/rerender_test.go
+++ b/hyoka/internal/rerender/rerender_test.go
@@ -42,14 +42,14 @@ func TestRerenderRun(t *testing.T) {
 		t.Fatalf("rerender failed: %v", err)
 	}
 
-	// Check HTML report was generated
-	htmlPath := filepath.Join(reportDir, "report.html")
+	// Check HTML report was generated (now includes promptID in path)
+	htmlPath := filepath.Join(dir, runID, "results", "storage", "data-plane", "go", "auth", "test-prompt", "baseline", "report.html")
 	if _, err := os.Stat(htmlPath); os.IsNotExist(err) {
 		t.Error("expected report.html to exist")
 	}
 
 	// Check MD report was generated
-	mdPath := filepath.Join(reportDir, "report.md")
+	mdPath := filepath.Join(dir, runID, "results", "storage", "data-plane", "go", "auth", "test-prompt", "baseline", "report.md")
 	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
 		t.Error("expected report.md to exist")
 	}

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -68,36 +68,12 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 	}
 	defer os.RemoveAll(configDir)
 
-	session, err := r.client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: r.model,
-		SystemMessage: &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
-		},
-		ConfigDir:           configDir,
-		WorkingDirectory:    workDir,
-		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-		SkillDirectories:    r.skillDirectories,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating review session: %w", err)
-	}
-	// SDK's Disconnect() can block if the CLI subprocess is stuck.
-	// Timeout and let the owning client's Stop handle final cleanup.
-	defer func() {
-		done := make(chan struct{})
-		go func() { session.Disconnect(); close(done) }()
-		select {
-		case <-done:
-		case <-time.After(15 * time.Second):
-		}
-	}()
-
 	// Capture the assistant's response and all session events
 	var assistantContent strings.Builder
 	var reviewEvents []ReviewEvent
 	var mu sync.Mutex
-	unsub := session.On(func(event copilot.SessionEvent) {
+
+	eventHandler := func(event copilot.SessionEvent) {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -134,8 +110,33 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 			evt.Duration = *event.Data.Duration
 		}
 		reviewEvents = append(reviewEvents, evt)
+	}
+
+	session, err := r.client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: r.model,
+		SystemMessage: &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
+		},
+		ConfigDir:           configDir,
+		WorkingDirectory:    workDir,
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		SkillDirectories:    r.skillDirectories,
+		OnEvent:             eventHandler,
 	})
-	defer unsub()
+	if err != nil {
+		return nil, fmt.Errorf("creating review session: %w", err)
+	}
+	// SDK's Disconnect() can block if the CLI subprocess is stuck.
+	// Timeout and let the owning client's Stop handle final cleanup.
+	defer func() {
+		done := make(chan struct{})
+		go func() { session.Disconnect(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+		}
+	}()
 
 	_, err = session.SendAndWait(ctx, copilot.MessageOptions{
 		Prompt: reviewPrompt,
@@ -339,25 +340,11 @@ func (p *PanelReviewer) runSingleReview(ctx context.Context, model string, revie
 	}
 	defer os.RemoveAll(configDir)
 
-	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: model,
-		SystemMessage: &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
-		},
-		ConfigDir:           configDir,
-		WorkingDirectory:    workDir,
-		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-		SkillDirectories:    p.skillDirectories,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating review session for %s: %w", model, err)
-	}
-
 	var assistantContent strings.Builder
 	var reviewEvents []ReviewEvent
 	var mu sync.Mutex
-	unsub := session.On(func(event copilot.SessionEvent) {
+
+	eventHandler := func(event copilot.SessionEvent) {
 		mu.Lock()
 		defer mu.Unlock()
 		if event.Type == copilot.SessionEventTypeAssistantMessage && event.Data.Content != nil {
@@ -392,8 +379,23 @@ func (p *PanelReviewer) runSingleReview(ctx context.Context, model string, revie
 			evt.Duration = *event.Data.Duration
 		}
 		reviewEvents = append(reviewEvents, evt)
+	}
+
+	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: model,
+		SystemMessage: &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
+		},
+		ConfigDir:           configDir,
+		WorkingDirectory:    workDir,
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		SkillDirectories:    p.skillDirectories,
+		OnEvent:             eventHandler,
 	})
-	defer unsub()
+	if err != nil {
+		return nil, fmt.Errorf("creating review session for %s: %w", model, err)
+	}
 
 	_, err = session.SendAndWait(ctx, copilot.MessageOptions{
 		Prompt: reviewPrompt,

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -59,12 +60,21 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 
 	reviewPrompt := BuildReviewPrompt(originalPrompt, generatedFiles, referenceFiles, evaluationCriteria)
 
+	// Create isolated config directory to prevent user-level skills from
+	// leaking into the review session (#21).
+	configDir, err := os.MkdirTemp("", "hyoka-config-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating isolated config dir: %w", err)
+	}
+	defer os.RemoveAll(configDir)
+
 	session, err := r.client.CreateSession(ctx, &copilot.SessionConfig{
 		Model: r.model,
 		SystemMessage: &copilot.SystemMessageConfig{
 			Mode:    "append",
 			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
 		},
+		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    r.skillDirectories,
@@ -321,12 +331,21 @@ func (p *PanelReviewer) runSingleReview(ctx context.Context, model string, revie
 		}
 	}()
 
+	// Create isolated config directory to prevent user-level skills from
+	// leaking into the review session (#21).
+	configDir, err := os.MkdirTemp("", "hyoka-config-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating isolated config dir for %s: %w", model, err)
+	}
+	defer os.RemoveAll(configDir)
+
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 		Model: model,
 		SystemMessage: &copilot.SystemMessageConfig{
 			Mode:    "append",
 			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
 		},
+		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    p.skillDirectories,

--- a/hyoka/internal/trends/analysis.go
+++ b/hyoka/internal/trends/analysis.go
@@ -3,6 +3,7 @@ package trends
 import (
 "context"
 "fmt"
+"os"
 "strings"
 "sync"
 
@@ -20,12 +21,21 @@ return "", fmt.Errorf("starting copilot client: %w", err)
 }
 defer client.Stop()
 
+// Create isolated config directory to prevent user-level skills from
+// leaking into the analysis session (#21).
+configDir, err := os.MkdirTemp("", "hyoka-config-*")
+if err != nil {
+return "", fmt.Errorf("creating isolated config dir: %w", err)
+}
+defer os.RemoveAll(configDir)
+
 session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 Model: "gpt-4.1",
 SystemMessage: &copilot.SystemMessageConfig{
 Mode:    "append",
 Content: "You are an expert at analyzing AI agent tool usage and its impact on code generation quality. Focus on how tool availability affects output. Be concise and actionable.",
 },
+ConfigDir:           configDir,
 OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 })
 if err != nil {

--- a/hyoka/internal/verify/verifier.go
+++ b/hyoka/internal/verify/verifier.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -68,12 +69,21 @@ func (v *CopilotVerifier) Verify(ctx context.Context, originalPrompt string, wor
 		}
 	}()
 
+	// Create isolated config directory to prevent user-level skills from
+	// leaking into the verification session (#21).
+	configDir, err := os.MkdirTemp("", "hyoka-config-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating isolated config dir: %w", err)
+	}
+	defer os.RemoveAll(configDir)
+
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 		Model: v.model,
 		SystemMessage: &copilot.SystemMessageConfig{
 			Mode:    "append",
 			Content: "You are a code verification judge. Respond with ONLY valid JSON. No markdown, no explanation.",
 		},
+		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    v.skillDirectories,


### PR DESCRIPTION
## Summary

This PR addresses two agent isolation issues in the eval engine.

### Issue #21: Fix user-level skills leaking into eval Copilot sessions

**Problem:** User-level skills from `~/.config/github-copilot/` were loaded into eval sessions alongside the explicitly configured skills, contaminating eval results.

**Fix:** Every `CreateSession` call now sets `SessionConfig.ConfigDir` to an isolated empty temp directory (`hyoka-config-*`). This tells the Copilot CLI to use that empty directory as its config root, preventing it from discovering user-level skills or configuration. Only skills listed in the eval config's `SkillDirectories` are loaded.

**Scope:** All 5 `CreateSession` call sites are patched:
- Generator (`copilot.go`)
- Single reviewer (`reviewer.go`)
- Panel reviewer (`reviewer.go`)
- Verifier (`verifier.go`)
- Trend analysis (`analysis.go`)

### Issue #26: Harden workspace isolation for generator and reviewer agents

**Problem:** Generator and reviewer agents could write files to the report directory or shared workspace, with no boundary enforcement.

**Fix:**
- **Generator isolation:** Each eval task creates a dedicated ephemeral temp directory (`hyoka-gen-*`) as the generator's `WorkingDirectory`. After generation, files are copied to the persistent report directory. The temp dir is cleaned up via `defer`.
- **Reviewer isolation:** Reviewers get their own copy of generated files in a separate temp directory (`hyoka-review-*`). They cannot modify the original generated output.
- **Post-generation validation:** After recovering misplaced files, `ValidateWorkspaceContainment` checks whether any items still escaped the workspace boundary and logs warnings.
- **Cleanup:** All temp directories are cleaned up on completion, even on error (via `defer os.RemoveAll`).

### New helpers in `workspace.go`
- `NewIsolatedConfigDir()` — creates empty config dir for skill isolation
- `NewReviewerWorkspace(sourceDir)` — copies generated files into a reviewer-specific temp dir
- `ValidateWorkspaceContainment(dir, preSnapshot)` — post-recovery safety net

### Testing
- All existing tests pass
- New test: `TestBuildSessionConfig_ConfigDir` verifies ConfigDir is set on the session config

Closes #21, Closes #26