### PR TITLE
Fix MCP tools not registering with generator agent

### DIFF
--- a/configs/azure-mcp-codex.yaml
+++ b/configs/azure-mcp-codex.yaml
@@ -11,7 +11,7 @@ configs:
       azure:
         type: local
         command: npx
-        args: ["-y", "@azure/mcp@latest"]
+        args: ["-y", "@azure/mcp@latest", "server", "start"]
         tools: ["*"]
     reviewer_skill_directories:
       - "./skills/reviewer"

--- a/configs/azure-mcp-opus.yaml
+++ b/configs/azure-mcp-opus.yaml
@@ -11,7 +11,7 @@ configs:
       azure:
         type: local
         command: npx
-        args: ["-y", "@azure/mcp@latest"]
+        args: ["-y", "@azure/mcp@latest", "server", "start"]
         tools: ["*"]
     reviewer_skill_directories:
       - "./skills/reviewer"

--- a/configs/azure-mcp-sonnet.yaml
+++ b/configs/azure-mcp-sonnet.yaml
@@ -11,7 +11,7 @@ configs:
       azure:
         type: local
         command: npx
-        args: ["-y", "@azure/mcp@latest"]
+        args: ["-y", "@azure/mcp@latest", "server", "start"]
         tools: ["*"]
     reviewer_skill_directories:
       - "./skills/reviewer"

--- a/configs/example-full.yaml
+++ b/configs/example-full.yaml
@@ -31,7 +31,7 @@ configs:
         azure:
           type: local
           command: npx
-          args: ["-y", "@azure/mcp@latest"]
+          args: ["-y", "@azure/mcp@latest", "server", "start"]
           tools: ["*"]
 
       # Tool restrictions (optional — omit for all defaults)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,29 +57,157 @@ configs:
 
 When `models` lists multiple models, hyoka uses a **panel review** where all models review independently and the first model acts as consolidator to produce a consensus result.
 
