### PR TITLE
fix: correct stale path in new-prompt command (#93)

### DIFF
--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -1169,7 +1169,7 @@ TODO: Why this prompt matters.
 			fmt.Printf("   Prompt ID: %s\n", id)
 			fmt.Println("\nNext steps:")
 			fmt.Println("  1. Edit the file to add your prompt text")
-			fmt.Println("  2. Run: go run ./tool/cmd/hyoka validate")
+			fmt.Println("  2. Run: go run ./hyoka validate")
 			return nil
 		},
 	}


### PR DESCRIPTION
Fixes #93 — Updated stale `go run ./tool/cmd/hyoka validate` reference to `go run ./hyoka validate` in the new-prompt command output.