### PR TITLE
feat: make eval tool portable — support running from any repo

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -65,6 +65,7 @@ type EngineOptions struct {
 	BuildTimeout    time.Duration // Timeout for build verification phase (--verify-build).
 	ReviewTimeout   time.Duration // Independent timeout for review phase.
 	OutputDir       string
+	CriteriaDir     string // Directory containing criteria YAML files (portable mode).
 	SkipTests       bool
 	SkipReview      bool
 	VerifyBuild     bool

--- a/hyoka/internal/project/project.go
+++ b/hyoka/internal/project/project.go
@@ -1,0 +1,154 @@
+// Package project provides project-level configuration discovery for hyoka.
+//
+// When hyoka runs in a repo other than the hyoka repo itself, it looks for a
+// hyoka.yaml or .hyoka.yaml file in the working directory (or up to the git
+// root) to discover where prompts, configs, skills, criteria, and reports live.
+//
+// Priority order for each path:
+//  1. Explicit CLI flag (e.g., --prompts, --config-dir)
+//  2. Project config file value (hyoka.yaml / .hyoka.yaml)
+//  3. Default candidates (./prompts, ../prompts, etc.)
+package project
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds paths discovered from a hyoka.yaml / .hyoka.yaml project file.
+// All paths are stored as-is from the YAML; call Resolve() to make them
+// absolute relative to the config file's directory.
+type Config struct {
+	// PromptsDir is the directory containing .prompt.md files.
+	PromptsDir string `yaml:"prompts_dir,omitempty"`
+	// ConfigsDir is the directory containing evaluation config YAML files.
+	ConfigsDir string `yaml:"configs_dir,omitempty"`
+	// SkillsDir is the directory containing skill files.
+	SkillsDir string `yaml:"skills_dir,omitempty"`
+	// CriteriaDir is the directory containing criteria YAML files.
+	CriteriaDir string `yaml:"criteria_dir,omitempty"`
+	// ReportsDir is the directory where evaluation reports are written.
+	ReportsDir string `yaml:"reports_dir,omitempty"`
+
+	// ConfigPath is the absolute path to the loaded config file (not from YAML).
+	ConfigPath string `yaml:"-"`
+}
+
+// configFileNames lists filenames to probe, in priority order.
+var configFileNames = []string{"hyoka.yaml", ".hyoka.yaml"}
+
+// Load reads a project config from the given explicit path.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading project config: %w", err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing project config %s: %w", path, err)
+	}
+	abs, _ := filepath.Abs(path)
+	cfg.ConfigPath = abs
+	cfg.resolve()
+	slog.Info("Loaded project config", "path", abs)
+	return &cfg, nil
+}
+
+// Discover searches for a project config file starting from startDir and
+// walking up parent directories until it finds one or reaches the filesystem
+// root. Returns nil (no error) if no config file is found — this is the
+// normal case when running inside the hyoka repo itself.
+func Discover(startDir string) (*Config, error) {
+	abs, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving start dir: %w", err)
+	}
+
+	dir := abs
+	for {
+		for _, name := range configFileNames {
+			candidate := filepath.Join(dir, name)
+			if _, err := os.Stat(candidate); err == nil {
+				slog.Debug("Found project config", "path", candidate)
+				return Load(candidate)
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached filesystem root
+		}
+		dir = parent
+	}
+
+	slog.Debug("No project config found", "searched_from", abs)
+	return nil, nil
+}
+
+// resolve makes all relative paths in the config absolute, based on the
+// directory containing the config file.
+func (c *Config) resolve() {
+	if c.ConfigPath == "" {
+		return
+	}
+	base := filepath.Dir(c.ConfigPath)
+	c.PromptsDir = resolveRelative(c.PromptsDir, base)
+	c.ConfigsDir = resolveRelative(c.ConfigsDir, base)
+	c.SkillsDir = resolveRelative(c.SkillsDir, base)
+	c.CriteriaDir = resolveRelative(c.CriteriaDir, base)
+	c.ReportsDir = resolveRelative(c.ReportsDir, base)
+}
+
+// resolveRelative makes path absolute if it is relative, using base as the
+// reference directory. Empty strings are returned as-is.
+func resolveRelative(path, base string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(base, path)
+}
+
+// EffectivePromptsDir returns the prompts directory to use, considering the
+// project config. Returns empty string if not set (caller should fall back to
+// default candidates).
+func (c *Config) EffectivePromptsDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.PromptsDir
+}
+
+// EffectiveConfigsDir returns the configs directory to use.
+func (c *Config) EffectiveConfigsDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.ConfigsDir
+}
+
+// EffectiveSkillsDir returns the skills directory to use.
+func (c *Config) EffectiveSkillsDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.SkillsDir
+}
+
+// EffectiveCriteriaDir returns the criteria directory to use.
+func (c *Config) EffectiveCriteriaDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.CriteriaDir
+}
+
+// EffectiveReportsDir returns the reports directory to use.
+func (c *Config) EffectiveReportsDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.ReportsDir
+}