-### Skill Types
+### Skills
+
+Skills are Copilot agent instructions packaged as directories containing a `SKILL.md` file. When attached to a generator or reviewer session, the agent receives the skill's content as additional context that guides its behavior.
+
+Skills can be attached to either the **generator** (code generation agent) or the **reviewer** (grading panel agents), or both. They are configured under the `generator.skills` and `reviewer.skills` fields respectively.
+
+#### Skill Types
+
+There are two ways to load skills: **local** (from the filesystem) and **remote** (fetched from a GitHub repository).
+
+##### Local Skills
+
+Local skills reference a directory on disk. Paths can be absolute or relative to the config file's directory.
 
 ```yaml
-skills:
-  # Local skill from filesystem
-  - type: local
-    path: ../skills/generator
-
-  # Remote skill from GitHub
-  - type: remote
-    repo: github.com/Azure/ai-hub-sdk
-    name: azure-sdk-tools
+generator:
+  model: claude-opus-4.6
+  skills:
+    - type: local
+      path: ./skills/generator
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | yes | Must be `"local"` |
+| `path` | yes | Path to a skill directory (absolute or relative) |
+
+**Glob patterns** are supported, letting you load multiple skill directories at once. Only directories are included — files are filtered out.
+
+```yaml
+generator:
+  skills:
+    # Loads every subdirectory under ./skills/generator/
+    - type: local
+      path: "./skills/generator/*"
+```
+
+For example, if `./skills/reviewer/` contains three subdirectories (`code-review-comments/`, `reviewer-build/`, `sdk-version-check/`), the pattern `./skills/reviewer/*` expands to all three.
+
+##### Remote Skills
+
+Remote skills are fetched from a GitHub repository using `npx skills add`. They are cached locally under `.skills-cache/` so subsequent runs don't re-download.
+
+```yaml
+generator:
+  model: claude-sonnet-4.5
+  skills:
+    - type: remote
+      name: azure-keyvault-py
+      repo: microsoft/skills
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | yes | Must be `"remote"` |
+| `repo` | yes | GitHub repository in `owner/repo` format |
+| `name` | no | Specific skill name within the repo |
+
+Under the hood, hyoka runs:
+
+```
+npx skills add <repo> --directory .skills-cache/<repo>/<name> [--name <name>]
+```
+
+#### Generator vs Reviewer Skills
+
+- **Generator skills** guide the code generation agent — for example, providing SDK usage patterns, coding conventions, or language-specific best practices.
+- **Reviewer skills** guide the review panel agents — for example, instructing them to add inline review comments or verify builds.
+
+```yaml
+configs:
+  - name: my-eval/claude-opus-4.6
+    generator:
+      model: claude-opus-4.6
+      skills:
+        - type: local
+          path: ./skills/generator
+        - type: remote
+          name: azure-keyvault-py
+          repo: microsoft/skills
+    reviewer:
+      models:
+        - claude-opus-4.6
+        - gpt-4.1
+      skills:
+        - type: local
+          path: "./skills/reviewer/*"
+```
+
+#### Skill Directory Structure
+
+Each skill is a directory containing at minimum a `SKILL.md` file:
+
+```
+skills/
+├── generator/
+│   └── my-sdk-skill/
+│       └── SKILL.md        # Instructions for the generator agent
+└── reviewer/
+    ├── code-review-comments/
+    │   └── SKILL.md        # Adds inline REVIEW: comments
+    ├── reviewer-build/
+    │   └── SKILL.md        # Verifies generated code builds
+    └── sdk-version-check/
+        └── SKILL.md        # Checks SDK package versions
+```
+
+The `SKILL.md` file contains markdown instructions that the Copilot agent receives as context during its session.
+
+#### Legacy Skill Format
+
+Older configs use flat `skill_directories`, `generator_skill_directories`, or `reviewer_skill_directories` fields. These are automatically normalized to the unified `skills` list at load time:
+
+```yaml
+# Legacy format (still supported)
+configs:
+  - name: old-style
+    model: claude-opus-4.6
+    skill_directories:              # → generator.skills (type: local)
+      - ../skills/generator
+    reviewer_skill_directories:     # → reviewer.skills (type: local)
+      - ../skills/reviewer
+```
+
+The precedence for legacy migration is:
+
+1. `generator_skill_directories` → `generator.skills`
+2. If absent, `skill_directories` → `generator.skills`
+3. `reviewer_skill_directories` → `reviewer.skills`
+
+New configs should use the structured `generator.skills` / `reviewer.skills` format.
 
 ### MCP Servers
 
 ```yaml
 mcp_servers:
   azure:
-    type: sse
+    type: local
     command: npx
-    args: ["-y", "@azure/mcp@latest"]
+    args: ["-y", "@azure/mcp@latest", "server", "start"]
+    tools: ["*"]
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | yes | `"local"` (stdio) or `"sse"` / `"http"` (remote) |
+| `command` | yes | Command to launch the MCP server |
+| `args` | no | Arguments passed to the command |
+| `tools` | no | Tool filter — `["*"]` for all tools, or a list of specific tool names |
+
+> **Important:** The `tools` field must be set (typically `["*"]`) for the MCP server's tools to be registered with the agent. Without it, the server starts but its tools won't be available.
 
 ## Legacy Format
 
@@ -94,7 +222,7 @@ configs:
       - ../skills/generator
 ```
 
-Legacy fields are normalized to the structured `generator`/`reviewer` format at load time.
+Legacy fields (`model`, `reviewer_model`, `reviewer_models`, `skill_directories`, `generator_skill_directories`, `reviewer_skill_directories`, `mcp_servers`, `available_tools`, `excluded_tools`) are automatically normalized to the structured `generator`/`reviewer` format at load time. See the [Skills > Legacy Skill Format](#legacy-skill-format) section for details on how skill directories are migrated.
 
 ## Multiple Config Files
 

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -473,7 +473,12 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		}
 	}
 
-	slog.Info("Creating Copilot session", "model", cfg.EffectiveModel(), "skills", len(sessionCfg.SkillDirectories), "work_dir", workDir)
+	slog.Info("Creating Copilot session",
+		"model", cfg.EffectiveModel(),
+		"skills", len(sessionCfg.SkillDirectories),
+		"mcp_servers", len(sessionCfg.MCPServers),
+		"work_dir", workDir,
+	)
 	session, err := client.CreateSession(genCtx, sessionCfg)
 	if err != nil {
 		return &EvalResult{
@@ -721,12 +726,25 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 	if len(mcpServers) > 0 {
 		sc.MCPServers = make(map[string]copilot.MCPServerConfig, len(mcpServers))
 		for name, srv := range mcpServers {
-			sc.MCPServers[name] = copilot.MCPServerConfig{
+			mcpCfg := copilot.MCPServerConfig{
 				"type":    srv.Type,
 				"command": srv.Command,
 				"args":    srv.Args,
 			}
+			if len(srv.Tools) > 0 {
+				mcpCfg["tools"] = srv.Tools
+			}
+			sc.MCPServers[name] = mcpCfg
+			slog.Info("MCP server configured",
+				"name", name,
+				"type", srv.Type,
+				"command", srv.Command,
+				"args", srv.Args,
+				"tools", srv.Tools,
+			)
 		}
+	} else {
+		slog.Debug("No MCP servers configured")
 	}
 
 	return sc

--- a/prompts/storage/data-plane/python/mcp-best-practices.prompt.md
+++ b/prompts/storage/data-plane/python/mcp-best-practices.prompt.md
@@ -1,0 +1,52 @@
+---
+id: storage-dp-python-mcp-best-practices
+service: storage
+plane: data-plane
+language: python
+category: best-practices
+difficulty: basic
+description: >
+  Can the agent use the Azure MCP best practices tool
+  to generate Azure Blob Storage code following official guidance?
+sdk_package: azure-storage-blob
+tags:
+  - mcp
+  - best-practices
+  - getting-started
+created: 2026-04-02
+author: ronniegeraghty
+---
+
+# Azure Blob Storage Best Practices (Python)
+
+## Prompt
+
+Before writing any code, you MUST use the Azure MCP tools available in your
+environment to look up Azure best practices for code generation. Look for a
+tool related to Azure best practices (it may be named something like
+`get_azure_bestpractices_get` or similar) and call it first.
+
+Then, following the best practices returned by that tool, write a Python script
+that uploads a file to Azure Blob Storage and downloads it back.
+
+Requirements:
+- You MUST call an Azure best practices MCP tool first to get guidance before generating code. Do not skip this step.
+- Use `DefaultAzureCredential` from `azure-identity` for authentication.
+- Use the `azure-storage-blob` SDK package.
+- Include proper error handling with `HttpResponseError`.
+- Include a `requirements.txt` with pinned package versions.
+
+## Evaluation Criteria
+
+- Agent called an Azure best practices MCP tool before generating code
+- Uses `DefaultAzureCredential` for authentication
+- Uses `BlobServiceClient` from `azure.storage.blob`
+- Includes upload and download operations
+- Includes error handling with `HttpResponseError`
+- Includes `requirements.txt`
+
+## Context
+
+This prompt tests whether the agent properly utilizes the Azure MCP server's
+best practices tools when explicitly instructed to do so, ensuring MCP tool
+integration is working end-to-end.


### PR DESCRIPTION
## Problem

MCP server tools were not available to the generator agent during evaluations. The agent would report "I don't have any Azure MCP tools available" despite the `MCP servers loaded` event firing successfully.

## Root Cause

Two bugs:

### 1. Config args missing `server start`
The Azure MCP configs used `args: ["-y", "@azure/mcp@latest"]` which prints the CLI help and exits immediately. The MCP server needs `server start` appended to actually run in stdio mode.

### 2. `tools` field not passed to SDK
`buildSessionConfig()` in `copilot.go` was not passing `srv.Tools` to the SDK's `MCPServerConfig` map. Without the `"tools"` key (e.g., `["*"]`), the Copilot SDK starts the MCP server but doesn't register its tools with the agent.

## Fix

- **Config files**: Added `"server", "start"` to args in all 4 azure-mcp configs + example-full.yaml
- **copilot.go**: Pass `srv.Tools` into `MCPServerConfig` when non-empty
- **Logging**: Added `MCP server configured` log (INFO) with name, type, command, args, tools; added `mcp_servers` count to session creation log
- **Docs**: Expanded skills documentation in configuration.md; updated MCP Servers section with correct args, tools field docs, and importance note
- **Test prompt**: Added `storage-dp-python-mcp-best-practices` prompt that explicitly requires the agent to call `get_azure_bestpractices` before generating code

## Verification

Before fix — agent reports: *"I don't have any Azure MCP tools available"*

After fix — agent successfully calls MCP tools:
```
🔧 azure-get_azure_bestpractices           (discover available commands)
🔧 azure-get_azure_bestpractices → get     (fetch best practices)
📄 create → requirements.txt
📄 create → blob_upload_download.py
✅ 3 files, 54s
```

## Files Changed

| File | Change |
|------|--------|
| `configs/azure-mcp-*.yaml` (3) | Add `server start` to MCP args |
| `configs/example-full.yaml` | Add `server start` to MCP args |
| `hyoka/internal/eval/copilot.go` | Pass `tools` to SDK, add MCP logging |
| `docs/configuration.md` | Expand skills docs, fix MCP server docs |
| `prompts/.../mcp-best-practices.prompt.md` | New test prompt for MCP tool usage |
