### PR TITLE
fix: validate generator.model is not empty (#94)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -123,6 +123,10 @@ func (cf *ConfigFile) Validate() error {
 		if c.Name == "" {
 			return fmt.Errorf("config at index %d has no name", i)
 		}
+		// Generator with a model is required for every config.
+		if c.Generator == nil || c.Generator.Model == "" {
+			return fmt.Errorf("config %q: generator.model is required", c.Name)
+		}
 		// Validate generator/reviewer skills have correct type
 		if c.Generator != nil {
 			for _, s := range c.Generator.Skills {

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -553,3 +553,35 @@ func TestGeneratorModelDirectAccess(t *testing.T) {
 		t.Errorf("expected 'new-model', got %q", c.Generator.Model)
 	}
 }
+
+func TestValidateRejectsNilGenerator(t *testing.T) {
+	cf := &ConfigFile{
+		Configs: []ToolConfig{
+			{Name: "no-gen"},
+		},
+	}
+	err := cf.Validate()
+	if err == nil {
+		t.Fatal("expected error for nil generator")
+	}
+	want := `config "no-gen": generator.model is required`
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
+	cf := &ConfigFile{
+		Configs: []ToolConfig{
+			{Name: "empty-model", Generator: &GeneratorConfig{Model: ""}},
+		},
+	}
+	err := cf.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty generator model")
+	}
+	want := `config "empty-model": generator.model is required`
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

Empty `Generator.Model` passed config validation but failed at runtime with a cryptic SDK error. This PR adds early validation in `ConfigFile.Validate()` so missing or empty generator models produce a clear error message:

```
config "my-config": generator.model is required
```

## Changes

- **`config.go`**: Added nil-generator and empty-model check before skill validation
- **`config_test.go`**: Added `TestValidateRejectsNilGenerator` and `TestValidateRejectsEmptyGeneratorModel`

Closes #94