### PR TITLE
feat: add YAML prompt format support (#109, #110)

### DIFF
--- a/hyoka/internal/prompt/loader.go
+++ b/hyoka/internal/prompt/loader.go
@@ -9,9 +9,17 @@ import (
 	"strings"
 )
 
-// LoadPrompts walks the directory tree at root and loads all .prompt.md files.
-// Returns an error if the directory contains zero valid prompts, along with
-// near-miss suggestions for files that almost match the naming pattern.
+// isPromptFile returns true if the filename matches a supported prompt extension.
+func isPromptFile(name string) bool {
+	return strings.HasSuffix(name, ".prompt.md") ||
+		strings.HasSuffix(name, ".prompt.yaml") ||
+		strings.HasSuffix(name, ".prompt.yml")
+}
+
+// LoadPrompts walks the directory tree at root and loads all prompt files
+// (.prompt.md, .prompt.yaml, .prompt.yml). Returns an error if the directory
+// contains zero valid prompts, along with near-miss suggestions for files that
+// almost match the naming pattern.
 func LoadPrompts(root string) ([]*Prompt, error) {
 	slog.Debug("Scanning for prompts", "root", root)
 	var prompts []*Prompt
@@ -23,7 +31,8 @@ func LoadPrompts(root string) ([]*Prompt, error) {
 		if info.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(info.Name(), ".prompt.md") {
+		name := info.Name()
+		if !isPromptFile(name) {
 			return nil
 		}
 
@@ -32,7 +41,12 @@ func LoadPrompts(root string) ([]*Prompt, error) {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		p, err := ParsePromptFile(data, path)
+		var p *Prompt
+		if strings.HasSuffix(name, ".prompt.yaml") || strings.HasSuffix(name, ".prompt.yml") {
+			p, err = ParsePromptYAML(data, path)
+		} else {
+			p, err = ParsePromptFile(data, path)
+		}
 		if err != nil {
 			return err
 		}
@@ -80,8 +94,8 @@ func ScanNearMisses(dir string) []string {
 		}
 		name := info.Name()
 
-		// Skip files that already match the correct pattern
-		if strings.HasSuffix(name, ".prompt.md") {
+		// Skip files that already match a correct prompt pattern
+		if isPromptFile(name) {
 			return nil
 		}
 
@@ -102,8 +116,8 @@ func ScanNearMisses(dir string) []string {
 			return nil
 		}
 
-		// Pattern: *.prompt.txt or *.prompt.* (right base, wrong extension)
-		if strings.Contains(name, ".prompt.") && !strings.HasSuffix(name, ".prompt.md") {
+		// Pattern: *.prompt.txt or other unsupported extensions
+		if strings.Contains(name, ".prompt.") && !isPromptFile(name) {
 			if !seen[rel] {
 				seen[rel] = true
 				nearMisses = append(nearMisses, rel)

--- a/hyoka/internal/prompt/loader_test.go
+++ b/hyoka/internal/prompt/loader_test.go
@@ -274,3 +274,145 @@ func containsSubstring(s, sub string) bool {
 	}
 	return false
 }
+
+const testYAMLPromptContent = `id: storage-auth-dotnet
+service: storage
+plane: data-plane
+language: dotnet
+category: authentication
+difficulty: beginner
+description: "Authenticate to Azure Blob Storage using DefaultAzureCredential"
+sdk_package: Azure.Storage.Blobs
+doc_url: https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs
+tags:
+  - authentication
+  - blob
+  - identity
+created: "2024-01-15"
+author: test
+expected_packages:
+  - Azure.Storage.Blobs
+  - Azure.Identity
+expected_tools:
+  - create_file
+  - run_terminal_command
+prompt_text: |
+  Write a C# console application that authenticates to Azure Blob Storage
+  using DefaultAzureCredential and lists all containers in the storage account.
+evaluation_criteria: |
+  Must use DefaultAzureCredential from Azure.Identity.
+`
+
+func TestParsePromptYAML(t *testing.T) {
+p, err := ParsePromptYAML([]byte(testYAMLPromptContent), "test.prompt.yaml")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+if p.ID != "storage-auth-dotnet" {
+t.Errorf("expected ID 'storage-auth-dotnet', got %q", p.ID)
+}
+if p.Service != "storage" {
+t.Errorf("expected service 'storage', got %q", p.Service)
+}
+if p.Plane != "data-plane" {
+t.Errorf("expected plane 'data-plane', got %q", p.Plane)
+}
+if p.Language != "dotnet" {
+t.Errorf("expected language 'dotnet', got %q", p.Language)
+}
+if p.Category != "authentication" {
+t.Errorf("expected category 'authentication', got %q", p.Category)
+}
+if p.Difficulty != "beginner" {
+t.Errorf("expected difficulty 'beginner', got %q", p.Difficulty)
+}
+if p.SDKPackage != "Azure.Storage.Blobs" {
+t.Errorf("expected sdk_package 'Azure.Storage.Blobs', got %q", p.SDKPackage)
+}
+if len(p.Tags) != 3 {
+t.Errorf("expected 3 tags, got %d", len(p.Tags))
+}
+if len(p.ExpectedPkgs) != 2 {
+t.Errorf("expected 2 expected_packages, got %d", len(p.ExpectedPkgs))
+}
+if len(p.ExpectedTools) != 2 {
+t.Errorf("expected 2 expected_tools, got %d", len(p.ExpectedTools))
+}
+if p.PromptText == "" {
+t.Error("expected non-empty prompt text")
+}
+if p.EvaluationCriteria == "" {
+t.Error("expected non-empty evaluation criteria")
+}
+if p.FilePath != "test.prompt.yaml" {
+t.Errorf("expected file path 'test.prompt.yaml', got %q", p.FilePath)
+}
+}
+
+func TestParsePromptYAMLMissingID(t *testing.T) {
+content := []byte("service: storage\nprompt_text: hello\n")
+_, err := ParsePromptYAML(content, "no-id.prompt.yaml")
+if err == nil {
+t.Fatal("expected error for missing ID")
+}
+}
+
+func TestParsePromptYAMLInvalidField(t *testing.T) {
+content := []byte("id: test\nunknown_field: bad\nprompt_text: hello\n")
+_, err := ParsePromptYAML(content, "bad.prompt.yaml")
+if err == nil {
+t.Fatal("expected error for unknown field with KnownFields(true)")
+}
+}
+
+func TestLoadPromptsYAML(t *testing.T) {
+dir := t.TempDir()
+subDir := filepath.Join(dir, "storage", "data-plane", "dotnet")
+if err := os.MkdirAll(subDir, 0755); err != nil {
+t.Fatalf("failed to create dir: %v", err)
+}
+
+if err := os.WriteFile(filepath.Join(subDir, "auth.prompt.yaml"), []byte(testYAMLPromptContent), 0644); err != nil {
+t.Fatalf("failed to write file: %v", err)
+}
+
+prompts, err := LoadPrompts(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(prompts) != 1 {
+t.Fatalf("expected 1 prompt, got %d", len(prompts))
+}
+if prompts[0].ID != "storage-auth-dotnet" {
+t.Errorf("expected ID 'storage-auth-dotnet', got %q", prompts[0].ID)
+}
+}
+
+func TestLoadPromptsMixed(t *testing.T) {
+dir := t.TempDir()
+if err := os.WriteFile(filepath.Join(dir, "md.prompt.md"), []byte(testPromptContent), 0644); err != nil {
+t.Fatalf("failed to write md file: %v", err)
+}
+if err := os.WriteFile(filepath.Join(dir, "yaml.prompt.yml"), []byte(testYAMLPromptContent), 0644); err != nil {
+t.Fatalf("failed to write yaml file: %v", err)
+}
+
+prompts, err := LoadPrompts(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(prompts) != 2 {
+t.Fatalf("expected 2 prompts (md + yaml), got %d", len(prompts))
+}
+}
+
+func TestScanNearMissesIgnoresYAMLPrompts(t *testing.T) {
+dir := t.TempDir()
+os.WriteFile(filepath.Join(dir, "auth.prompt.yaml"), []byte("id: x\nprompt_text: hello\n"), 0644)
+misses := ScanNearMisses(dir)
+if len(misses) != 0 {
+t.Errorf("expected 0 near misses for .prompt.yaml file, got %d", len(misses))
+}
+}
+

--- a/hyoka/internal/prompt/parser.go
+++ b/hyoka/internal/prompt/parser.go
@@ -13,6 +13,7 @@ var promptSectionRe = regexp.MustCompile(`(?m)^## Prompt\s*\n`)
 var evaluationCriteriaRe = regexp.MustCompile(`(?m)^## Evaluation Criteria\s*\n`)
 
 // ParsePromptFile parses a .prompt.md file's content into a Prompt struct.
+// For .prompt.yaml/.prompt.yml files, use ParsePromptYAML instead.
 func ParsePromptFile(content []byte, filePath string) (*Prompt, error) {
 text := string(content)
 
@@ -63,4 +64,35 @@ return nil, fmt.Errorf("prompt missing required 'id' field: %s", filePath)
 }
 
 return &p, nil
+}
+
+// yamlPromptFile is used internally to parse .prompt.yaml files where
+// prompt_text and evaluation_criteria are YAML fields rather than Markdown sections.
+type yamlPromptFile struct {
+Prompt                  `yaml:",inline"`
+PromptTextField         string `yaml:"prompt_text"`
+EvaluationCriteriaField string `yaml:"evaluation_criteria"`
+}
+
+// ParsePromptYAML parses a pure YAML prompt file (.prompt.yaml or .prompt.yml)
+// into a Prompt struct. All fields including prompt_text and evaluation_criteria
+// are expressed as top-level YAML keys.
+func ParsePromptYAML(content []byte, filePath string) (*Prompt, error) {
+var yf yamlPromptFile
+dec := yaml.NewDecoder(bytes.NewReader(content))
+dec.KnownFields(true)
+if err := dec.Decode(&yf); err != nil {
+return nil, fmt.Errorf("parsing YAML prompt %s: %w", filePath, err)
+}
+
+p := &yf.Prompt
+p.PromptText = yf.PromptTextField
+p.EvaluationCriteria = yf.EvaluationCriteriaField
+p.FilePath = filePath
+
+if p.ID == "" {
+return nil, fmt.Errorf("prompt missing required 'id' field: %s", filePath)
+}
+
+return p, nil
 }

--- a/hyoka/internal/prompt/types.go
+++ b/hyoka/internal/prompt/types.go
@@ -1,6 +1,7 @@
 package prompt
 
-// Prompt represents a parsed .prompt.md file with frontmatter metadata and prompt text.
+// Prompt represents a parsed prompt file (.prompt.md, .prompt.yaml, or .prompt.yml)
+// with metadata and prompt text.
 type Prompt struct {
 	ID              string            `yaml:"id" json:"id"`
 	Service         string            `yaml:"service" json:"service"`
@@ -21,10 +22,12 @@ type Prompt struct {
 	ExpectedPkgs    []string          `yaml:"expected_packages" json:"expected_packages,omitempty"`
 	ExpectedTools   []string          `yaml:"expected_tools" json:"expected_tools,omitempty"`
 
-	// The prompt text extracted from the ## Prompt section
+	// The prompt text: extracted from ## Prompt section (.prompt.md)
+	// or from the prompt_text field (.prompt.yaml/.prompt.yml)
 	PromptText string `yaml:"-" json:"prompt_text"`
 
-	// The evaluation criteria text extracted from the ## Evaluation Criteria section
+	// The evaluation criteria: extracted from ## Evaluation Criteria section (.prompt.md)
+	// or from the evaluation_criteria field (.prompt.yaml/.prompt.yml)
 	EvaluationCriteria string `yaml:"-" json:"evaluation_criteria,omitempty"`
 
 	// Source file path


### PR DESCRIPTION
## Summary

Add support for pure YAML prompt files (`.prompt.yaml` and `.prompt.yml`) alongside the existing Markdown format (`.prompt.md`). Both formats produce the same `Prompt` struct.

## Changes

- **parser.go**: Add `ParsePromptYAML()` function with a `yamlPromptFile` struct that uses `yaml:",inline"` embedding to decode all fields including `prompt_text` and `evaluation_criteria` from top-level YAML keys
- **loader.go**: Add `isPromptFile()` helper; update `LoadPrompts()` to auto-detect format by extension and dispatch to the correct parser; update `ScanNearMisses()` to recognize `.prompt.yaml`/`.prompt.yml` as valid files
- **types.go**: Update doc comments to reference all three supported extensions
- **loader_test.go**: Add tests for YAML parsing, missing ID, unknown fields, YAML loading, mixed format loading, and near-miss exclusion

## Example YAML prompt

```yaml
id: key-vault-dp-python-crud
service: key-vault
language: python
plane: data-plane
category: crud
difficulty: intermediate
description: CRUD operations on Key Vault secrets
prompt_text: |
  Write a Python script that creates a Key Vault client...
evaluation_criteria: |
  Must use DefaultAzureCredential.
```

Closes #109
Closes #110