### PR TITLE
feat: add serve command for eval results viewer

### DIFF
--- a/hyoka/internal/serve/serve.go
+++ b/hyoka/internal/serve/serve.go
@@ -1,0 +1,235 @@
+// Package serve starts a local HTTP server to browse evaluation reports.
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Options configures the serve command.
+type Options struct {
+	ReportsDir string // directory containing evaluation report runs
+	Port       int    // TCP port to listen on
+	Open       bool   // auto-open the browser
+}
+
+// runInfo is one discovered run for the index page.
+type runInfo struct {
+	ID          string
+	Timestamp   string
+	HasSummary  bool
+	SummaryLink string
+	EvalCount   int
+}
+
+// summaryJSON is a minimal view of summary.json used to extract eval count.
+type summaryJSON struct {
+	TotalEvals int `json:"total_evaluations"`
+}
+
+// Run starts the HTTP server and blocks until ctx is cancelled.
+func Run(ctx context.Context, opts Options) error {
+	absDir, err := filepath.Abs(opts.ReportsDir)
+	if err != nil {
+		return fmt.Errorf("resolving reports dir: %w", err)
+	}
+
+	if info, err := os.Stat(absDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("reports directory does not exist: %s", absDir)
+	}
+
+	mux := http.NewServeMux()
+
+	// Serve the index page listing all runs.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		runs, err := discoverRuns(absDir)
+		if err != nil {
+			slog.Error("discovering runs", "error", err)
+			http.Error(w, "failed to list runs", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := indexTmpl.Execute(w, runs); err != nil {
+			slog.Error("rendering index", "error", err)
+		}
+	})
+
+	// Serve static report files under /reports/...
+	fileServer := http.FileServer(http.Dir(absDir))
+	mux.Handle("/reports/", http.StripPrefix("/reports/", fileServer))
+
+	addr := fmt.Sprintf(":%d", opts.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", addr, err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%d", opts.Port)
+	slog.Info("serving eval reports", "url", url, "dir", absDir)
+	fmt.Printf("🔍 Hyoka report viewer: %s\n", url)
+	fmt.Printf("   Reports directory:   %s\n", absDir)
+	fmt.Println("   Press Ctrl+C to stop")
+
+	if opts.Open {
+		// Opened by the caller (main.go) after starting the server.
+	}
+
+	srv := &http.Server{Handler: mux}
+
+	// Graceful shutdown on context cancel.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("server error: %w", err)
+	}
+	return nil
+}
+
+// discoverRuns scans the reports directory for run subdirectories.
+func discoverRuns(dir string) ([]runInfo, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var runs []runInfo
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Skip non-run dirs (e.g. "trends").
+		if name == "trends" || strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		ri := runInfo{
+			ID:        name,
+			Timestamp: formatRunID(name),
+		}
+
+		summaryPath := filepath.Join(dir, name, "summary.html")
+		if _, err := os.Stat(summaryPath); err == nil {
+			ri.HasSummary = true
+			ri.SummaryLink = "/reports/" + name + "/summary.html"
+		}
+
+		// Try to read eval count from summary.json.
+		sjPath := filepath.Join(dir, name, "summary.json")
+		if data, err := os.ReadFile(sjPath); err == nil {
+			var sj summaryJSON
+			if json.Unmarshal(data, &sj) == nil {
+				ri.EvalCount = sj.TotalEvals
+			}
+		}
+
+		runs = append(runs, ri)
+	}
+
+	// Most recent first.
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].ID > runs[j].ID
+	})
+
+	return runs, nil
+}
+
+// formatRunID converts a timestamp-based run ID (e.g. "20260327-191240")
+// into a human-readable string.
+func formatRunID(id string) string {
+	t, err := time.Parse("20060102-150405", id)
+	if err != nil {
+		return id
+	}
+	return t.Format("2006-01-02 15:04:05")
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hyoka — Eval Report Viewer</title>
+<style>
+  :root {
+    --bg: #f8fafc; --card-bg: #fff; --border: #e2e8f0;
+    --text: #0f172a; --text-muted: #64748b; --blue: #2563eb;
+    --green: #22c55e; --purple: #7c3aed;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg); color: var(--text);
+    max-width: 900px; margin: 0 auto; padding: 2rem;
+  }
+  h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+  .subtitle { color: var(--text-muted); margin-bottom: 1.5rem; }
+  .run-list { list-style: none; }
+  .run-item {
+    background: var(--card-bg); border: 1px solid var(--border);
+    border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem;
+    display: flex; justify-content: space-between; align-items: center;
+    transition: box-shadow 0.15s;
+  }
+  .run-item:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .run-id { font-family: monospace; font-weight: 600; font-size: 0.95rem; }
+  .run-ts { color: var(--text-muted); font-size: 0.85rem; margin-top: 0.15rem; }
+  .run-meta { text-align: right; font-size: 0.85rem; color: var(--text-muted); }
+  .run-meta a {
+    display: inline-block; margin-left: 0.5rem; padding: 0.3rem 0.75rem;
+    background: var(--blue); color: #fff; text-decoration: none;
+    border-radius: 4px; font-size: 0.8rem; font-weight: 500;
+  }
+  .run-meta a:hover { opacity: 0.9; }
+  .badge {
+    display: inline-block; padding: 0.15rem 0.5rem;
+    background: #e0e7ff; color: var(--blue); border-radius: 9999px;
+    font-size: 0.75rem; font-weight: 600;
+  }
+  .empty { color: var(--text-muted); text-align: center; padding: 3rem; }
+</style>
+</head>
+<body>
+  <h1>📊 Hyoka — Eval Report Viewer</h1>
+  <p class="subtitle">Browse evaluation runs</p>
+  {{if .}}
+  <ul class="run-list">
+    {{range .}}
+    <li class="run-item">
+      <div>
+        <div class="run-id">{{.ID}}</div>
+        <div class="run-ts">{{.Timestamp}}</div>
+      </div>
+      <div class="run-meta">
+        {{if .EvalCount}}<span class="badge">{{.EvalCount}} evals</span>{{end}}
+        {{if .HasSummary}}<a href="{{.SummaryLink}}">View Summary</a>{{end}}
+        <a href="/reports/{{.ID}}/">Browse Files</a>
+      </div>
+    </li>
+    {{end}}
+  </ul>
+  {{else}}
+  <div class="empty">No evaluation runs found.</div>
+  {{end}}
+</body>
+</html>
+`))

--- a/hyoka/internal/serve/serve_test.go
+++ b/hyoka/internal/serve/serve_test.go
@@ -1,0 +1,264 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setupTestReports creates a temporary reports directory with sample run data.
+func setupTestReports(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Run 1: has summary.html and summary.json
+	run1 := filepath.Join(dir, "20260327-191240")
+	if err := os.MkdirAll(run1, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(run1, "summary.html"), []byte("<html>summary1</html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sj := summaryJSON{TotalEvals: 5}
+	data, _ := json.Marshal(sj)
+	if err := os.WriteFile(filepath.Join(run1, "summary.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run 2: no summary
+	run2 := filepath.Join(dir, "20260324-103151")
+	if err := os.MkdirAll(run2, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-run dirs should be skipped
+	if err := os.MkdirAll(filepath.Join(dir, "trends"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func TestDiscoverRuns(t *testing.T) {
+	dir := setupTestReports(t)
+
+	runs, err := discoverRuns(dir)
+	if err != nil {
+		t.Fatalf("discoverRuns: %v", err)
+	}
+
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+
+	// Most recent first
+	if runs[0].ID != "20260327-191240" {
+		t.Errorf("expected first run ID 20260327-191240, got %s", runs[0].ID)
+	}
+	if !runs[0].HasSummary {
+		t.Error("expected first run to have summary")
+	}
+	if runs[0].EvalCount != 5 {
+		t.Errorf("expected 5 evals, got %d", runs[0].EvalCount)
+	}
+
+	if runs[1].ID != "20260324-103151" {
+		t.Errorf("expected second run ID 20260324-103151, got %s", runs[1].ID)
+	}
+	if runs[1].HasSummary {
+		t.Error("expected second run to not have summary")
+	}
+}
+
+func TestFormatRunID(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"20260327-191240", "2026-03-27 19:12:40"},
+		{"invalid-id", "invalid-id"},
+	}
+	for _, tt := range tests {
+		got := formatRunID(tt.input)
+		if got != tt.want {
+			t.Errorf("formatRunID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIndexPage(t *testing.T) {
+	dir := setupTestReports(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		runs, _ := discoverRuns(dir)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = indexTmpl.Execute(w, runs)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	html := string(body)
+
+	if !strings.Contains(html, "20260327-191240") {
+		t.Error("index page should contain run ID")
+	}
+	if !strings.Contains(html, "View Summary") {
+		t.Error("index page should contain summary link")
+	}
+	if !strings.Contains(html, "5 evals") {
+		t.Error("index page should contain eval count")
+	}
+}
+
+func TestStaticFileServing(t *testing.T) {
+	dir := setupTestReports(t)
+
+	mux := http.NewServeMux()
+	fileServer := http.FileServer(http.Dir(dir))
+	mux.Handle("/reports/", http.StripPrefix("/reports/", fileServer))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/reports/20260327-191240/summary.html")
+	if err != nil {
+		t.Fatalf("GET summary.html: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "<html>summary1</html>" {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+func TestRunInvalidDir(t *testing.T) {
+	err := Run(context.Background(), Options{
+		ReportsDir: "/nonexistent/path",
+		Port:       0,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent dir")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestServerLifecycle(t *testing.T) {
+	dir := setupTestReports(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use port 0 to let OS pick a free port.
+	// We need to start the server in a modified way to capture the actual port.
+	opts := Options{
+		ReportsDir: dir,
+		Port:       0,
+		Open:       false,
+	}
+
+	absDir, _ := filepath.Abs(opts.ReportsDir)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		runs, _ := discoverRuns(absDir)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = indexTmpl.Execute(w, runs)
+	})
+
+	fileServer := http.FileServer(http.Dir(absDir))
+	mux.Handle("/reports/", http.StripPrefix("/reports/", fileServer))
+
+	srv := &http.Server{Handler: mux}
+	ln, err := (&net.ListenConfig{}).Listen(ctx, "tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(ln) }()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Give server a moment to start.
+	time.Sleep(50 * time.Millisecond)
+
+	base := fmt.Sprintf("http://localhost:%d", port)
+
+	// Test the index
+	resp, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Test static file
+	resp2, err := http.Get(base + "/reports/20260327-191240/summary.html")
+	if err != nil {
+		t.Fatalf("GET summary: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp2.StatusCode)
+	}
+
+	// Shutdown
+	cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer shutdownCancel()
+	_ = srv.Shutdown(shutdownCtx)
+
+	srvErr := <-errCh
+	if srvErr != nil && srvErr != http.ErrServerClosed {
+		t.Fatalf("server error: %v", srvErr)
+	}
+}
+
+func TestDiscoverRunsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	runs, err := discoverRuns(dir)
+	if err != nil {
+		t.Fatalf("discoverRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected 0 runs, got %d", len(runs))
+	}
+}

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -22,6 +23,7 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/rerender"
 	"github.com/ronniegeraghty/hyoka/internal/report"
 	"github.com/ronniegeraghty/hyoka/internal/review"
+	"github.com/ronniegeraghty/hyoka/internal/serve"
 	"github.com/ronniegeraghty/hyoka/internal/trends"
 	"github.com/ronniegeraghty/hyoka/internal/validate"
 	"github.com/spf13/cobra"
@@ -70,6 +72,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(checkEnvCmd())
 	root.AddCommand(trendsCmd())
 	root.AddCommand(reportCmd())
+	root.AddCommand(serveCmd())
 	root.AddCommand(newPromptCmd())
 
 	return root
@@ -912,6 +915,47 @@ func reportCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&reportsDir, "reports-dir", "./reports", "Directory containing evaluation reports")
 	cmd.Flags().BoolVar(&all, "all", false, "Re-render all runs")
+
+	return cmd
+}
+
+func serveCmd() *cobra.Command {
+	var reportsDir string
+	var port int
+	var noOpen bool
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start a local HTTP server to browse evaluation reports",
+		Long:  "Starts a local web server that provides an index of all evaluation runs with links to summary and individual report HTML files. Press Ctrl+C to stop.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reportsDir = resolvePathFlag(cmd, "reports-dir", []string{"../reports", "./reports"})
+
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+			defer stop()
+
+			open := !noOpen
+
+			if open {
+				url := fmt.Sprintf("http://localhost:%d", port)
+				go func() {
+					// Small delay so the server has time to bind.
+					time.Sleep(300 * time.Millisecond)
+					openInBrowser(url)
+				}()
+			}
+
+			return serve.Run(ctx, serve.Options{
+				ReportsDir: reportsDir,
+				Port:       port,
+				Open:       open,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&reportsDir, "reports-dir", "./reports", "Directory containing evaluation reports")
+	cmd.Flags().IntVar(&port, "port", 8080, "Port to listen on")
+	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Do not auto-open the browser")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Implements `hyoka serve` — a local HTTP server for browsing evaluation report runs.

### Features
- **Index page** listing all discovered runs (most recent first) with eval counts and summary links
- **Static file serving** for all report HTML/JSON/MD files
- `--port` flag (default 8080)
- `--reports-dir` flag (default `./reports`, with auto-resolution for both repo root and tool dir)
- `--no-open` flag to disable auto-opening browser
- **Graceful shutdown** on Ctrl+C (SIGINT via `signal.NotifyContext`)
- Styled responsive card layout matching existing hyoka report aesthetics

### Implementation
- New `internal/serve` package with `Run(ctx, Options)` — clean separation from CLI wiring
- Uses Go stdlib `net/http` — no external dependencies added
- `discoverRuns()` scans the reports directory, reads `summary.json` for eval counts, sorts most-recent-first
- `serveCmd()` in main.go follows existing cobra patterns (`resolvePathFlag`, `openInBrowser`)

### Tests
7 new tests covering:
- Run discovery, sorting, and empty directory handling
- Timestamp formatting (valid + invalid)
- Index page HTML rendering with expected content
- Static file serving
- Invalid directory error handling
- Full server lifecycle (start → request → shutdown)

All 18 packages pass. Build clean.

Closes #20