--- a/hyoka/internal/project/project_test.go
+++ b/hyoka/internal/project/project_test.go
@@ -1,0 +1,268 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	content := `
+prompts_dir: my-prompts
+configs_dir: my-configs
+skills_dir: my-skills
+criteria_dir: my-criteria
+reports_dir: my-reports
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Paths should be resolved relative to the config file dir
+	wantPrompts := filepath.Join(dir, "my-prompts")
+	if cfg.PromptsDir != wantPrompts {
+		t.Errorf("PromptsDir = %q, want %q", cfg.PromptsDir, wantPrompts)
+	}
+	wantConfigs := filepath.Join(dir, "my-configs")
+	if cfg.ConfigsDir != wantConfigs {
+		t.Errorf("ConfigsDir = %q, want %q", cfg.ConfigsDir, wantConfigs)
+	}
+	wantSkills := filepath.Join(dir, "my-skills")
+	if cfg.SkillsDir != wantSkills {
+		t.Errorf("SkillsDir = %q, want %q", cfg.SkillsDir, wantSkills)
+	}
+	wantCriteria := filepath.Join(dir, "my-criteria")
+	if cfg.CriteriaDir != wantCriteria {
+		t.Errorf("CriteriaDir = %q, want %q", cfg.CriteriaDir, wantCriteria)
+	}
+	wantReports := filepath.Join(dir, "my-reports")
+	if cfg.ReportsDir != wantReports {
+		t.Errorf("ReportsDir = %q, want %q", cfg.ReportsDir, wantReports)
+	}
+	if cfg.ConfigPath != cfgPath {
+		t.Errorf("ConfigPath = %q, want %q", cfg.ConfigPath, cfgPath)
+	}
+}
+
+func TestLoad_AbsolutePaths(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	content := `
+prompts_dir: /absolute/prompts
+configs_dir: /absolute/configs
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.PromptsDir != "/absolute/prompts" {
+		t.Errorf("PromptsDir = %q, want /absolute/prompts", cfg.PromptsDir)
+	}
+	if cfg.ConfigsDir != "/absolute/configs" {
+		t.Errorf("ConfigsDir = %q, want /absolute/configs", cfg.ConfigsDir)
+	}
+}
+
+func TestLoad_PartialConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	content := `prompts_dir: my-prompts`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.PromptsDir != filepath.Join(dir, "my-prompts") {
+		t.Errorf("PromptsDir = %q, want resolved path", cfg.PromptsDir)
+	}
+	// Unset fields should remain empty
+	if cfg.ConfigsDir != "" {
+		t.Errorf("ConfigsDir = %q, want empty", cfg.ConfigsDir)
+	}
+	if cfg.ReportsDir != "" {
+		t.Errorf("ReportsDir = %q, want empty", cfg.ReportsDir)
+	}
+}
+
+func TestLoad_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// All fields should be empty
+	if cfg.PromptsDir != "" || cfg.ConfigsDir != "" || cfg.ReportsDir != "" {
+		t.Error("expected all dirs to be empty for empty config")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("{{not yaml"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/hyoka.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestDiscover_FindsHyokaYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hyoka.yaml")
+
+	content := `prompts_dir: prompts`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Discover() returned nil, expected config")
+	}
+	if cfg.PromptsDir != filepath.Join(dir, "prompts") {
+		t.Errorf("PromptsDir = %q, want %q", cfg.PromptsDir, filepath.Join(dir, "prompts"))
+	}
+}
+
+func TestDiscover_FindsDotHyokaYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".hyoka.yaml")
+
+	content := `prompts_dir: my-prompts`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Discover() returned nil, expected config")
+	}
+	if cfg.PromptsDir != filepath.Join(dir, "my-prompts") {
+		t.Errorf("PromptsDir = %q", cfg.PromptsDir)
+	}
+}
+
+func TestDiscover_PrefersHyokaYAMLOverDot(t *testing.T) {
+	dir := t.TempDir()
+
+	// Both exist — hyoka.yaml should win
+	if err := os.WriteFile(filepath.Join(dir, "hyoka.yaml"), []byte("prompts_dir: from-hyoka"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".hyoka.yaml"), []byte("prompts_dir: from-dot"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config")
+	}
+	want := filepath.Join(dir, "from-hyoka")
+	if cfg.PromptsDir != want {
+		t.Errorf("PromptsDir = %q, want %q (hyoka.yaml should take priority)", cfg.PromptsDir, want)
+	}
+}
+
+func TestDiscover_WalksUpParent(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "sub", "deep")
+	if err := os.MkdirAll(child, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(root, "hyoka.yaml")
+	if err := os.WriteFile(cfgPath, []byte("prompts_dir: prompts"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Discover(child)
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config found by walking up")
+	}
+	want := filepath.Join(root, "prompts")
+	if cfg.PromptsDir != want {
+		t.Errorf("PromptsDir = %q, want %q", cfg.PromptsDir, want)
+	}
+}
+
+func TestDiscover_NoConfigReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	// No config file anywhere
+
+	cfg, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if cfg != nil {
+		t.Error("expected nil config when no file found")
+	}
+}
+
+func TestEffective_NilConfig(t *testing.T) {
+	var cfg *Config
+
+	if cfg.EffectivePromptsDir() != "" {
+		t.Error("expected empty for nil config")
+	}
+	if cfg.EffectiveConfigsDir() != "" {
+		t.Error("expected empty for nil config")
+	}
+	if cfg.EffectiveSkillsDir() != "" {
+		t.Error("expected empty for nil config")
+	}
+	if cfg.EffectiveCriteriaDir() != "" {
+		t.Error("expected empty for nil config")
+	}
+	if cfg.EffectiveReportsDir() != "" {
+		t.Error("expected empty for nil config")
+	}
+}

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/config"
 	"github.com/ronniegeraghty/hyoka/internal/eval"
 	"github.com/ronniegeraghty/hyoka/internal/logging"
+	"github.com/ronniegeraghty/hyoka/internal/project"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
 	"github.com/ronniegeraghty/hyoka/internal/rerender"
 	"github.com/ronniegeraghty/hyoka/internal/report"
@@ -29,6 +30,10 @@ import (
 
 var version = "0.2.0"
 
+// projectCfg holds the project-level config discovered from hyoka.yaml / .hyoka.yaml.
+// It is nil when no project config file is found (e.g., when running inside the hyoka repo).
+var projectCfg *project.Config
+
 func main() {
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(1)
@@ -36,12 +41,12 @@ func main() {
 }
 
 func rootCmd() *cobra.Command {
-	var logLevel, logFile string
+	var logLevel, logFile, projectConfigPath string
 
 	root := &cobra.Command{
 		Use:   "hyoka",
 		Short: "Azure SDK Prompt Evaluation Tool — test AI agent code generation quality",
-		Long:  "A tool for evaluating AI agent code generation quality by running prompts through the Copilot SDK, running build verification, and generating reports.",
+		Long:  "A tool for evaluating AI agent code generation quality by running prompts through the Copilot SDK, running build verification, and generating reports.\n\nPortable mode: Place a hyoka.yaml or .hyoka.yaml in your repo root to configure directory paths (prompts_dir, configs_dir, skills_dir, criteria_dir, reports_dir).",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			closer, err := logging.Setup(logging.Options{
 				Level:    logLevel,
@@ -50,16 +55,33 @@ func rootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Store closer on the context so it can be called at shutdown.
-			// For simplicity we use a runtime finalizer via cobra's PostRun;
-			// in practice the process exits right after Execute returns.
 			cmd.Root().PersistentPostRun = func(*cobra.Command, []string) { closer() }
+
+			// Load project config — explicit path or auto-discover
+			if projectConfigPath != "" {
+				cfg, err := project.Load(projectConfigPath)
+				if err != nil {
+					return fmt.Errorf("loading project config: %w", err)
+				}
+				projectCfg = cfg
+			} else {
+				cwd, _ := os.Getwd()
+				cfg, err := project.Discover(cwd)
+				if err != nil {
+					slog.Warn("Error discovering project config", "error", err)
+				}
+				projectCfg = cfg // may be nil — that's fine
+			}
+			if projectCfg != nil {
+				slog.Info("Using project config", "path", projectCfg.ConfigPath)
+			}
 			return nil
 		},
 	}
 
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "Log level: debug, info, warn, error")
 	root.PersistentFlags().StringVar(&logFile, "log-file", "", "Redirect log output to a file (stderr stays clean)")
+	root.PersistentFlags().StringVar(&projectConfigPath, "project-config", "", "Path to hyoka.yaml project config file (auto-discovered if not specified)")
 
 	root.AddCommand(runCmd())
 	root.AddCommand(listCmd())
@@ -76,7 +98,8 @@ func rootCmd() *cobra.Command {
 }
 
 // resolvePathFlag returns the flag value if explicitly set by the user,
-// otherwise tries the candidate paths in order, falling back to the default.
+// otherwise tries the project config value, then candidate paths in order,
+// falling back to the default.
 func resolvePathFlag(cmd *cobra.Command, flagName string, candidates []string) string {
 	if cmd.Flags().Changed(flagName) {
 		val, _ := cmd.Flags().GetString(flagName)
@@ -91,8 +114,32 @@ func resolvePathFlag(cmd *cobra.Command, flagName string, candidates []string) s
 	return val
 }
 
+// resolveWithProjectConfig resolves a path using project config first, then
+// candidates, then the flag default. The projectDir is the value from the
+// project config (may be empty if not set or no project config).
+func resolveWithProjectConfig(cmd *cobra.Command, flagName, projectDir string, candidates []string) string {
+	if cmd.Flags().Changed(flagName) {
+		val, _ := cmd.Flags().GetString(flagName)
+		return val
+	}
+	if projectDir != "" {
+		return projectDir
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	val, _ := cmd.Flags().GetString(flagName)
+	return val
+}
+
 func resolvePromptsDir(cmd *cobra.Command) string {
-	return resolvePathFlag(cmd, "prompts", []string{"./prompts", "../prompts"})
+	var projDir string
+	if projectCfg != nil {
+		projDir = projectCfg.EffectivePromptsDir()
+	}
+	return resolveWithProjectConfig(cmd, "prompts", projDir, []string{"./prompts", "../prompts"})
 }
 
 func resolveConfigFile(cmd *cobra.Command) string {
@@ -102,13 +149,27 @@ func resolveConfigFile(cmd *cobra.Command) string {
 }
 
 func resolveConfigDir(cmd *cobra.Command) string {
-	return resolvePathFlag(cmd, "config-dir", []string{
-		"./configs", "../configs",
-	})
+	var projDir string
+	if projectCfg != nil {
+		projDir = projectCfg.EffectiveConfigsDir()
+	}
+	return resolveWithProjectConfig(cmd, "config-dir", projDir, []string{"./configs", "../configs"})
 }
 
 func resolveOutputDir(cmd *cobra.Command) string {
-	return resolvePathFlag(cmd, "output", []string{"./reports", "../reports"})
+	var projDir string
+	if projectCfg != nil {
+		projDir = projectCfg.EffectiveReportsDir()
+	}
+	return resolveWithProjectConfig(cmd, "output", projDir, []string{"./reports", "../reports"})
+}
+
+func resolveCriteriaDir(cmd *cobra.Command) string {
+	var projDir string
+	if projectCfg != nil {
+		projDir = projectCfg.EffectiveCriteriaDir()
+	}
+	return resolveWithProjectConfig(cmd, "criteria-dir", projDir, []string{"./criteria", "../criteria"})
 }
 
 func resolveOutputFile(cmd *cobra.Command, candidates []string) string {
@@ -126,6 +187,7 @@ type runFlags struct {
 	configName   string
 	configFile   string
 	configDir    string
+	criteriaDir  string
 	workers         int
 	maxSessions     int
 	timeout         int
@@ -163,6 +225,7 @@ func addFilterFlags(cmd *cobra.Command, f *runFlags) {
 	cmd.Flags().StringVar(&f.configName, "config", "", "Config name(s) from config file (comma-separated)")
 	cmd.Flags().StringVar(&f.configFile, "config-file", "", "Path to a specific configuration YAML file (default: load all from configs/)")
 	cmd.Flags().StringVar(&f.configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
+	cmd.Flags().StringVar(&f.criteriaDir, "criteria-dir", "./criteria", "Directory containing criteria YAML files for attribute-matched evaluation")
 	cmd.Flags().IntVar(&f.workers, "workers", 0, "Parallel evaluation workers (default: number of CPUs, max 8)")
 	cmd.Flags().IntVar(&f.maxSessions, "max-sessions", 0, "Maximum concurrent Copilot sessions (default: workers × 3)")
 	cmd.Flags().IntVar(&f.timeout, "timeout", 600, "Per-prompt generation timeout in seconds (deprecated: use --generate-timeout)")
@@ -191,22 +254,34 @@ func addFilterFlags(cmd *cobra.Command, f *runFlags) {
 	cmd.Flags().MarkHidden("sandbox") // sandbox is the default; --allow-cloud is the opt-out
 }
 
-// resolveSkillsDirs finds the skills directory relative to the prompts directory.
-// It checks multiple candidate paths to work from both repo root and tool/ directory.
 // resolveSkillsDirs resolves skill directories for generator and reviewer sessions.
+// It consults the project config first, then checks standard candidate paths.
 // It looks for skills/generator/ and skills/reviewer/ subdirectories.
 // Falls back to the parent skills/ directory for both if subdirs don't exist.
 func resolveSkillsDirs(promptsDir string) (generatorDirs, reviewerDirs []string) {
 	var baseDir string
-	for _, candidate := range []string{
-		filepath.Join(filepath.Dir(promptsDir), "skills"),
-		"./skills",
-		"../skills",
-	} {
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			abs, _ := filepath.Abs(candidate)
-			baseDir = abs
-			break
+
+	// Check project config first
+	if projectCfg != nil {
+		if d := projectCfg.EffectiveSkillsDir(); d != "" {
+			if info, err := os.Stat(d); err == nil && info.IsDir() {
+				abs, _ := filepath.Abs(d)
+				baseDir = abs
+			}
+		}
+	}
+
+	if baseDir == "" {
+		for _, candidate := range []string{
+			filepath.Join(filepath.Dir(promptsDir), "skills"),
+			"./skills",
+			"../skills",
+		} {
+			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+				abs, _ := filepath.Abs(candidate)
+				baseDir = abs
+				break
+			}
 		}
 	}
 	if baseDir == "" {
@@ -333,6 +408,17 @@ func runCmd() *cobra.Command {
 
 			f.prompts = resolvePromptsDir(cmd)
 			f.output = resolveOutputDir(cmd)
+			f.criteriaDir = resolveCriteriaDir(cmd)
+
+			// Log resolved paths for portable mode debugging
+			if projectCfg != nil {
+				slog.Info("Portable mode: paths resolved",
+					"prompts", f.prompts,
+					"output", f.output,
+					"criteria", f.criteriaDir,
+					"project_config", projectCfg.ConfigPath,
+				)
+			}
 
 			// Load config(s)
 			var cfgFile *config.ConfigFile
@@ -508,6 +594,7 @@ func runCmd() *cobra.Command {
 				BuildTimeout:     time.Duration(f.buildTimeout) * time.Second,
 				ReviewTimeout:    time.Duration(f.reviewTimeout) * time.Second,
 				OutputDir:        f.output,
+				CriteriaDir:     f.criteriaDir,
 				SkipTests:        f.skipTests,
 				SkipReview:       f.skipReview,
 				VerifyBuild:      f.verifyBuild,
@@ -690,6 +777,7 @@ func configsCmd() *cobra.Command {
 
 func validateCmd() *cobra.Command {
 	var promptsDir string
+	var configDir string
 
 	cmd := &cobra.Command{
 		Use:   "validate",
@@ -729,8 +817,12 @@ func validateCmd() *cobra.Command {
 				allOK = false
 			}
 
-			// Validate config files
-			configDir := filepath.Join(filepath.Dir(promptsDir), "configs")
+			// Validate config files — use project config if available, else infer from prompts dir
+			configDir := resolveConfigDir(cmd)
+			if _, statErr := os.Stat(configDir); statErr != nil {
+				// Fall back to legacy behavior: sibling to prompts dir
+				configDir = filepath.Join(filepath.Dir(promptsDir), "configs")
+			}
 			if entries, err := os.ReadDir(configDir); err == nil {
 				configCount := 0
 				configErrors := 0
@@ -764,6 +856,7 @@ func validateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&promptsDir, "prompts", "./prompts", "Path to prompt library directory")
+	cmd.Flags().StringVar(&configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Makes hyoka portable so it can run from any repository, not just the hyoka repo itself. Teams can create their own `prompts/` and `configs/` directories, add a `hyoka.yaml` project config file, and run evaluations from their repo root.

## Changes

### New: `internal/project` package
- `Config` type with `prompts_dir`, `configs_dir`, `skills_dir`, `criteria_dir`, `reports_dir` fields
- `Load(path)` — reads and parses an explicit project config file
- `Discover(startDir)` — walks up from CWD to find `hyoka.yaml` or `.hyoka.yaml`
- All relative paths resolved against the config file's directory
- 14 tests covering load, discover, walk-up, priority, partial configs, nil safety

### Updated: CLI flags & path resolution
- New `--project-config` persistent flag (auto-discovered if not specified)
- New `--criteria-dir` flag for criteria file discovery
- `resolveWithProjectConfig()` implements 3-tier priority: CLI flag → project config → candidate paths
- All resolve functions (`resolvePromptsDir`, `resolveConfigDir`, `resolveOutputDir`, `resolveSkillsDirs`) now consult project config
- `EngineOptions.CriteriaDir` added for forward compatibility
- `validateCmd` uses `resolveConfigDir()` instead of hardcoded path

### Backward compatible
Existing workflows without a project config file continue to work identically — `Discover()` returns nil and falls through to existing candidate-path logic.

### Example `hyoka.yaml`
```yaml
prompts_dir: my-prompts
configs_dir: eval-configs
skills_dir: skills
criteria_dir: criteria
reports_dir: reports
```

Closes #14