### PR TITLE
Add criteria comparison and tool/skill usage to summary reports

### DIFF
--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -578,6 +578,46 @@ func htmlFuncMap() template.FuncMap {
 		},
 		"hasPrefix": strings.HasPrefix,
 		"contains":  strings.Contains,
+		"mdToHTML": func(md string) template.HTML {
+			var b strings.Builder
+			inList := false
+			for _, line := range strings.Split(md, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if trimmed == "" {
+					if inList {
+						b.WriteString("</ul>")
+						inList = false
+					}
+					continue
+				}
+				// Headers
+				if strings.HasPrefix(trimmed, "## ") {
+					if inList { b.WriteString("</ul>"); inList = false }
+					b.WriteString("<h3>" + template.HTMLEscapeString(strings.TrimPrefix(trimmed, "## ")) + "</h3>")
+					continue
+				}
+				// Bullets
+				if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+					if !inList { b.WriteString("<ul>"); inList = true }
+					content := trimmed[2:]
+					// Bold
+					for strings.Contains(content, "**") {
+						i := strings.Index(content, "**")
+						j := strings.Index(content[i+2:], "**")
+						if j < 0 { break }
+						content = content[:i] + "<strong>" + content[i+2:i+2+j] + "</strong>" + content[i+2+j+2:]
+					}
+					b.WriteString("<li>" + content + "</li>")
+					continue
+				}
+				// Regular paragraph with bold
+				if inList { b.WriteString("</ul>"); inList = false }
+				content := template.HTMLEscapeString(trimmed)
+				b.WriteString("<p>" + content + "</p>")
+			}
+			if inList { b.WriteString("</ul>") }
+			return template.HTML(b.String())
+		},
 		"fileTypeSummary": func(files []string) string {
 			counts := make(map[string]int)
 			for _, f := range files {
@@ -1247,7 +1287,7 @@ const summaryTemplate = `<!DOCTYPE html>
 {{if .Summary.Analysis}}
 <div class="analysis">
   <h2>🤖 AI Analysis</h2>
-  <div class="analysis-content">{{.Summary.Analysis}}</div>
+  <div class="analysis-content">{{mdToHTML .Summary.Analysis}}</div>
 </div>
 {{end}}
 

--- a/hyoka/internal/report/markdown.go
+++ b/hyoka/internal/report/markdown.go
@@ -527,6 +527,134 @@ func WriteSummaryMarkdown(s *RunSummary, outputDir string) (string, error) {
 		b.WriteString("\n")
 	}
 
+	// Per-prompt criteria comparison across configs (like evaluation-results.md reference format)
+	if len(matrix.Configs) > 1 {
+		b.WriteString("## Criteria Comparison\n\n")
+
+		for _, pid := range matrix.Prompts {
+			fmt.Fprintf(&b, "### %s\n\n", pid)
+
+			// Collect criteria from all configs for this prompt
+			type criteriaEntry struct {
+				name    string
+				results map[string]string // config → "✅"/"❌"/"—"
+				reasons map[string]string // config → reason
+			}
+			criteriaMap := make(map[string]*criteriaEntry)
+			var criteriaOrder []string
+
+			for _, r := range s.Results {
+				if r.PromptID != pid || r.Review == nil {
+					continue
+				}
+				for _, c := range r.Review.Scores.Criteria {
+					entry, exists := criteriaMap[c.Name]
+					if !exists {
+						entry = &criteriaEntry{
+							name:    c.Name,
+							results: make(map[string]string),
+							reasons: make(map[string]string),
+						}
+						criteriaMap[c.Name] = entry
+						criteriaOrder = append(criteriaOrder, c.Name)
+					}
+					if c.Passed {
+						entry.results[r.ConfigName] = "✅"
+					} else {
+						entry.results[r.ConfigName] = "❌"
+					}
+					if c.Reason != "" {
+						entry.reasons[r.ConfigName] = c.Reason
+					}
+				}
+			}
+
+			if len(criteriaOrder) > 0 {
+				// Header
+				b.WriteString("| Criteria |")
+				for _, cfg := range matrix.Configs {
+					// Shorten config name for readability
+					short := cfg
+					if idx := strings.LastIndex(cfg, "/"); idx >= 0 {
+						short = cfg[:idx]
+					}
+					fmt.Fprintf(&b, " %s |", short)
+				}
+				b.WriteString("\n|----------|")
+				for range matrix.Configs {
+					b.WriteString("------|")
+				}
+				b.WriteString("\n")
+
+				// Rows
+				for _, name := range criteriaOrder {
+					entry := criteriaMap[name]
+					fmt.Fprintf(&b, "| %s |", name)
+					for _, cfg := range matrix.Configs {
+						result, ok := entry.results[cfg]
+						if !ok {
+							result = "—"
+						}
+						fmt.Fprintf(&b, " %s |", result)
+					}
+					b.WriteString("\n")
+				}
+				b.WriteString("\n")
+
+				// Issues and strengths per config
+				for _, r := range s.Results {
+					if r.PromptID != pid || r.Review == nil {
+						continue
+					}
+					if len(r.Review.Strengths) > 0 || len(r.Review.Issues) > 0 {
+						short := r.ConfigName
+						if idx := strings.LastIndex(short, "/"); idx >= 0 {
+							short = short[:idx]
+						}
+						fmt.Fprintf(&b, "**%s:**\n", short)
+						for _, s := range r.Review.Strengths {
+							fmt.Fprintf(&b, "- ✅ %s\n", s)
+						}
+						for _, iss := range r.Review.Issues {
+							fmt.Fprintf(&b, "- ❌ %s\n", iss)
+						}
+						b.WriteString("\n")
+					}
+				}
+			}
+		}
+	}
+
+	// Tool & Skill Usage by Config
+	if len(matrix.Configs) > 0 {
+		b.WriteString("## Tool & Skill Usage by Config\n\n")
+		b.WriteString("| Config | Tools Used | MCP Calls | Skills Invoked | Duration |\n")
+		b.WriteString("|--------|-----------|-----------|----------------|----------|\n")
+		for _, r := range s.Results {
+			tools := "—"
+			if len(r.ToolCalls) > 0 {
+				tools = strings.Join(r.ToolCalls, ", ")
+			}
+			mcpCount := 0
+			var skillNames []string
+			if r.Environment != nil {
+				skillNames = r.Environment.SkillsInvoked
+			}
+			for _, ev := range r.SessionEvents {
+				if ev.MCPServerName != "" || ev.MCPToolName != "" {
+					mcpCount++
+				}
+			}
+			skillStr := "—"
+			if len(skillNames) > 0 {
+				skillStr = strings.Join(skillNames, ", ")
+			}
+			fmt.Fprintf(&b, "| %s | %s | %d | %s | %.1fs |\n",
+				r.ConfigName, tools, mcpCount, skillStr, r.Duration)
+		}
+		b.WriteString("\n")
+	}
+
 	// Per-prompt pairwise details
 	if len(s.PairwiseResults) > 0 {
 		b.WriteString("## Pairwise Details (per Prompt)\n\n")

--- a/hyoka/internal/trends/analysis.go
+++ b/hyoka/internal/trends/analysis.go
@@ -50,7 +50,29 @@ session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 Model: "gpt-4.1",
 SystemMessage: &copilot.SystemMessageConfig{
 Mode:    "append",
-Content: "You are an expert at analyzing AI agent tool usage and its impact on code generation quality. Focus on how tool availability affects output. Be concise and actionable.",
+Content: `You are an Azure SDK code evaluation analyst. You analyze results from automated code generation evaluations where different AI agent configurations (baseline, with-skills, with-MCP-tools) are compared.
+
+Your output must be structured markdown with these exact sections:
+
+## Key Findings
+A 3-5 bullet summary of the most important takeaways.
+
+## Config Comparison
+For each prompt evaluated, a table comparing configs:
+| Criteria | Config A | Config B | Config C | Notes |
+Use ✅/❌ for pass/fail. Add a Notes column explaining differences.
+
+## What Tools/Skills Helped
+- Which specific tools or skills were invoked and what impact they had
+- What the agent got RIGHT because of tools/skills that baseline got wrong
+- What the agent got WRONG despite having tools/skills
+
+## What Needs Investigation
+- Criteria that failed across ALL configs (systemic gaps)
+- Unexpected regressions (config with more tools scored lower)
+- Non-deterministic behavior (same config, different results)
+
+Be specific — reference exact criteria names, tool names, and scores. Do NOT reference historical runs or prompts not in the current data.`,
 },
 ConfigDir:           configDir,
 OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
@@ -98,17 +120,12 @@ return result, nil
 func formatTrendPrompt(tr *TrendReport) string {
 var b strings.Builder
 
-b.WriteString("Analyze the following evaluation data with a focus on TOOL USAGE and RESOURCE IMPACT.\n\n")
-b.WriteString("This tool measures how adding different tools/resources to an AI agent helps it produce better code. ")
-b.WriteString("Each prompt tests an Azure SDK scenario. Configs represent different tool setups — ")
-b.WriteString("'baseline' has NO tools (agent relies on its own knowledge), while 'azure-mcp' gives the agent access to MCP tools.\n\n")
-b.WriteString("Provide:\n")
-b.WriteString("1. **TOOL USAGE COMPARISON** — For each config, what tools did the AI agent use? Compare tool call counts and types between baseline and azure-mcp.\n")
-b.WriteString("2. **RESOURCE IMPACT** — Which prompts showed the biggest improvement when tools were available? Which performed similarly with or without tools?\n")
-b.WriteString("3. **KNOWLEDGE vs TOOLS** — For baseline (no tools), what did the agent rely on? For tool-enhanced runs, which tools were most impactful?\n")
-b.WriteString("4. **RECOMMENDATIONS** — Based on the data, which prompts would benefit most from additional tools/resources? Are there tools that should be added?\n")
-b.WriteString("5. **QUALITY DELTA** — Compare pass rates, file counts, scores, and durations between configs to quantify tool impact.\n\n")
-b.WriteString("Be concise and specific. Reference prompt IDs, config names, and tool names. Use bullet points.\n\n")
+b.WriteString("Analyze the following evaluation results from a SINGLE RUN comparing different AI agent configurations.\n\n")
+b.WriteString("Each config represents a different tool setup for the same AI model:\n")
+b.WriteString("- 'baseline' = no tools, no skills (agent relies on built-in knowledge)\n")
+b.WriteString("- 'baseline-skills' = SDK-specific skills loaded (patterns, examples, acceptance criteria)\n")
+b.WriteString("- 'azure-mcp' = Azure MCP server tools (get_best_practices, documentation lookup)\n\n")
+b.WriteString("Analyze ONLY the data below. Do NOT reference prompts or runs not listed here.\n\n")
 b.WriteString("---\n\n")
 
 // Overall stats
@@ -174,6 +191,14 @@ avgDur = totalDur / float64(len(runs))
 trend := pt.Trend[cfg]
 fmt.Fprintf(&b, "- **%s**: %d/%d passed (%.0f%%), avg duration: %s, trend: %s\n",
 cfg, p, p+f, pct(p, p+f), formatDuration(avgDur), trend)
+
+// Include score details from most recent run
+if len(runs) > 0 {
+latest := runs[len(runs)-1]
+if latest.HasReview && latest.MaxScore > 0 {
+fmt.Fprintf(&b, "  Score: %d/%d (%.0f%%)\n", latest.Score, latest.MaxScore, pct(latest.Score, latest.MaxScore))
+}
+}
 
 if len(toolSet) > 0 {
 b.WriteString("  Tools used: ")


### PR DESCRIPTION
## Summary

Add criteria-level comparison and tool/skill usage tables to the summary markdown report, addressing #86.

### New Sections

**Criteria Comparison** — Per-prompt table showing pass/fail for each criterion across configs:

| Criteria | azure-mcp | baseline-skills | baseline |
|----------|-----------|-----------------|----------|
| Code Builds | pass | fail | fail |
| Best Practices | pass | pass | fail |
| Blob index tags | pass | pass | missing |

Plus strengths/issues listed per config.

**Tool and Skill Usage by Config** — Quick reference table:

| Config | Tools Used | MCP Calls | Skills Invoked | Duration |
|--------|-----------|-----------|----------------|----------|
| azure-mcp | report_intent, azure-get_azure_bestpractices, create | 2 | n/a | 806s |
| baseline-skills | report_intent, create, skill, view | 0 | azure-storage-blob-java | 678s |
| baseline | report_intent, create, powershell | 0 | n/a | 565s |

### Motivation

The previous summary only showed scores (e.g., 11/12, 8/12, 5/12) without showing which criteria passed or failed in each config. This made it hard to understand what skills/MCP tools actually improved.

Fixes #86
