### PR TITLE
fix: log discarded errors instead of silently dropping (#97)

### DIFF
--- a/hyoka/internal/build/verifier.go
+++ b/hyoka/internal/build/verifier.go
@@ -108,7 +108,7 @@ func buildCommands(lc *LanguageConfig, workDir string) []buildStep {
 		}
 	case "python":
 		var pyFiles []string
-		_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+		if err := filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return nil
 			}
@@ -122,7 +122,9 @@ func buildCommands(lc *LanguageConfig, workDir string) []buildStep {
 				pyFiles = append(pyFiles, path)
 			}
 			return nil
-		})
+		}); err != nil {
+			slog.Warn("Failed to walk directory for Python files", "dir", workDir, "error", err)
+		}
 		if len(pyFiles) == 0 {
 			return []buildStep{{Cmd: "python3", Args: []string{"-m", "py_compile", os.DevNull}}}
 		}
@@ -131,7 +133,7 @@ func buildCommands(lc *LanguageConfig, workDir string) []buildStep {
 		return []buildStep{{Cmd: "python3", Args: args}}
 	case "javascript":
 		var jsFiles []string
-		_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+		if err := filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return nil
 			}
@@ -145,7 +147,9 @@ func buildCommands(lc *LanguageConfig, workDir string) []buildStep {
 				jsFiles = append(jsFiles, path)
 			}
 			return nil
-		})
+		}); err != nil {
+			slog.Warn("Failed to walk directory for JavaScript files", "dir", workDir, "error", err)
+		}
 		if len(jsFiles) == 0 {
 			return []buildStep{{Cmd: "node", Args: []string{"--check", os.DevNull}}}
 		}

--- a/hyoka/internal/clean/clean.go
+++ b/hyoka/internal/clean/clean.go
@@ -5,6 +5,7 @@ package clean
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -316,7 +317,7 @@ func isHyokaSession(sessionPath string) bool {
 // dirSize returns the total size of all files in a directory tree.
 func dirSize(path string) int64 {
 	var size int64
-	_ = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+	if walkErr := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip inaccessible files but continue walk
 		}
@@ -324,7 +325,9 @@ func dirSize(path string) int64 {
 			size += info.Size()
 		}
 		return nil
-	})
+	}); walkErr != nil {
+		slog.Warn("Failed to walk directory for size calculation", "path", path, "error", walkErr)
+	}
 	return size
 }
 

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -88,7 +88,11 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		if err := copyDir(starterDir, workDir); err != nil {
 			return nil, fmt.Errorf("copying starter project: %w", err)
 		}
-		starterFiles, _ = listFiles(workDir)
+		var listErr error
+		starterFiles, listErr = listFiles(workDir)
+		if listErr != nil {
+			slog.Warn("Failed to list starter files", "dir", workDir, "error", listErr)
+		}
 	}
 
 	// Create Copilot client
