### PR TITLE
feat: Tiered eval criteria system — general, attribute-matched, and prompt-specific

### DIFF
--- a/criteria/language/java.yaml
+++ b/criteria/language/java.yaml
@@ -1,0 +1,47 @@
+match:
+  language: java
+criteria:
+  - name: Maven/Gradle Dependency Declaration
+    description: >
+      Generated code includes correct dependency declarations
+      (groupId, artifactId, version) for all Azure SDK packages used.
+  - name: Try-With-Resources for Clients
+    description: >
+      All Azure SDK client instances that implement AutoCloseable
+      are used within try-with-resources blocks or explicitly closed
+      in a finally block.
+  - name: Correct Import Packages
+    description: >
+      Imports use the latest azure-sdk-for-java package structure
+      (com.azure.*), not legacy packages (com.microsoft.azure.*).
+  - name: TokenCredential Authentication
+    description: >
+      Authentication uses DefaultAzureCredential or another
+      TokenCredential implementation, not connection strings or
+      hardcoded keys.
+  - name: Async Client Usage
+    description: >
+      If async operations are requested, code uses the *AsyncClient
+      variant (e.g., SecretAsyncClient) with proper reactive patterns.
+  - name: Builder Pattern for Clients
+    description: >
+      SDK clients are constructed using the builder pattern
+      (e.g., new SecretClientBuilder().credential(...).buildClient()).
+  - name: Proper Exception Handling
+    description: >
+      Azure SDK exceptions (HttpResponseException and subclasses) are
+      caught and handled with status code inspection where appropriate.
+  - name: Logging Configuration
+    description: >
+      If logging is included, it uses the Azure SDK's ClientLogger
+      or SLF4J integration, not System.out.println.
+  - name: Pagination Handling
+    description: >
+      List operations use PagedIterable/PagedFlux correctly, iterating
+      with .stream() or .forEach() rather than calling .getValue() on
+      the paged response directly.
+  - name: Service Version Pinning
+    description: >
+      Client builders specify a serviceVersion() when API stability is
+      required, or explicitly omit it with a comment explaining why
+      latest is acceptable.

--- a/criteria/language/python.yaml
+++ b/criteria/language/python.yaml
@@ -1,0 +1,24 @@
+match:
+  language: python
+criteria:
+  - name: Context Manager Usage
+    description: >
+      SDK clients that support context managers are used with
+      'with' statements to ensure proper resource cleanup.
+  - name: azure-identity Authentication
+    description: >
+      Authentication uses DefaultAzureCredential from the
+      azure-identity package, not connection strings or hardcoded keys.
+  - name: Correct Package Imports
+    description: >
+      Imports use the latest azure-* package names, not the
+      deprecated azure-mgmt-* or msrestazure packages where
+      data-plane equivalents exist.
+  - name: Async Pattern Usage
+    description: >
+      If async operations are requested, code uses the async client
+      variant with proper async/await patterns.
+  - name: Pagination Handling
+    description: >
+      List operations use the SDK's built-in pagination (iterating
+      the paged response), not manual next_link handling.

--- a/criteria/service/key-vault.yaml
+++ b/criteria/service/key-vault.yaml
@@ -1,0 +1,16 @@
+match:
+  service: key-vault
+criteria:
+  - name: Secret/Key/Certificate Client Separation
+    description: >
+      Uses the correct sub-client for the operation (SecretClient for
+      secrets, KeyClient for keys, CertificateClient for certificates)
+      — not a single generic client.
+  - name: Key Vault URI Format
+    description: >
+      Vault URI follows the https://{vault-name}.vault.azure.net
+      pattern and is parameterized, not hardcoded.
+  - name: Purge Protection Awareness
+    description: >
+      Delete operations account for soft-delete and purge protection —
+      code includes comments or handling for the recovery period.

