### PR TITLE
feat(config): add plugin system for bundled skills, MCP servers, and hooks

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -29,6 +29,45 @@ type Skill struct {
 	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
+// HooksConfig holds declarative lifecycle hook rules that map to the SDK's
+// OnPreToolUse and OnPostToolUse callbacks. Hook names are strings that
+// the eval engine resolves to concrete handler functions at runtime.
+//
+// Built-in hooks:
+//   - validate_workspace_paths  — deny file writes outside workspace
+//   - block_destructive_commands — deny destructive shell commands (rm -rf, az delete, etc.)
+//   - validate_file_sizes       — warn on files exceeding size threshold
+type HooksConfig struct {
+	PreToolUse  []string `yaml:"pre_tool_use,omitempty" json:"pre_tool_use,omitempty"`
+	PostToolUse []string `yaml:"post_tool_use,omitempty" json:"post_tool_use,omitempty"`
+}
+
+// Plugin represents a composable bundle of skills, MCP servers, and hooks.
+// Plugins let users define a cohesive set of capabilities once and reference
+// them by name across multiple configs.
+//
+// Example YAML:
+//
+//	plugins:
+//	  - name: azure-sdk-tools
+//	    skills:
+//	      - type: local
+//	        path: ../skills/generator
+//	    mcp_servers:
+//	      azure:
+//	        type: sse
+//	        command: npx
+//	        args: ["-y", "@azure/mcp@latest"]
+//	    hooks:
+//	      pre_tool_use:
+//	        - validate_workspace_paths
+type Plugin struct {
+	Name       string                `yaml:"name" json:"name"`
+	Skills     []Skill               `yaml:"skills,omitempty" json:"skills,omitempty"`
+	MCPServers map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	Hooks      *HooksConfig          `yaml:"hooks,omitempty" json:"hooks,omitempty"`
+}
+
 // GeneratorConfig holds all configuration for the code generation agent.
 type GeneratorConfig struct {
 	Model          string                `yaml:"model" json:"model"`
@@ -36,13 +75,21 @@ type GeneratorConfig struct {
 	MCPServers     map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	AvailableTools []string              `yaml:"available_tools,omitempty" json:"available_tools,omitempty"`
 	ExcludedTools  []string              `yaml:"excluded_tools,omitempty" json:"excluded_tools,omitempty"`
+	Plugins        []Plugin              `yaml:"plugins,omitempty" json:"plugins,omitempty"`
+	Hooks          *HooksConfig          `yaml:"hooks,omitempty" json:"hooks,omitempty"`
+
+	pluginsMerged bool // internal flag to prevent re-merging on repeated Normalize
 }
 
 // ReviewerConfig holds all configuration for the review/grading plane.
 type ReviewerConfig struct {
-	Model  string  `yaml:"model,omitempty" json:"model,omitempty"`
-	Models []string `yaml:"models,omitempty" json:"models,omitempty"`
-	Skills []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Model   string       `yaml:"model,omitempty" json:"model,omitempty"`
+	Models  []string     `yaml:"models,omitempty" json:"models,omitempty"`
+	Skills  []Skill      `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Plugins []Plugin     `yaml:"plugins,omitempty" json:"plugins,omitempty"`
+	Hooks   *HooksConfig `yaml:"hooks,omitempty" json:"hooks,omitempty"`
+
+	pluginsMerged bool // internal flag to prevent re-merging on repeated Normalize
 }
 
 // ToolConfig represents a single evaluation configuration.
@@ -71,7 +118,8 @@ type ToolConfig struct {
 }
 
 // Normalize migrates legacy top-level fields into the Generator/Reviewer
-// sub-structs. It is idempotent — safe to call multiple times.
+// sub-structs and merges plugin contributions. It is idempotent — safe to
+// call multiple times.
 func (tc *ToolConfig) Normalize() {
 	if tc.Generator == nil {
 		tc.Generator = &GeneratorConfig{}
@@ -124,6 +172,67 @@ func (tc *ToolConfig) Normalize() {
 			tc.Reviewer.Skills = append(tc.Reviewer.Skills, Skill{Type: "local", Path: d})
 		}
 	}
+
+	// Merge generator plugins into generator config (only once)
+	if !tc.Generator.pluginsMerged {
+		mergePlugins(tc.Generator.Plugins, &tc.Generator.Skills, &tc.Generator.MCPServers, &tc.Generator.Hooks)
+		tc.Generator.pluginsMerged = true
+	}
+
+	// Merge reviewer plugins into reviewer config (only once)
+	if !tc.Reviewer.pluginsMerged {
+		mergePlugins(tc.Reviewer.Plugins, &tc.Reviewer.Skills, nil, &tc.Reviewer.Hooks)
+		tc.Reviewer.pluginsMerged = true
+	}
+}
+
+// mergePlugins folds plugin contributions (skills, MCP servers, hooks) into
+// the parent config's fields. Plugin-contributed items are appended after
+// directly-configured items, preserving plugin declaration order.
+func mergePlugins(plugins []Plugin, skills *[]Skill, mcpServers *map[string]*MCPServer, hooks **HooksConfig) {
+	for _, p := range plugins {
+		// Merge skills — plugin skills appended after direct skills
+		*skills = append(*skills, p.Skills...)
+
+		// Merge MCP servers — plugin servers added if not already present
+		if mcpServers != nil && len(p.MCPServers) > 0 {
+			if *mcpServers == nil {
+				*mcpServers = make(map[string]*MCPServer)
+			}
+			for name, srv := range p.MCPServers {
+				if _, exists := (*mcpServers)[name]; !exists {
+					(*mcpServers)[name] = srv
+				} else {
+					slog.Debug("Plugin MCP server skipped (already defined at config level)",
+						"plugin", p.Name, "server", name)
+				}
+			}
+		}
+
+		// Merge hooks — plugin hooks appended after direct hooks
+		if p.Hooks != nil {
+			if *hooks == nil {
+				*hooks = &HooksConfig{}
+			}
+			(*hooks).PreToolUse = appendUnique((*hooks).PreToolUse, p.Hooks.PreToolUse)
+			(*hooks).PostToolUse = appendUnique((*hooks).PostToolUse, p.Hooks.PostToolUse)
+		}
+	}
+}
+
+// appendUnique appends items from src to dst, skipping duplicates.
+func appendUnique(dst, src []string) []string {
+	seen := make(map[string]bool, len(dst))
+	for _, s := range dst {
+		seen[s] = true
+	}
+	for _, s := range src {
+		if !seen[s] {
+			dst = append(dst, s)
+			seen[s] = true
+		}
+	}
+	return dst
 }
 
 // EffectiveModel returns the generator model, preferring Generator.Model.
@@ -184,6 +293,40 @@ func (tc *ToolConfig) EffectiveGeneratorSkills() []Skill {
 func (tc *ToolConfig) EffectiveReviewerSkills() []Skill {
 	if tc.Reviewer != nil {
 		return tc.Reviewer.Skills
+	}
+	return nil
+}
+
+// EffectiveGeneratorHooks returns the merged hook config for the generator,
+// combining direct hooks with plugin-contributed hooks (after Normalize).
+func (tc *ToolConfig) EffectiveGeneratorHooks() *HooksConfig {
+	if tc.Generator != nil {
+		return tc.Generator.Hooks
+	}
+	return nil
+}
+
+// EffectiveReviewerHooks returns the merged hook config for the reviewer,
+// combining direct hooks with plugin-contributed hooks (after Normalize).
+func (tc *ToolConfig) EffectiveReviewerHooks() *HooksConfig {
+	if tc.Reviewer != nil {
+		return tc.Reviewer.Hooks
+	}
+	return nil
+}
+
+// EffectiveGeneratorPlugins returns the generator's plugin list.
+func (tc *ToolConfig) EffectiveGeneratorPlugins() []Plugin {
+	if tc.Generator != nil {
+		return tc.Generator.Plugins
+	}
+	return nil
+}
+
+// EffectiveReviewerPlugins returns the reviewer's plugin list.
+func (tc *ToolConfig) EffectiveReviewerPlugins() []Plugin {
+	if tc.Reviewer != nil {
+		return tc.Reviewer.Plugins
 	}
 	return nil
 }
@@ -266,6 +409,14 @@ func (cf *ConfigFile) Validate() error {
 				return fmt.Errorf("config %q reviewer skill: %w", c.Name, err)
 			}
 		}
+		// Validate generator plugins
+		if err := validatePlugins(c.EffectiveGeneratorPlugins(), c.Name, "generator"); err != nil {
+			return err
+		}
+		// Validate reviewer plugins
+		if err := validatePlugins(c.EffectiveReviewerPlugins(), c.Name, "reviewer"); err != nil {
+			return err
+		}
 		// Check for duplicate reviewer models
 		reviewerModels := c.EffectiveReviewerModels()
 		seen := make(map[string]bool, len(reviewerModels))
@@ -274,6 +425,40 @@ func (cf *ConfigFile) Validate() error {
 				return fmt.Errorf("config %q: duplicate reviewer model %q", c.Name, rm)
 			}
 			seen[rm] = true
+		}
+	}
+	return nil
+}
+
+// validatePlugins checks that plugins have valid names, no duplicate names,
+// no conflicting MCP server names, and valid skill entries.
+func validatePlugins(plugins []Plugin, configName, section string) error {
+	seenNames := make(map[string]bool, len(plugins))
+	seenMCP := make(map[string]string) // mcp server name → plugin name
+
+	for _, p := range plugins {
+		if p.Name == "" {
+			return fmt.Errorf("config %q %s: plugin missing name", configName, section)
+		}
+		if seenNames[p.Name] {
+			return fmt.Errorf("config %q %s: duplicate plugin name %q", configName, section, p.Name)
+		}
+		seenNames[p.Name] = true
+
+		// Validate plugin skills
+		for _, s := range p.Skills {
+			if err := validateSkill(s); err != nil {
+				return fmt.Errorf("config %q %s plugin %q skill: %w", configName, section, p.Name, err)
+			}
+		}
+
+		// Check for MCP server name conflicts across plugins
+		for name := range p.MCPServers {
+			if prevPlugin, exists := seenMCP[name]; exists {
+				return fmt.Errorf("config %q %s: MCP server %q defined in both plugin %q and %q",
+					configName, section, name, prevPlugin, p.Name)
+			}
+			seenMCP[name] = p.Name
 		}
 	}
 	return nil

--- a/hyoka/internal/config/plugin_test.go
+++ b/hyoka/internal/config/plugin_test.go
@@ -1,0 +1,599 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseGeneratorPlugins(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: with-plugins
+    description: "Config with generator plugins"
+    generator:
+      model: "claude-opus-4.6"
+      skills:
+        - type: local
+          path: "./skills/direct"
+      plugins:
+        - name: azure-sdk-tools
+          skills:
+            - type: local
+              path: ../skills/generator
+            - type: remote
+              repo: github.com/Azure/ai-hub-sdk
+              name: azure-sdk-tools
+          mcp_servers:
+            azure:
+              type: sse
+              command: npx
+              args: ["-y", "@azure/mcp@latest"]
+          hooks:
+            pre_tool_use:
+              - validate_workspace_paths
+              - block_destructive_commands
+            post_tool_use:
+              - validate_file_sizes
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	// Plugin should be present
+	plugins := c.EffectiveGeneratorPlugins()
+	if len(plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(plugins))
+	}
+	if plugins[0].Name != "azure-sdk-tools" {
+		t.Errorf("expected plugin name 'azure-sdk-tools', got %q", plugins[0].Name)
+	}
+
+	// Skills should be merged: 1 direct + 2 from plugin = 3
+	skills := c.EffectiveGeneratorSkills()
+	if len(skills) != 3 {
+		t.Fatalf("expected 3 merged skills, got %d", len(skills))
+	}
+	if skills[0].Path != "./skills/direct" {
+		t.Errorf("first skill should be direct, got %+v", skills[0])
+	}
+	if skills[1].Path != "../skills/generator" {
+		t.Errorf("second skill should be from plugin, got %+v", skills[1])
+	}
+	if skills[2].Type != "remote" || skills[2].Name != "azure-sdk-tools" {
+		t.Errorf("third skill should be remote from plugin, got %+v", skills[2])
+	}
+
+	// MCP servers from plugin should be merged
+	mcpServers := c.EffectiveMCPServers()
+	if len(mcpServers) != 1 {
+		t.Fatalf("expected 1 MCP server from plugin, got %d", len(mcpServers))
+	}
+	azure, ok := mcpServers["azure"]
+	if !ok {
+		t.Fatal("expected 'azure' MCP server from plugin")
+	}
+	if azure.Command != "npx" {
+		t.Errorf("expected command 'npx', got %q", azure.Command)
+	}
+
+	// Hooks from plugin should be merged
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil {
+		t.Fatal("expected hooks from plugin")
+	}
+	if len(hooks.PreToolUse) != 2 {
+		t.Errorf("expected 2 pre_tool_use hooks, got %d", len(hooks.PreToolUse))
+	}
+	if hooks.PreToolUse[0] != "validate_workspace_paths" {
+		t.Errorf("expected first hook 'validate_workspace_paths', got %q", hooks.PreToolUse[0])
+	}
+	if len(hooks.PostToolUse) != 1 || hooks.PostToolUse[0] != "validate_file_sizes" {
+		t.Errorf("expected 1 post_tool_use hook 'validate_file_sizes', got %v", hooks.PostToolUse)
+	}
+}
+
+func TestParseReviewerPlugins(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: reviewer-plugins
+    description: "Config with reviewer plugins"
+    generator:
+      model: "gpt-4"
+    reviewer:
+      models:
+        - "claude-opus-4.6"
+      plugins:
+        - name: sdk-review-standards
+          skills:
+            - type: local
+              path: ../skills/reviewer
+          hooks:
+            pre_tool_use:
+              - validate_workspace_paths
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	plugins := c.EffectiveReviewerPlugins()
+	if len(plugins) != 1 || plugins[0].Name != "sdk-review-standards" {
+		t.Fatalf("expected 1 reviewer plugin 'sdk-review-standards', got %v", plugins)
+	}
+
+	skills := c.EffectiveReviewerSkills()
+	if len(skills) != 1 || skills[0].Path != "../skills/reviewer" {
+		t.Errorf("expected reviewer skills from plugin, got %v", skills)
+	}
+
+	hooks := c.EffectiveReviewerHooks()
+	if hooks == nil || len(hooks.PreToolUse) != 1 {
+		t.Fatalf("expected 1 reviewer pre_tool_use hook, got %v", hooks)
+	}
+}
+
+func TestMultiplePluginsMerge(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: multi-plugin
+    description: "Config with multiple plugins"
+    generator:
+      model: "claude-opus-4.6"
+      plugins:
+        - name: plugin-a
+          skills:
+            - type: local
+              path: ./skills/a
+          mcp_servers:
+            server-a:
+              type: sse
+              command: cmd-a
+          hooks:
+            pre_tool_use:
+              - validate_workspace_paths
+        - name: plugin-b
+          skills:
+            - type: local
+              path: ./skills/b
+          mcp_servers:
+            server-b:
+              type: sse
+              command: cmd-b
+          hooks:
+            pre_tool_use:
+              - block_destructive_commands
+            post_tool_use:
+              - validate_file_sizes
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	// Skills merged from both plugins
+	skills := c.EffectiveGeneratorSkills()
+	if len(skills) != 2 {
+		t.Errorf("expected 2 skills from 2 plugins, got %d", len(skills))
+	}
+
+	// MCP servers merged from both plugins
+	mcpServers := c.EffectiveMCPServers()
+	if len(mcpServers) != 2 {
+		t.Errorf("expected 2 MCP servers from 2 plugins, got %d", len(mcpServers))
+	}
+
+	// Hooks merged from both plugins
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil {
+		t.Fatal("expected hooks")
+	}
+	if len(hooks.PreToolUse) != 2 {
+		t.Errorf("expected 2 pre_tool_use hooks, got %d: %v", len(hooks.PreToolUse), hooks.PreToolUse)
+	}
+	if len(hooks.PostToolUse) != 1 {
+		t.Errorf("expected 1 post_tool_use hook, got %d", len(hooks.PostToolUse))
+	}
+}
+
+func TestPluginMCPServerConfigLevelPrecedence(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: precedence
+    description: "Config-level MCP servers take precedence over plugin"
+    generator:
+      model: "gpt-4"
+      mcp_servers:
+        azure:
+          type: sse
+          command: config-cmd
+      plugins:
+        - name: tools
+          mcp_servers:
+            azure:
+              type: sse
+              command: plugin-cmd
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	// Config-level 'azure' should win over plugin's 'azure'
+	mcpServers := c.EffectiveMCPServers()
+	if len(mcpServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(mcpServers))
+	}
+	if mcpServers["azure"].Command != "config-cmd" {
+		t.Errorf("expected config-level command 'config-cmd', got %q", mcpServers["azure"].Command)
+	}
+}
+
+func TestPluginHookDeduplication(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: dedup-hooks
+    description: "Duplicate hook names across plugins are deduplicated"
+    generator:
+      model: "gpt-4"
+      hooks:
+        pre_tool_use:
+          - validate_workspace_paths
+      plugins:
+        - name: plugin-a
+          hooks:
+            pre_tool_use:
+              - validate_workspace_paths
+              - block_destructive_commands
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil {
+		t.Fatal("expected hooks")
+	}
+	// validate_workspace_paths should appear only once
+	if len(hooks.PreToolUse) != 2 {
+		t.Errorf("expected 2 unique pre_tool_use hooks, got %d: %v", len(hooks.PreToolUse), hooks.PreToolUse)
+	}
+	if hooks.PreToolUse[0] != "validate_workspace_paths" || hooks.PreToolUse[1] != "block_destructive_commands" {
+		t.Errorf("unexpected hooks: %v", hooks.PreToolUse)
+	}
+}
+
+func TestValidateRejectsPluginMissingName(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: bad-plugin
+    description: "Plugin with no name"
+    generator:
+      model: "gpt-4"
+      plugins:
+        - skills:
+            - type: local
+              path: ./skills
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for plugin missing name")
+	}
+	if !strings.Contains(err.Error(), "plugin missing name") {
+		t.Errorf("expected 'plugin missing name' error, got: %v", err)
+	}
+}
+
+func TestValidateRejectsDuplicatePluginNames(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: dupe-plugins
+    description: "Two plugins with same name"
+    generator:
+      model: "gpt-4"
+      plugins:
+        - name: tools
+          skills:
+            - type: local
+              path: ./skills/a
+        - name: tools
+          skills:
+            - type: local
+              path: ./skills/b
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate plugin names")
+	}
+	if !strings.Contains(err.Error(), "duplicate plugin name") {
+		t.Errorf("expected 'duplicate plugin name' error, got: %v", err)
+	}
+}
+
+func TestValidateRejectsConflictingMCPServerAcrossPlugins(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: mcp-conflict
+    description: "Two plugins define same MCP server"
+    generator:
+      model: "gpt-4"
+      plugins:
+        - name: plugin-a
+          mcp_servers:
+            azure:
+              type: sse
+              command: cmd-a
+        - name: plugin-b
+          mcp_servers:
+            azure:
+              type: sse
+              command: cmd-b
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for conflicting MCP server names across plugins")
+	}
+	if !strings.Contains(err.Error(), "MCP server") && !strings.Contains(err.Error(), "azure") {
+		t.Errorf("expected MCP server conflict error, got: %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidSkillInPlugin(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: bad-plugin-skill
+    description: "Plugin with invalid skill type"
+    generator:
+      model: "gpt-4"
+      plugins:
+        - name: bad-skills
+          skills:
+            - type: invalid
+              path: ./foo
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for invalid skill type in plugin")
+	}
+	if !strings.Contains(err.Error(), "plugin") && !strings.Contains(err.Error(), "skill") {
+		t.Errorf("expected plugin skill validation error, got: %v", err)
+	}
+}
+
+func TestPluginsWithDirectHooksMerge(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: direct-and-plugin-hooks
+    description: "Direct hooks and plugin hooks merge"
+    generator:
+      model: "gpt-4"
+      hooks:
+        pre_tool_use:
+          - validate_workspace_paths
+        post_tool_use:
+          - validate_file_sizes
+      plugins:
+        - name: safety
+          hooks:
+            pre_tool_use:
+              - block_destructive_commands
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil {
+		t.Fatal("expected hooks")
+	}
+	if len(hooks.PreToolUse) != 2 {
+		t.Errorf("expected 2 pre_tool_use hooks (1 direct + 1 plugin), got %d: %v",
+			len(hooks.PreToolUse), hooks.PreToolUse)
+	}
+	if len(hooks.PostToolUse) != 1 {
+		t.Errorf("expected 1 post_tool_use hook (direct only), got %d", len(hooks.PostToolUse))
+	}
+}
+
+func TestNoPluginsConfigUnchanged(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: no-plugins
+    description: "Config without plugins"
+    generator:
+      model: "gpt-4"
+      skills:
+        - type: local
+          path: ./skills
+    reviewer:
+      models:
+        - claude-opus-4.6
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	if len(c.EffectiveGeneratorPlugins()) != 0 {
+		t.Error("expected 0 generator plugins")
+	}
+	if len(c.EffectiveReviewerPlugins()) != 0 {
+		t.Error("expected 0 reviewer plugins")
+	}
+	if c.EffectiveGeneratorHooks() != nil {
+		t.Error("expected nil generator hooks")
+	}
+	if c.EffectiveReviewerHooks() != nil {
+		t.Error("expected nil reviewer hooks")
+	}
+}
+
+func TestPluginNormalizeIdempotent(t *testing.T) {
+	c := ToolConfig{
+		Name: "test",
+		Generator: &GeneratorConfig{
+			Model: "gpt-4",
+			Plugins: []Plugin{
+				{
+					Name:   "tools",
+					Skills: []Skill{{Type: "local", Path: "./skills/plugin"}},
+					Hooks:  &HooksConfig{PreToolUse: []string{"validate_workspace_paths"}},
+				},
+			},
+		},
+	}
+	c.Normalize()
+	skillCount1 := len(c.Generator.Skills)
+	hookCount1 := len(c.Generator.Hooks.PreToolUse)
+
+	c.Normalize()
+	skillCount2 := len(c.Generator.Skills)
+	hookCount2 := len(c.Generator.Hooks.PreToolUse)
+
+	if skillCount1 != skillCount2 {
+		t.Errorf("Normalize not idempotent for skills: %d vs %d", skillCount1, skillCount2)
+	}
+	if hookCount1 != hookCount2 {
+		t.Errorf("Normalize not idempotent for hooks: %d vs %d", hookCount1, hookCount2)
+	}
+}
+
+func TestFullPluginConfigFromIssue(t *testing.T) {
+	// This test uses the exact config format from issue #50
+	data := []byte(`
+configs:
+  - name: azure-mcp/claude-opus-4.6
+    generator:
+      model: claude-opus-4.6
+      plugins:
+        - name: azure-sdk-tools
+          skills:
+            - type: local
+              path: ../skills/generator
+            - type: remote
+              repo: github.com/Azure/ai-hub-sdk
+              name: azure-sdk-tools
+          mcp_servers:
+            azure:
+              type: sse
+              command: npx
+              args: ["-y", "@azure/mcp@latest"]
+          hooks:
+            pre_tool_use:
+              - validate_workspace_paths
+              - block_destructive_commands
+            post_tool_use:
+              - validate_file_sizes
+    reviewer:
+      models:
+        - claude-opus-4.6
+        - gpt-5.3-codex
+      plugins:
+        - name: sdk-review-standards
+          skills:
+            - type: local
+              path: ../skills/reviewer
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error parsing issue #50 config: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	// Generator: 1 plugin with 2 skills, 1 MCP server, 3 hooks
+	if len(c.EffectiveGeneratorPlugins()) != 1 {
+		t.Errorf("expected 1 generator plugin")
+	}
+	if len(c.EffectiveGeneratorSkills()) != 2 {
+		t.Errorf("expected 2 generator skills (from plugin), got %d", len(c.EffectiveGeneratorSkills()))
+	}
+	if len(c.EffectiveMCPServers()) != 1 {
+		t.Errorf("expected 1 MCP server (from plugin), got %d", len(c.EffectiveMCPServers()))
+	}
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil || len(hooks.PreToolUse) != 2 || len(hooks.PostToolUse) != 1 {
+		t.Errorf("expected 2 pre + 1 post hooks, got %v", hooks)
+	}
+
+	// Reviewer: 1 plugin with 1 skill
+	if len(c.EffectiveReviewerPlugins()) != 1 {
+		t.Errorf("expected 1 reviewer plugin")
+	}
+	if len(c.EffectiveReviewerSkills()) != 1 {
+		t.Errorf("expected 1 reviewer skill (from plugin), got %d", len(c.EffectiveReviewerSkills()))
+	}
+}
+
+func TestDirectHooksWithoutPlugins(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: direct-hooks
+    description: "Hooks without any plugins"
+    generator:
+      model: "gpt-4"
+      hooks:
+        pre_tool_use:
+          - validate_workspace_paths
+        post_tool_use:
+          - validate_file_sizes
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	hooks := c.EffectiveGeneratorHooks()
+	if hooks == nil {
+		t.Fatal("expected hooks without plugins")
+	}
+	if len(hooks.PreToolUse) != 1 || hooks.PreToolUse[0] != "validate_workspace_paths" {
+		t.Errorf("unexpected pre_tool_use: %v", hooks.PreToolUse)
+	}
+	if len(hooks.PostToolUse) != 1 || hooks.PostToolUse[0] != "validate_file_sizes" {
+		t.Errorf("unexpected post_tool_use: %v", hooks.PostToolUse)
+	}
+}
+
+func TestPluginWithOnlyMCPServers(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: mcp-only-plugin
+    description: "Plugin that only contributes MCP servers"
+    generator:
+      model: "gpt-4"
+      plugins:
+        - name: azure-servers
+          mcp_servers:
+            azure:
+              type: sse
+              command: npx
+              args: ["-y", "@azure/mcp@latest"]
+            github:
+              type: sse
+              command: npx
+              args: ["-y", "@github/mcp@latest"]
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+
+	mcpServers := c.EffectiveMCPServers()
+	if len(mcpServers) != 2 {
+		t.Errorf("expected 2 MCP servers from plugin, got %d", len(mcpServers))
+	}
+	if len(c.EffectiveGeneratorSkills()) != 0 {
+		t.Error("expected 0 skills when plugin only has MCP servers")
+	}
+}


### PR DESCRIPTION
## Summary

Implements #50 — adds a composable plugin system to hyoka configs.

### What's New

**Plugin type** — a named bundle of skills, MCP servers, and declarative lifecycle hooks:

```yaml
generator:
  model: claude-opus-4.6
  plugins:
    - name: azure-sdk-tools
      skills:
        - type: local
          path: ../skills/generator
      mcp_servers:
        azure:
          type: sse
          command: npx
          args: ["-y", "@azure/mcp@latest"]
      hooks:
        pre_tool_use:
          - validate_workspace_paths
          - block_destructive_commands
```

**HooksConfig** — declarative `pre_tool_use` / `post_tool_use` hook names that map to the SDK's `OnPreToolUse`/`OnPostToolUse` callbacks. Can be defined directly on generator/reviewer or via plugins.

### Key Design Decisions

- **Config-level precedence**: Direct MCP servers take priority over plugin MCP servers with the same name
- **Hook deduplication**: Same hook name from multiple sources appears only once
- **Idempotent Normalize()**: Plugin merge tracked with internal flag — safe to call multiple times
- **Validation**: Plugin name required, duplicate names rejected, MCP server conflicts across plugins rejected, plugin skills validated with same rules as direct skills

### New Accessor Methods

- `EffectiveGeneratorHooks()` / `EffectiveReviewerHooks()`
- `EffectiveGeneratorPlugins()` / `EffectiveReviewerPlugins()`

### Tests

16 new tests in `plugin_test.go` covering:
- Plugin parsing (generator + reviewer)
- Multi-plugin merging (skills, MCP servers, hooks)
- Config-level MCP server precedence
- Hook deduplication
- Validation errors (missing name, duplicate names, MCP conflicts, invalid skills)
- Idempotent Normalize()
- Exact config format from issue #50
- Direct hooks without plugins
- Plugin with only MCP servers

All 40 config tests pass. Full suite (17 packages) clean.

Closes #50