@@ -534,7 +538,10 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		// post-generation guardrail in engine.go can mark the eval as failed
 		// with a proper reason instead of treating it as an SDK error.
 		if actionLimitHit {
-			generatedFiles, _ := listFiles(workDir)
+			generatedFiles, listErr := listFiles(workDir)
+			if listErr != nil {
+				lg.Warn("Failed to list generated files after action-limit", "dir", workDir, "error", listErr)
+			}
 			lg.Warn("Returning partial results after action-limit cancellation",
 				"actions", actionCounter, "files", len(generatedFiles))
 			return &EvalResult{
@@ -564,7 +571,10 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 	copy(capturedRecords, sessionRecords)
 	mu.Unlock()
 
-	generatedFiles, _ := listFiles(workDir)
+	generatedFiles, listErr := listFiles(workDir)
+	if listErr != nil {
+		lg.Warn("Failed to list generated files", "dir", workDir, "error", listErr)
+	}
 	toolCalls := extractToolCalls(capturedEvents)
 	hasError := hasSessionError(capturedEvents)
 

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -665,7 +665,10 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		lg.Warn("Failed to copy generated files to report dir", "error", err)
 	}
 
-	generatedFiles, _ := ws.ListFiles()
+	generatedFiles, listErr := ws.ListFiles()
+	if listErr != nil {
+		lg.Warn("Failed to list workspace files", "error", listErr)
+	}
 	if len(generatedFiles) == 0 && result != nil && len(result.GeneratedFiles) > 0 {
 		generatedFiles = result.GeneratedFiles
 	}

--- a/hyoka/internal/prompt/loader.go
+++ b/hyoka/internal/prompt/loader.go
@@ -74,7 +74,7 @@ func ScanNearMisses(dir string) []string {
 	var nearMisses []string
 	seen := make(map[string]bool)
 
-	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	if walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -85,7 +85,10 @@ func ScanNearMisses(dir string) []string {
 			return nil
 		}
 
-		rel, _ := filepath.Rel(dir, path)
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			slog.Warn("Failed to compute relative path", "dir", dir, "path", path, "error", relErr)
+		}
 		if rel == "" {
 			rel = name
 		}
@@ -121,7 +124,9 @@ func ScanNearMisses(dir string) []string {
 		}
 
 		return nil
-	})
+	}); walkErr != nil {
+		slog.Warn("Failed to walk directory for near-miss prompts", "dir", dir, "error", walkErr)
+	}
 
 	return nearMisses
 }

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -336,7 +336,11 @@ func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, 
 
 	var referenceFiles map[string]string
 	if referenceDir != "" {
-		referenceFiles, _ = utils.ReadDirFiles(referenceDir)
+		var readErr error
+		referenceFiles, readErr = utils.ReadDirFiles(referenceDir)
+		if readErr != nil {
+			slog.Warn("Failed to read reference files", "dir", referenceDir, "error", readErr)
+		}
 	}
 
 	reviewPrompt := BuildReviewPrompt(originalPrompt, generatedFiles, referenceFiles, evaluationCriteria)

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -65,7 +65,10 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 				continue
 			}
 			if info.IsDir() {
-				abs, _ := filepath.Abs(m)
+				abs, absErr := filepath.Abs(m)
+				if absErr != nil {
+					slog.Warn("Failed to resolve absolute path", "path", m, "error", absErr)
+				}
 				dirs = append(dirs, abs)
 			}
 		}
@@ -79,13 +82,19 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 	}
 	for _, c := range candidates {
 		if info, err := os.Stat(c); err == nil && info.IsDir() {
-			abs, _ := filepath.Abs(c)
+			abs, absErr := filepath.Abs(c)
+			if absErr != nil {
+				slog.Warn("Failed to resolve absolute path", "path", c, "error", absErr)
+			}
 			return []string{abs}, nil
 		}
 	}
 
 	// Path doesn't exist yet — return absolute form anyway
-	abs, _ := filepath.Abs(path)
+	abs, absErr := filepath.Abs(path)
+	if absErr != nil {
+		slog.Warn("Failed to resolve absolute path", "path", path, "error", absErr)
+	}
 	return []string{abs}, nil
 }
 
@@ -117,6 +126,9 @@ func fetchRemote(s config.Skill, baseDir string) (string, error) {
 		return "", fmt.Errorf("npx skills add: %w", err)
 	}
 
-	abs, _ := filepath.Abs(installDir)
+	abs, absErr := filepath.Abs(installDir)
+	if absErr != nil {
+		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
+	}
 	return abs, nil
 }

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -222,7 +222,10 @@ func resolveConfigSkillDirs(configs []config.ToolConfig, promptsDir string) {
 				}
 				for _, c := range candidates {
 					if info, err := os.Stat(c); err == nil && info.IsDir() {
-						abs, _ := filepath.Abs(c)
+						abs, absErr := filepath.Abs(c)
+						if absErr != nil {
+							slog.Warn("Failed to resolve absolute skill path", "path", c, "error", absErr)
+						}
 						skills[j].Path = abs
 						break
 					}


### PR DESCRIPTION
## Summary

Added `slog.Warn` calls for all silently discarded errors across the codebase. No control flow changes — just diagnostic visibility.

## Changes

| File | Locations | What was discarded |
|------|-----------|--------------------|
| `review/reviewer.go` | 1 | `utils.ReadDirFiles` error |
| `eval/copilot.go` | 3 | `listFiles` errors (starter, action-limit, final) |
| `eval/engine.go` | 1 | `ws.ListFiles` error |
| `main.go` | 1 | `filepath.Abs` error |
| `skills/fetcher.go` | 4 | `filepath.Abs` errors |
| `build/verifier.go` | 2 | `filepath.WalkDir` errors (Python, JS) |
| `prompt/loader.go` | 2 | `filepath.Walk` + `filepath.Rel` errors |
| `clean/clean.go` | 1 | `filepath.Walk` error in `dirSize` |

**Total: 15 locations across 8 files**

## Testing

- `go build ./hyoka/...` ✅
- `go vet ./hyoka/...` ✅
- `go test ./hyoka/...` ✅ (pre-existing config test failure unrelated)

Closes #97