--- a/hyoka/internal/criteria/criteria_test.go
+++ b/hyoka/internal/criteria/criteria_test.go
@@ -1,0 +1,367 @@
+package criteria
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatchRule_Matches(t *testing.T) {
+	tests := []struct {
+		name  string
+		rule  MatchRule
+		attrs PromptAttributes
+		want  bool
+	}{
+		{
+			name:  "empty rule matches everything",
+			rule:  MatchRule{},
+			attrs: PromptAttributes{Language: "java", Service: "keyvault"},
+			want:  true,
+		},
+		{
+			name:  "language match",
+			rule:  MatchRule{Language: "java"},
+			attrs: PromptAttributes{Language: "java", Service: "keyvault"},
+			want:  true,
+		},
+		{
+			name:  "language mismatch",
+			rule:  MatchRule{Language: "python"},
+			attrs: PromptAttributes{Language: "java"},
+			want:  false,
+		},
+		{
+			name:  "service match",
+			rule:  MatchRule{Service: "keyvault"},
+			attrs: PromptAttributes{Language: "java", Service: "keyvault"},
+			want:  true,
+		},
+		{
+			name:  "multi-field match",
+			rule:  MatchRule{Language: "java", Service: "keyvault"},
+			attrs: PromptAttributes{Language: "java", Service: "keyvault", Plane: "data-plane"},
+			want:  true,
+		},
+		{
+			name:  "multi-field partial mismatch",
+			rule:  MatchRule{Language: "java", Service: "storage"},
+			attrs: PromptAttributes{Language: "java", Service: "keyvault"},
+			want:  false,
+		},
+		{
+			name:  "plane match",
+			rule:  MatchRule{Plane: "management-plane"},
+			attrs: PromptAttributes{Language: "python", Plane: "management-plane"},
+			want:  true,
+		},
+		{
+			name:  "category match",
+			rule:  MatchRule{Category: "provisioning"},
+			attrs: PromptAttributes{Category: "provisioning"},
+			want:  true,
+		},
+		{
+			name:  "empty attrs against empty rule",
+			rule:  MatchRule{},
+			attrs: PromptAttributes{},
+			want:  true,
+		},
+		{
+			name:  "empty attrs against non-empty rule",
+			rule:  MatchRule{Language: "java"},
+			attrs: PromptAttributes{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.rule.Matches(tt.attrs)
+			if got != tt.want {
+				t.Errorf("MatchRule.Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadCriteriaSets(t *testing.T) {
+	// Create temp dir with criteria files
+	dir := t.TempDir()
+
+	langDir := filepath.Join(dir, "language")
+	if err := os.MkdirAll(langDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	javaYAML := `match:
+  language: java
+criteria:
+  - name: Maven Dependency Declaration
+    description: Generated code includes correct Maven dependencies.
+  - name: Try-With-Resources
+    description: AutoCloseable clients use try-with-resources.
+`
+	if err := os.WriteFile(filepath.Join(langDir, "java.yaml"), []byte(javaYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pythonYAML := `match:
+  language: python
+criteria:
+  - name: Context Manager Usage
+    description: SDK clients use context managers (with statements).
+`
+	if err := os.WriteFile(filepath.Join(langDir, "python.yml"), []byte(pythonYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svcDir := filepath.Join(dir, "service")
+	if err := os.MkdirAll(svcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	kvYAML := `match:
+  service: keyvault
+criteria:
+  - name: Key Vault URI Format
+    description: Vault URI follows https://{vault-name}.vault.azure.net pattern.
+`
+	if err := os.WriteFile(filepath.Join(svcDir, "keyvault.yaml"), []byte(kvYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sets, err := LoadCriteriaSets(dir)
+	if err != nil {
+		t.Fatalf("LoadCriteriaSets() error = %v", err)
+	}
+
+	if len(sets) != 3 {
+		t.Fatalf("expected 3 criteria sets, got %d", len(sets))
+	}
+
+	// Count total criteria
+	total := 0
+	for _, s := range sets {
+		total += len(s.Criteria)
+	}
+	if total != 4 {
+		t.Errorf("expected 4 total criteria, got %d", total)
+	}
+}
+
+func TestLoadCriteriaSets_NonexistentDir(t *testing.T) {
+	sets, err := LoadCriteriaSets("/nonexistent/path/criteria")
+	if err != nil {
+		t.Fatalf("expected nil error for nonexistent dir, got %v", err)
+	}
+	if len(sets) != 0 {
+		t.Errorf("expected 0 sets for nonexistent dir, got %d", len(sets))
+	}
+}
+
+func TestLoadCriteriaSets_EmptyCriteria(t *testing.T) {
+	dir := t.TempDir()
+	emptyYAML := `match:
+  language: rust
+criteria: []
+`
+	if err := os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte(emptyYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sets, err := LoadCriteriaSets(dir)
+	if err != nil {
+		t.Fatalf("LoadCriteriaSets() error = %v", err)
+	}
+	if len(sets) != 0 {
+		t.Errorf("expected 0 sets (empty criteria skipped), got %d", len(sets))
+	}
+}
+
+func TestLoadCriteriaSets_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("{{invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Also add a valid file to ensure it's still loaded
+	validYAML := `match:
+  language: go
+criteria:
+  - name: Error Wrapping
+    description: Errors are wrapped with fmt.Errorf.
+`
+	if err := os.WriteFile(filepath.Join(dir, "good.yaml"), []byte(validYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sets, err := LoadCriteriaSets(dir)
+	if err != nil {
+		t.Fatalf("LoadCriteriaSets() error = %v", err)
+	}
+	if len(sets) != 1 {
+		t.Errorf("expected 1 valid set (bad file skipped), got %d", len(sets))
+	}
+}
+
+func TestLoadCriteriaSets_IgnoresNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# Hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sets, err := LoadCriteriaSets(dir)
+	if err != nil {
+		t.Fatalf("LoadCriteriaSets() error = %v", err)
+	}
+	if len(sets) != 0 {
+		t.Errorf("expected 0 sets (non-YAML ignored), got %d", len(sets))
+	}
+}
+
+func TestMatchCriteria(t *testing.T) {
+	sets := []CriteriaSet{
+		{
+			Match:    MatchRule{Language: "java"},
+			Criteria: []Criterion{{Name: "Java Check 1"}, {Name: "Java Check 2"}},
+			Source:   "language/java.yaml",
+		},
+		{
+			Match:    MatchRule{Language: "python"},
+			Criteria: []Criterion{{Name: "Python Check"}},
+			Source:   "language/python.yaml",
+		},
+		{
+			Match:    MatchRule{Service: "keyvault"},
+			Criteria: []Criterion{{Name: "KV Check"}},
+			Source:   "service/keyvault.yaml",
+		},
+		{
+			Match:    MatchRule{Language: "java", Service: "keyvault"},
+			Criteria: []Criterion{{Name: "Java+KV Check"}},
+			Source:   "combined/java-keyvault.yaml",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		attrs     PromptAttributes
+		wantCount int
+		wantNames []string
+	}{
+		{
+			name:      "java keyvault gets 4 criteria",
+			attrs:     PromptAttributes{Language: "java", Service: "keyvault"},
+			wantCount: 4,
+			wantNames: []string{"Java Check 1", "Java Check 2", "KV Check", "Java+KV Check"},
+		},
+		{
+			name:      "python keyvault gets 2 criteria",
+			attrs:     PromptAttributes{Language: "python", Service: "keyvault"},
+			wantCount: 2,
+			wantNames: []string{"Python Check", "KV Check"},
+		},
+		{
+			name:      "java storage gets 2 criteria",
+			attrs:     PromptAttributes{Language: "java", Service: "storage"},
+			wantCount: 2,
+			wantNames: []string{"Java Check 1", "Java Check 2"},
+		},
+		{
+			name:      "go storage gets 0 criteria",
+			attrs:     PromptAttributes{Language: "go", Service: "storage"},
+			wantCount: 0,
+		},
+		{
+			name:      "empty attrs gets 0 criteria",
+			attrs:     PromptAttributes{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := MatchCriteria(sets, tt.attrs)
+			if len(matched) != tt.wantCount {
+				t.Errorf("MatchCriteria() returned %d criteria, want %d", len(matched), tt.wantCount)
+			}
+			for _, wantName := range tt.wantNames {
+				found := false
+				for _, c := range matched {
+					if c.Name == wantName {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("MatchCriteria() missing expected criterion %q", wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchCriteria_NilSets(t *testing.T) {
+	matched := MatchCriteria(nil, PromptAttributes{Language: "java"})
+	if len(matched) != 0 {
+		t.Errorf("expected 0 criteria from nil sets, got %d", len(matched))
+	}
+}
+
+func TestFormatCriteria(t *testing.T) {
+	criteria := []Criterion{
+		{Name: "Maven Deps", Description: "Correct Maven dependencies."},
+		{Name: "Try-With-Resources", Description: "AutoCloseable clients use try-with-resources."},
+	}
+
+	result := FormatCriteria(criteria)
+
+	if result == "" {
+		t.Fatal("expected non-empty formatted criteria")
+	}
+
+	// Check numbered list format
+	if !containsStr(result, "1. **Maven Deps**") {
+		t.Error("expected numbered criterion 1")
+	}
+	if !containsStr(result, "2. **Try-With-Resources**") {
+		t.Error("expected numbered criterion 2")
+	}
+	if !containsStr(result, "Correct Maven dependencies") {
+		t.Error("expected description in output")
+	}
+}
+
+func TestFormatCriteria_Empty(t *testing.T) {
+	result := FormatCriteria(nil)
+	if result != "" {
+		t.Errorf("expected empty string for nil criteria, got %q", result)
+	}
+}
+
+func TestFormatCriteria_NoDescription(t *testing.T) {
+	criteria := []Criterion{{Name: "Simple Check"}}
+	result := FormatCriteria(criteria)
+	if !containsStr(result, "1. **Simple Check**") {
+		t.Errorf("expected criterion name in output, got %q", result)
+	}
+	if containsStr(result, "—") {
+		t.Error("should not contain dash separator when description is empty")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && len(s) > 0 && findSubstring(s, sub)
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/hyoka/internal/criteria/loader.go
+++ b/hyoka/internal/criteria/loader.go
@@ -1,0 +1,104 @@
+package criteria
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadCriteriaSets scans a directory tree for .yaml/.yml files and parses each
+// as a CriteriaSet. Files that fail to parse are logged as warnings and skipped.
+func LoadCriteriaSets(root string) ([]CriteriaSet, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Debug("Criteria directory does not exist, skipping", "path", root)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat criteria directory %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("criteria path is not a directory: %s", root)
+	}
+
+	var sets []CriteriaSet
+	err = filepath.Walk(root, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(fi.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			slog.Warn("Failed to read criteria file", "path", path, "error", readErr)
+			return nil
+		}
+
+		var cs CriteriaSet
+		if parseErr := yaml.Unmarshal(data, &cs); parseErr != nil {
+			slog.Warn("Failed to parse criteria file", "path", path, "error", parseErr)
+			return nil
+		}
+
+		if len(cs.Criteria) == 0 {
+			slog.Debug("Criteria file has no criteria entries, skipping", "path", path)
+			return nil
+		}
+
+		rel, _ := filepath.Rel(root, path)
+		if rel == "" {
+			rel = path
+		}
+		cs.Source = rel
+
+		slog.Debug("Loaded criteria set", "path", rel, "match", cs.Match, "criteria_count", len(cs.Criteria))
+		sets = append(sets, cs)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking criteria directory %s: %w", root, err)
+	}
+
+	slog.Info("Criteria sets loaded", "count", len(sets), "root", root)
+	return sets, nil
+}
+
+// MatchCriteria returns all criteria from the loaded sets whose match rules
+// are satisfied by the given prompt attributes. Results are returned in load order.
+func MatchCriteria(sets []CriteriaSet, attrs PromptAttributes) []Criterion {
+	var matched []Criterion
+	for _, s := range sets {
+		if s.Match.Matches(attrs) {
+			slog.Debug("Criteria set matched", "source", s.Source, "criteria_count", len(s.Criteria))
+			matched = append(matched, s.Criteria...)
+		}
+	}
+	return matched
+}
+
+// FormatCriteria renders a list of criteria as a numbered markdown list
+// suitable for injection into the review prompt.
+func FormatCriteria(criteria []Criterion) string {
+	if len(criteria) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, c := range criteria {
+		fmt.Fprintf(&b, "%d. **%s**", i+1, c.Name)
+		if c.Description != "" {
+			fmt.Fprintf(&b, " — %s", strings.TrimSpace(c.Description))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/hyoka/internal/criteria/types.go
+++ b/hyoka/internal/criteria/types.go
@@ -1,0 +1,55 @@
+// Package criteria provides a tiered evaluation criteria system.
+// Tier 1: General criteria (always applied, from rubric.md).
+// Tier 2: Attribute-matched criteria (applied when prompt metadata matches).
+// Tier 3: Prompt-specific criteria (per-prompt, from ## Evaluation Criteria).
+package criteria
+
+// Criterion defines a single evaluation criterion with a name and description.
+type Criterion struct {
+	Name        string `yaml:"name" json:"name"`
+	Description string `yaml:"description" json:"description"`
+}
+
+// MatchRule defines conditions under which a criteria set applies.
+// All non-empty fields must match (AND logic).
+type MatchRule struct {
+	Language string `yaml:"language" json:"language,omitempty"`
+	Service  string `yaml:"service" json:"service,omitempty"`
+	Plane    string `yaml:"plane" json:"plane,omitempty"`
+	Category string `yaml:"category" json:"category,omitempty"`
+}
+
+// CriteriaSet is a YAML file defining criteria that activate when match conditions are met.
+type CriteriaSet struct {
+	Match    MatchRule   `yaml:"match" json:"match"`
+	Criteria []Criterion `yaml:"criteria" json:"criteria"`
+
+	// Source records which file this criteria set was loaded from (not serialized to YAML).
+	Source string `yaml:"-" json:"source,omitempty"`
+}
+
+// PromptAttributes holds the metadata extracted from a prompt for matching purposes.
+type PromptAttributes struct {
+	Language string
+	Service  string
+	Plane    string
+	Category string
+}
+
+// Matches returns true if all non-empty fields in the match rule are satisfied
+// by the given prompt attributes. Empty fields are wildcards.
+func (m MatchRule) Matches(attrs PromptAttributes) bool {
+	if m.Language != "" && m.Language != attrs.Language {
+		return false
+	}
+	if m.Service != "" && m.Service != attrs.Service {
+		return false
+	}
+	if m.Plane != "" && m.Plane != attrs.Plane {
+		return false
+	}
+	if m.Category != "" && m.Category != attrs.Category {
+		return false
+	}
+	return true
+}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ronniegeraghty/hyoka/internal/build"
 	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/criteria"
 	"github.com/ronniegeraghty/hyoka/internal/logging"
 	"github.com/ronniegeraghty/hyoka/internal/progress"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
@@ -85,6 +86,7 @@ type Engine struct {
 	evaluator      CopilotEvaluator
 	reviewer       review.Reviewer
 	panelReviewer  *review.PanelReviewer
+	criteriaSets   []criteria.CriteriaSet
 	opts           EngineOptions
 }
 
@@ -148,6 +150,22 @@ func NewEngineWithReviewer(evaluator CopilotEvaluator, reviewer review.Reviewer,
 // When set, the engine uses the panel instead of the single reviewer.
 func (e *Engine) SetPanelReviewer(pr *review.PanelReviewer) {
 	e.panelReviewer = pr
+}
+
+// SetCriteriaSets configures attribute-matched criteria sets (Tier 2).
+// When set, matching criteria are injected into the review prompt based on prompt metadata.
+func (e *Engine) SetCriteriaSets(sets []criteria.CriteriaSet) {
+	e.criteriaSets = sets
+}
+
+// promptAttributes extracts criteria-matching attributes from a prompt.
+func promptAttributes(p *prompt.Prompt) criteria.PromptAttributes {
+	return criteria.PromptAttributes{
+		Language: p.Language,
+		Service:  p.Service,
+		Plane:    p.Plane,
+		Category: p.Category,
+	}
 }
 
 // EvalTask represents a single prompt+config evaluation to run.
@@ -678,11 +696,22 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			referenceDir = task.Prompt.ReferenceAnswer
 		}
 
+		// Build attribute-matched criteria (Tier 2) for this prompt
+		attrs := promptAttributes(task.Prompt)
+		matchedCriteria := criteria.MatchCriteria(e.criteriaSets, attrs)
+		attrCriteriaText := criteria.FormatCriteria(matchedCriteria)
+		if len(matchedCriteria) > 0 {
+			rlg.Info("Attribute-matched criteria applied",
+				"count", len(matchedCriteria),
+				"language", attrs.Language,
+				"service", attrs.Service)
+		}
+
 		if e.panelReviewer != nil {
 			models := e.panelReviewer.Models()
 			rlg.Debug("Starting review panel")
 			sendEvent(progress.EventToolStart, fmt.Sprintf("Review panel: %v", models))
-			panel, consolidated, err := e.panelReviewer.ReviewPanel(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria)
+			panel, consolidated, err := e.panelReviewer.ReviewPanel(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria, attrCriteriaText)
 			if err != nil {
 				rlg.Error("Review panel failed", "error", err)
 				sendEvent(progress.EventReasoning, fmt.Sprintf("Review panel failed: %v", err))
@@ -702,7 +731,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		} else if e.reviewer != nil {
 			rlg.Debug("Starting single review session")
 			sendEvent(progress.EventToolStart, "Single model review")
-			reviewResult, err := e.reviewer.Review(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria)
+			reviewResult, err := e.reviewer.Review(reviewCtx, task.Prompt.PromptText, reviewWorkDir, referenceDir, task.Prompt.EvaluationCriteria, attrCriteriaText)
 			if err != nil {
 				rlg.Error("Code review failed", "error", err)
 				sendEvent(progress.EventReasoning, fmt.Sprintf("Review failed: %v", err))

--- a/hyoka/internal/review/review_test.go
+++ b/hyoka/internal/review/review_test.go
@@ -60,6 +60,60 @@ func TestBuildReviewPromptWithEvaluationCriteria(t *testing.T) {
 	}
 }
 
+func TestBuildReviewPromptTiered(t *testing.T) {
+	prompt := "Write Azure Key Vault code"
+	generated := map[string]string{"Main.java": "import com.azure.security.keyvault.secrets.*;"}
+	attrCriteria := "1. **Maven Deps** — Correct Maven dependencies.\n2. **Try-With-Resources** — AutoCloseable clients.\n"
+	promptCriteria := "- Must use DefaultAzureCredential"
+
+	result := BuildReviewPromptTiered(prompt, generated, nil, attrCriteria, promptCriteria)
+
+	checks := []string{
+		"Attribute-Matched Evaluation Criteria",
+		"Maven Deps",
+		"Try-With-Resources",
+		"Prompt-Specific Evaluation Criteria",
+		"DefaultAzureCredential",
+		"Scoring Rubric",
+	}
+	for _, check := range checks {
+		if !contains(result, check) {
+			t.Errorf("tiered review prompt missing %q", check)
+		}
+	}
+}
+
+func TestBuildReviewPromptTieredNoAttrCriteria(t *testing.T) {
+	prompt := "Write code"
+	generated := map[string]string{"main.go": "package main"}
+	promptCriteria := "- Must handle errors"
+
+	result := BuildReviewPromptTiered(prompt, generated, nil, "", promptCriteria)
+
+	if contains(result, "Attribute-Matched") {
+		t.Error("should not contain attribute-matched section when empty")
+	}
+	if !contains(result, "Prompt-Specific Evaluation Criteria") {
+		t.Error("should contain prompt-specific criteria")
+	}
+}
+
+func TestBuildReviewPromptTieredBackwardCompat(t *testing.T) {
+	// BuildReviewPrompt (legacy) should still work, delegating to BuildReviewPromptTiered
+	prompt := "Write code"
+	generated := map[string]string{"main.go": "package main"}
+	criteria := "- Must use DefaultAzureCredential"
+
+	result := BuildReviewPrompt(prompt, generated, nil, criteria)
+
+	if !contains(result, "Prompt-Specific Evaluation Criteria") {
+		t.Error("legacy BuildReviewPrompt should include prompt-specific criteria")
+	}
+	if contains(result, "Attribute-Matched") {
+		t.Error("legacy BuildReviewPrompt should not include attribute-matched section")
+	}
+}
+
 func TestParseReviewResponse(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -110,7 +164,7 @@ func TestParseReviewResponse(t *testing.T) {
 
 func TestStubReviewer(t *testing.T) {
 	s := &StubReviewer{}
-	result, err := s.Review(nil, "test prompt", "/tmp/test", "", "")
+	result, err := s.Review(nil, "test prompt", "/tmp/test", "", "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -17,7 +17,7 @@ import (
 
 // Reviewer runs LLM-as-judge code reviews via a separate Copilot session.
 type Reviewer interface {
-	Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string) (*ReviewResult, error)
+	Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string, attributeMatchedCriteria string) (*ReviewResult, error)
 }
 
 // CopilotReviewer uses a Copilot session to perform code reviews.
@@ -41,7 +41,7 @@ func (r *CopilotReviewer) SetSkillDirectories(dirs []string) {
 }
 
 // Review creates a separate Copilot session, sends the review prompt, and parses results.
-func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string) (*ReviewResult, error) {
+func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string, attributeMatchedCriteria string) (*ReviewResult, error) {
 	slog.Debug("Reading generated files for review", "workDir", workDir)
 	generatedFiles, err := utils.ReadDirFiles(workDir)
 	if err != nil {
@@ -62,7 +62,7 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 		}
 	}
 
-	reviewPrompt := BuildReviewPrompt(originalPrompt, generatedFiles, referenceFiles, evaluationCriteria)
+	reviewPrompt := BuildReviewPromptTiered(originalPrompt, generatedFiles, referenceFiles, attributeMatchedCriteria, evaluationCriteria)
 
 	// Create isolated config directory to prevent user-level skills from
 	// leaking into the review session (#21).
@@ -173,7 +173,7 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 type StubReviewer struct{}
 
 // Review returns a stub review result.
-func (s *StubReviewer) Review(_ context.Context, _ string, _ string, _ string, _ string) (*ReviewResult, error) {
+func (s *StubReviewer) Review(_ context.Context, _ string, _ string, _ string, _ string, _ string) (*ReviewResult, error) {
 	return &ReviewResult{
 		Scores: ReviewScores{
 			Criteria: []CriterionResult{
@@ -239,7 +239,7 @@ func (p *PanelReviewer) Models() []string {
 // ReviewPanel runs all reviewer models in parallel and returns individual results
 // plus a consolidated result. The consolidated result is produced by the first model
 // in the list, which receives all other reviewers' outputs.
-func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string) (panel []ReviewResult, consolidated *ReviewResult, err error) {
+func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string, attributeMatchedCriteria string) (panel []ReviewResult, consolidated *ReviewResult, err error) {
 	slog.Info("Starting panel review", "model_count", len(p.models), "models", p.models)
 	if len(p.models) == 0 {
 		return nil, nil, fmt.Errorf("no reviewer models configured")
@@ -255,7 +255,7 @@ func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, 
 		referenceFiles, _ = utils.ReadDirFiles(referenceDir)
 	}
 
-	reviewPrompt := BuildReviewPrompt(originalPrompt, generatedFiles, referenceFiles, evaluationCriteria)
+	reviewPrompt := BuildReviewPromptTiered(originalPrompt, generatedFiles, referenceFiles, attributeMatchedCriteria, evaluationCriteria)
 
 	// Run all reviewers in parallel
 	type reviewOutput struct {
@@ -333,8 +333,8 @@ func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, 
 }
 
 // Review implements the Reviewer interface using the panel (for backward compat).
-func (p *PanelReviewer) Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string) (*ReviewResult, error) {
-	_, consolidated, err := p.ReviewPanel(ctx, originalPrompt, workDir, referenceDir, evaluationCriteria)
+func (p *PanelReviewer) Review(ctx context.Context, originalPrompt string, workDir string, referenceDir string, evaluationCriteria string, attributeMatchedCriteria string) (*ReviewResult, error) {
+	_, consolidated, err := p.ReviewPanel(ctx, originalPrompt, workDir, referenceDir, evaluationCriteria, attributeMatchedCriteria)
 	return consolidated, err
 }
 

--- a/hyoka/internal/review/rubric.go
+++ b/hyoka/internal/review/rubric.go
@@ -11,23 +11,39 @@ var embeddedRubric string
 
 // BuildReviewPrompt constructs a structured review prompt for the LLM-as-judge.
 // It includes the original prompt, generated code files, optional reference answer,
-// and optional prompt-specific evaluation criteria.
+// attribute-matched criteria (Tier 2), and prompt-specific evaluation criteria (Tier 3).
 func BuildReviewPrompt(originalPrompt string, generatedFiles map[string]string, referenceFiles map[string]string, evaluationCriteria string) string {
+	return BuildReviewPromptTiered(originalPrompt, generatedFiles, referenceFiles, "", evaluationCriteria)
+}
+
+// BuildReviewPromptTiered constructs a review prompt with all three tiers of criteria:
+//   - Tier 1 (General): embedded rubric.md, always applied
+//   - Tier 2 (Attribute-Matched): criteria matched by prompt metadata (language, service, etc.)
+//   - Tier 3 (Prompt-Specific): per-prompt criteria from ## Evaluation Criteria section
+func BuildReviewPromptTiered(originalPrompt string, generatedFiles map[string]string, referenceFiles map[string]string, attributeMatchedCriteria string, promptSpecificCriteria string) string {
 	var b strings.Builder
 
 	b.WriteString("You are evaluating another AI agent's work. The agent was given the prompt below ")
 	b.WriteString("and asked to produce code. Review the generated code against the original prompt, ")
-	b.WriteString("the general scoring rubric, and any prompt-specific evaluation criteria.\n\n")
+	b.WriteString("the general scoring rubric, and any additional evaluation criteria.\n\n")
 
 	b.WriteString("## Original Prompt\n\n")
 	b.WriteString(originalPrompt)
 	b.WriteString("\n\n")
 
-	if evaluationCriteria != "" {
+	if attributeMatchedCriteria != "" {
+		b.WriteString("## Attribute-Matched Evaluation Criteria\n\n")
+		b.WriteString("These criteria apply based on the prompt's language, service, or other attributes. ")
+		b.WriteString("Evaluate EACH criterion individually as pass/fail:\n\n")
+		b.WriteString(attributeMatchedCriteria)
+		b.WriteString("\n\n")
+	}
+
+	if promptSpecificCriteria != "" {
 		b.WriteString("## Prompt-Specific Evaluation Criteria\n\n")
 		b.WriteString("The prompt author defined these criteria the generated code should satisfy. ")
 		b.WriteString("Evaluate EACH criterion individually as pass/fail:\n\n")
-		b.WriteString(evaluationCriteria)
+		b.WriteString(promptSpecificCriteria)
 		b.WriteString("\n\n")
 	}
 

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -16,6 +16,7 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/ronniegeraghty/hyoka/internal/checkenv"
 	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/criteria"
 	"github.com/ronniegeraghty/hyoka/internal/eval"
 	"github.com/ronniegeraghty/hyoka/internal/logging"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
@@ -521,6 +522,20 @@ func runCmd() *cobra.Command {
 			})
 			if panelReviewer != nil && !f.skipReview {
 				engine.SetPanelReviewer(panelReviewer)
+			}
+
+			// Load attribute-matched criteria (Tier 2) from criteria/ directory
+			criteriaDir := filepath.Join(filepath.Dir(f.prompts), "criteria")
+			criteriaSets, criteriaErr := criteria.LoadCriteriaSets(criteriaDir)
+			if criteriaErr != nil {
+				slog.Warn("Failed to load criteria sets", "dir", criteriaDir, "error", criteriaErr)
+			} else if len(criteriaSets) > 0 {
+				engine.SetCriteriaSets(criteriaSets)
+				totalCriteria := 0
+				for _, s := range criteriaSets {
+					totalCriteria += len(s.Criteria)
+				}
+				fmt.Printf("Loaded %d criteria set(s) with %d total criteria from %s\n", len(criteriaSets), totalCriteria, criteriaDir)
 			}
 
 			summary, err := engine.Run(context.Background(), filtered, configs)


### PR DESCRIPTION
## Summary

Implements issue #30 — a three-tier evaluation criteria architecture:

| Tier | Source | When Applied |
|------|--------|-------------|
| 1 | `rubric.md` (5 general criteria) | Always |
| 2 | `criteria/` YAML files | When prompt metadata matches |
| 3 | Prompt's `## Evaluation Criteria` | Per-prompt |

### What's New

**New `criteria` package** (`internal/criteria/`):
- `types.go`: `Criterion`, `MatchRule`, `CriteriaSet`, `PromptAttributes` structs
- `loader.go`: `LoadCriteriaSets()`, `MatchCriteria()`, `FormatCriteria()`
- `criteria_test.go`: 15 test cases

**Review system updates**:
- `BuildReviewPromptTiered()` — new function accepting both attribute-matched (Tier 2) and prompt-specific (Tier 3) criteria as separate sections
- `BuildReviewPrompt()` — backward-compatible wrapper (Tier 3 only)
- `Reviewer` interface extended with `attributeMatchedCriteria` parameter
- Engine wires criteria loading: scans `criteria/` dir relative to prompts dir, matches per prompt, injects into review calls

**Sample criteria files**:
- `criteria/language/java.yaml` — 10 Java SDK criteria
- `criteria/language/python.yaml` — 5 Python SDK criteria
- `criteria/service/key-vault.yaml` — 3 Key Vault criteria

### How It Works

At eval time, when reviewing `prompts/key-vault/data-plane/java/create-secret.prompt.md`:
1. General criteria (Tier 1): 5 from `rubric.md` — always applied
2. Attribute-matched (Tier 2): `java.yaml` (10) + `key-vault.yaml` (3) — matched via `language=java`, `service=key-vault`
3. Prompt-specific (Tier 3): from `## Evaluation Criteria` section — per-prompt

All criteria appear as individual `CriterionResult` entries in the review output.

### Backward Compatible

- Prompts without metadata or matching criteria files get Tier 1 + Tier 3 only (same as before)
- `BuildReviewPrompt()` still works with the original 4-parameter signature
- No existing behavior changes

### Testing

All 18 packages build and pass tests (17 existing + 1 new `criteria` package).

Closes #30