### PR TITLE
fix: detect duplicate config names (#95)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -80,6 +80,7 @@ return nil, fmt.Errorf("reading config directory %s: %w", dir, err)
 }
 
 merged := &ConfigFile{}
+nameSource := make(map[string]string) // config name → source filename
 for _, e := range entries {
 if e.IsDir() || (filepath.Ext(e.Name()) != ".yaml" && filepath.Ext(e.Name()) != ".yml") {
 continue
@@ -87,6 +88,12 @@ continue
 cf, err := Load(filepath.Join(dir, e.Name()))
 if err != nil {
 return nil, fmt.Errorf("loading %s: %w", e.Name(), err)
+}
+for _, c := range cf.Configs {
+if prev, ok := nameSource[c.Name]; ok {
+return nil, fmt.Errorf("duplicate config name %q found in files %s and %s", c.Name, prev, e.Name())
+}
+nameSource[c.Name] = e.Name()
 }
 merged.Configs = append(merged.Configs, cf.Configs...)
 }
@@ -119,6 +126,7 @@ func (cf *ConfigFile) Validate() error {
 	if len(cf.Configs) == 0 {
 		return fmt.Errorf("no configs defined")
 	}
+	namesSeen := make(map[string]int, len(cf.Configs))
 	for i, c := range cf.Configs {
 		if c.Name == "" {
 			return fmt.Errorf("config at index %d has no name", i)
@@ -127,6 +135,10 @@ func (cf *ConfigFile) Validate() error {
 		if c.Generator == nil || c.Generator.Model == "" {
 			return fmt.Errorf("config %q: generator.model is required", c.Name)
 		}
+		if prev, ok := namesSeen[c.Name]; ok {
+			return fmt.Errorf("duplicate config name %q at index %d and %d", c.Name, prev, i)
+		}
+		namesSeen[c.Name] = i
 		// Validate generator/reviewer skills have correct type
 		if c.Generator != nil {
 			for _, s := range c.Generator.Skills {

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -540,6 +541,59 @@ _, err := Parse(data)
 if err == nil {
 t.Fatal("expected error for remote skill without repo")
 }
+}
+
+func TestParseDuplicateConfigNamesRejected(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: same-name
+    description: "First"
+    generator:
+      model: "gpt-4"
+  - name: same-name
+    description: "Second"
+    generator:
+      model: "claude-sonnet-4.5"
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate config names within a file")
+	}
+	if got := err.Error(); !strings.Contains(got, "duplicate config name") {
+		t.Errorf("expected duplicate config name error, got: %v", err)
+	}
+}
+
+func TestLoadDirDuplicateConfigNamesAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	file1 := []byte(`
+configs:
+  - name: shared-name
+    description: "In file1"
+    generator:
+      model: "gpt-4"
+`)
+	file2 := []byte(`
+configs:
+  - name: shared-name
+    description: "In file2"
+    generator:
+      model: "claude-sonnet-4.5"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), file1, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.yaml"), file2, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("expected error for duplicate config names across files")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "duplicate config name") || !strings.Contains(got, "a.yaml") || !strings.Contains(got, "b.yaml") {
+		t.Errorf("expected error mentioning duplicate name and both files, got: %v", err)
+	}
 }
 
 func TestGeneratorModelDirectAccess(t *testing.T) {


### PR DESCRIPTION
Two configs with the same `name:` field silently shadowed each other — the second config became inaccessible via `--config`.

## Changes

- **`Validate()`**: Detects duplicate config names within a single config file
- **`LoadDir()`**: Detects duplicate config names across files, with an error message that includes both filenames

## Tests

- `TestParseDuplicateConfigNamesRejected` — within-file duplicates
- `TestLoadDirDuplicateConfigNamesAcrossFiles` — cross-file duplicates

Closes #95