### PR TITLE
feat: Go project hygiene — Makefile, golangci-lint, CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,48 @@
+name: Go CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: hyoka/go.mod
+      - name: Download dependencies
+        run: cd hyoka && go mod download
+      - name: Verify dependencies
+        run: cd hyoka && go mod verify
+      - name: Build
+        run: cd hyoka && go build ./...
+      - name: Vet
+        run: cd hyoka && go vet ./...
+      - name: Test
+        run: cd hyoka && go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: hyoka/coverage.txt
+        if: always()
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: hyoka/go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: hyoka

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ skills-lock.json
 
 # Built binary
 /hyoka/azsdk-prompt-eval
+coverage.txt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+run:
+  go: "1.24"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - unconvert
+    - unused
+    - staticcheck
+  settings:
+    gocyclo:
+      min-complexity: 15
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: all build test lint vet fmt clean cover install
+
+# Default
+all: fmt lint vet test build
+
+# Build binary
+build:
+	cd hyoka && go build -o ../bin/hyoka .
+
+# Run tests with race detection
+test:
+	cd hyoka && go test -race -count=1 ./...
+
+# Lint with golangci-lint
+lint:
+	cd hyoka && golangci-lint run ./...
+
+# Go vet
+vet:
+	cd hyoka && go vet ./...
+
+# Format and tidy
+fmt:
+	cd hyoka && gofmt -w . && go mod tidy
+
+# Coverage report
+cover:
+	cd hyoka && go test -race -coverprofile=coverage.txt -covermode=atomic ./... && go tool cover -func=coverage.txt
+
+# Install binary
+install: build
+	cp bin/hyoka $(GOPATH)/bin/hyoka 2>/dev/null || cp bin/hyoka /usr/local/bin/hyoka
+
+# Clean
+clean:
+	rm -rf bin/ hyoka/coverage.txt


### PR DESCRIPTION
Adds:
- Makefile with build/test/lint/vet/clean/cover targets
- .golangci-lint configuration (errcheck, govet, ineffassign, misspell, unconvert, unused, staticcheck)
- GitHub Actions CI workflow (build, test, lint jobs)
- .gitignore updates (coverage.txt)

Recovered from crashed session b17e6743.

> 🤖 Created by Treebeard (Hyoka PM & Lead Dev) from [Ronnie's Agent Squad](https://github.com/ronniegeraghty/ronnies-agent-team)