### PR TITLE
refactor: replace typed Prompt fields with Properties map (#100)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -38,6 +38,7 @@ type GeneratorConfig struct {
 	MCPServers     map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	AvailableTools []string              `yaml:"available_tools,omitempty" json:"available_tools,omitempty"`
 	ExcludedTools  []string              `yaml:"excluded_tools,omitempty" json:"excluded_tools,omitempty"`
+	Tools          []ToolEntry           `yaml:"tools,omitempty" json:"tools,omitempty"`
 }
 
 // ReviewerConfig holds all configuration for the review/grading plane.
@@ -146,6 +147,11 @@ func (cf *ConfigFile) Validate() error {
 			for _, s := range c.Generator.Skills {
 				if err := validateSkill(s); err != nil {
 					return fmt.Errorf("config %q generator skill: %w", c.Name, err)
+				}
+			}
+			for j, te := range c.Generator.Tools {
+				if err := validateToolEntry(te, c.Name, j); err != nil {
+					return err
 				}
 			}
 		}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -196,11 +196,11 @@ func (e *Engine) loadCriteria() {
 // text for the given prompt.
 func (e *Engine) mergedCriteria(p *prompt.Prompt) string {
 	attrs := criteria.PromptAttrs{
-		Language: p.Language,
-		Service:  p.Service,
-		Plane:    p.Plane,
-		Category: p.Category,
-		SDK:      p.SDKPackage,
+		Language: p.Language(),
+		Service:  p.Service(),
+		Plane:    p.Plane(),
+		Category: p.Category(),
+		SDK:      p.SDKPackage(),
 	}
 	matched := criteria.MatchingCriteria(e.criteriaSets, attrs)
 	merged := criteria.MergeCriteria(matched, p.EvaluationCriteria)
@@ -530,13 +530,13 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		ConfigName: task.Config.Name,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		PromptMeta: map[string]any{
-			"service":     task.Prompt.Service,
-			"plane":       task.Prompt.Plane,
-			"language":    task.Prompt.Language,
-			"category":    task.Prompt.Category,
-			"description": task.Prompt.Description,
-			"difficulty":  task.Prompt.Difficulty,
-			"sdk_package": task.Prompt.SDKPackage,
+			"service":     task.Prompt.Service(),
+			"plane":       task.Prompt.Plane(),
+			"language":    task.Prompt.Language(),
+			"category":    task.Prompt.Category(),
+			"description": task.Prompt.Description(),
+			"difficulty":  task.Prompt.Difficulty(),
+			"sdk_package": task.Prompt.SDKPackage(),
 		},
 		ConfigUsed: map[string]any{
 			"name":  task.Config.Name,
@@ -928,13 +928,13 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 
 	// Write HTML report
 	if _, err := report.WriteHTMLReport(evalReport, e.opts.OutputDir, runID,
-		task.Prompt.Service, task.Prompt.Plane, task.Prompt.Language, task.Prompt.Category); err != nil {
+		task.Prompt.Service(), task.Prompt.Plane(), task.Prompt.Language(), task.Prompt.Category()); err != nil {
 		lg.Error("Failed to write HTML report", "error", err)
 	}
 
 	// Write Markdown report
 	if _, err := report.WriteMarkdownReport(evalReport, e.opts.OutputDir, runID,
-		task.Prompt.Service, task.Prompt.Plane, task.Prompt.Language, task.Prompt.Category); err != nil {
+		task.Prompt.Service(), task.Prompt.Plane(), task.Prompt.Language(), task.Prompt.Category()); err != nil {
 		lg.Error("Failed to write Markdown report", "error", err)
 	}
 

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -41,7 +41,7 @@ func (s *slowEvaluator) Evaluate(ctx context.Context, _ *prompt.Prompt, _ *confi
 
 func TestStubEvaluator(t *testing.T) {
 stub := &StubEvaluator{}
-p := &prompt.Prompt{ID: "test-prompt", Language: "go"}
+p := &prompt.Prompt{ID: "test-prompt", Properties: map[string]string{"language": "go"}}
 cfg := &config.ToolConfig{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
 
 result, err := stub.Evaluate(context.Background(), p, cfg, t.TempDir())
@@ -66,8 +66,8 @@ DryRun:  true,
 }))
 
 prompts := []*prompt.Prompt{
-{ID: "p1", Service: "storage", Language: "dotnet"},
-{ID: "p2", Service: "keyvault", Language: "python"},
+{ID: "p1", Properties: map[string]string{"service": "storage", "language": "dotnet"}},
+{ID: "p2", Properties: map[string]string{"service": "keyvault", "language": "python"}},
 }
 configs := []config.ToolConfig{
 {Name: "baseline", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -100,7 +100,7 @@ OutputDir: outputDir,
 }))
 
 prompts := []*prompt.Prompt{
-{ID: "test-prompt", Service: "storage", Plane: "data-plane", Language: "go", Category: "auth"},
+{ID: "test-prompt", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
 }
 configs := []config.ToolConfig{
 {Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -126,7 +126,7 @@ func TestEngineRunCapturesGeneratedFiles(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "filelist-test", Service: "storage", Plane: "data-plane", Language: "python", Category: "crud"},
+		{ID: "filelist-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "python", "category": "crud"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "baseline", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -155,7 +155,7 @@ func TestEngineRunTimeoutError(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "timeout-test", Service: "storage", Plane: "data-plane", Language: "go", Category: "auth"},
+		{ID: "timeout-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "baseline", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -299,7 +299,7 @@ func TestGuardrailMaxFiles(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "guardrail-files", Service: "storage", Plane: "data-plane", Language: "go", Category: "auth"},
+		{ID: "guardrail-files", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -331,7 +331,7 @@ func TestGuardrailMaxTurns(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "guardrail-turns", Service: "storage", Plane: "data-plane", Language: "go", Category: "auth"},
+		{ID: "guardrail-turns", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -365,7 +365,7 @@ func TestGuardrailMaxOutputSize(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "guardrail-size", Service: "storage", Plane: "data-plane", Language: "go", Category: "auth"},
+		{ID: "guardrail-size", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -411,7 +411,7 @@ func TestStubEvalLifecycle(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "lifecycle-test", Service: "storage", Plane: "data-plane", Language: "go", Category: "crud"},
+		{ID: "lifecycle-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "baseline", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -482,9 +482,9 @@ func TestMultiPromptMultiConfigFanOut(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "p1", Service: "storage", Plane: "data-plane", Language: "go", Category: "crud"},
-		{ID: "p2", Service: "keyvault", Plane: "data-plane", Language: "python", Category: "auth"},
-		{ID: "p3", Service: "cosmos-db", Plane: "data-plane", Language: "java", Category: "query"},
+		{ID: "p1", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"}},
+		{ID: "p2", Properties: map[string]string{"service": "keyvault", "plane": "data-plane", "language": "python", "category": "auth"}},
+		{ID: "p3", Properties: map[string]string{"service": "cosmos-db", "plane": "data-plane", "language": "java", "category": "query"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "config-a", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -538,7 +538,7 @@ func TestPhaseDurationTracking(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "timing-test", Service: "storage", Plane: "data-plane", Language: "go", Category: "crud"},
+		{ID: "timing-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"}},
 	}
 	configs := []config.ToolConfig{
 		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
@@ -576,10 +576,18 @@ func TestLargeRunAutoConfirmBypass(t *testing.T) {
 	for i := 0; i < 12; i++ {
 		prompts = append(prompts, &prompt.Prompt{
 			ID:       fmt.Sprintf("auto-confirm-%d", i),
-			Service:  "storage",
-			Plane:    "data-plane",
-			Language: "go",
-			Category: "crud",
+
+			Properties: map[string]string{
+
+				"service":  "storage",
+
+				"plane":    "data-plane",
+
+				"language": "go",
+
+				"category": "crud",
+
+			},
 		})
 	}
 	configs := []config.ToolConfig{
@@ -610,10 +618,18 @@ func TestLargeRunConfirmAbort(t *testing.T) {
 	for i := 0; i < 12; i++ {
 		prompts = append(prompts, &prompt.Prompt{
 			ID:       fmt.Sprintf("abort-%d", i),
-			Service:  "storage",
-			Plane:    "data-plane",
-			Language: "go",
-			Category: "crud",
+
+			Properties: map[string]string{
+
+				"service":  "storage",
+
+				"plane":    "data-plane",
+
+				"language": "go",
+
+				"category": "crud",
+
+			},
 		})
 	}
 
@@ -668,8 +684,8 @@ criteria:
 
 	prompts := []*prompt.Prompt{
 		{
-			ID: "criteria-test", Service: "storage", Plane: "data-plane",
-			Language: "go", Category: "crud",
+			ID: "criteria-test", Properties: map[string]string{"service": "storage", "plane": "data-plane",
+				"language": "go", "category": "crud"},
 			EvaluationCriteria: "- Must handle errors properly",
 		},
 	}
@@ -698,7 +714,7 @@ func TestCriteriaDirNotExist(t *testing.T) {
 	}))
 
 	prompts := []*prompt.Prompt{
-		{ID: "dir-test", Service: "storage", Language: "go", Plane: "data-plane", Category: "crud"},
+		{ID: "dir-test", Properties: map[string]string{"service": "storage", "language": "go", "plane": "data-plane", "category": "crud"}},
 	}
 	configs := []config.ToolConfig{{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}}
 
@@ -719,8 +735,8 @@ func TestCriteriaDirEmpty(t *testing.T) {
 
 	prompts := []*prompt.Prompt{
 		{
-			ID: "empty-criteria", Service: "storage", Language: "go",
-			Plane: "data-plane", Category: "crud",
+			ID: "empty-criteria", Properties: map[string]string{"service": "storage", "language": "go",
+				"plane": "data-plane", "category": "crud"},
 			EvaluationCriteria: "- Prompt specific criterion",
 		},
 	}

--- a/hyoka/internal/eval/reviewer_factory_test.go
+++ b/hyoka/internal/eval/reviewer_factory_test.go
@@ -51,13 +51,10 @@ func TestReviewerFactoryPerConfig(t *testing.T) {
 	// Create a single prompt
 	prompts := []*prompt.Prompt{
 		{
-			ID:                  "test-prompt",
-			Language:            "python",
-			Service:             "identity",
-			Plane:               "data-plane",
-			Category:            "auth",
-			PromptText:          "Create a test file",
-			EvaluationCriteria:  "Must work",
+			ID:                 "test-prompt",
+			Properties:         map[string]string{"language": "python", "service": "identity", "plane": "data-plane", "category": "auth"},
+			PromptText:         "Create a test file",
+			EvaluationCriteria: "Must work",
 		},
 	}
 
@@ -144,7 +141,7 @@ func TestReviewerFactoryNilWhenSkipReview(t *testing.T) {
 		ProgressMode: "off",
 	}))
 
-	prompts := []*prompt.Prompt{{ID: "test", Language: "python", PromptText: "test"}}
+	prompts := []*prompt.Prompt{{ID: "test", Properties: map[string]string{"language": "python"}, PromptText: "test"}}
 	configs := []config.ToolConfig{{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}}}
 
 	_, err := engine.Run(context.Background(), prompts, configs)

--- a/hyoka/internal/manifest/manifest.go
+++ b/hyoka/internal/manifest/manifest.go
@@ -65,26 +65,26 @@ func Generate(promptsDir string) (*Manifest, error) {
 
 		entry := PromptEntry{
 			ID:          p.ID,
-			Service:     p.Service,
-			Plane:       p.Plane,
-			Language:    p.Language,
-			Category:    p.Category,
-			Difficulty:  p.Difficulty,
-			Description: p.Description,
+			Service:     p.Service(),
+			Plane:       p.Plane(),
+			Language:    p.Language(),
+			Category:    p.Category(),
+			Difficulty:  p.Difficulty(),
+			Description: p.Description(),
 			Path:        relPath,
-			Created:     p.Created,
-			Author:      p.Author,
-			SDKPackage:  p.SDKPackage,
-			DocURL:      p.DocURL,
+			Created:     p.Created(),
+			Author:      p.Author(),
+			SDKPackage:  p.SDKPackage(),
+			DocURL:      p.DocURL(),
 		}
 		if len(p.Tags) > 0 {
 			entry.Tags = p.Tags
 		}
 		entries = append(entries, entry)
 
-		serviceSet[p.Service] = true
-		languageSet[p.Language] = true
-		categorySet[p.Category] = true
+		serviceSet[p.Service()] = true
+		languageSet[p.Language()] = true
+		categorySet[p.Category()] = true
 	}
 
 	sort.Slice(entries, func(i, j int) bool {

--- a/hyoka/internal/prompt/loader_test.go
+++ b/hyoka/internal/prompt/loader_test.go
@@ -51,17 +51,17 @@ func TestParsePromptFile(t *testing.T) {
 	if p.ID != "storage-auth-dotnet" {
 		t.Errorf("expected ID 'storage-auth-dotnet', got %q", p.ID)
 	}
-	if p.Service != "storage" {
-		t.Errorf("expected service 'storage', got %q", p.Service)
+	if p.Service() != "storage" {
+		t.Errorf("expected service 'storage', got %q", p.Service())
 	}
-	if p.Plane != "data-plane" {
-		t.Errorf("expected plane 'data-plane', got %q", p.Plane)
+	if p.Plane() != "data-plane" {
+		t.Errorf("expected plane 'data-plane', got %q", p.Plane())
 	}
-	if p.Language != "dotnet" {
-		t.Errorf("expected language 'dotnet', got %q", p.Language)
+	if p.Language() != "dotnet" {
+		t.Errorf("expected language 'dotnet', got %q", p.Language())
 	}
-	if p.Category != "authentication" {
-		t.Errorf("expected category 'authentication', got %q", p.Category)
+	if p.Category() != "authentication" {
+		t.Errorf("expected category 'authentication', got %q", p.Category())
 	}
 	if len(p.Tags) != 3 {
 		t.Errorf("expected 3 tags, got %d", len(p.Tags))
@@ -138,9 +138,9 @@ func TestLoadPrompts(t *testing.T) {
 
 func TestFilterPrompts(t *testing.T) {
 	prompts := []*Prompt{
-		{ID: "p1", Service: "storage", Language: "dotnet", Plane: "data-plane", Category: "authentication", Tags: []string{"blob", "identity"}},
-		{ID: "p2", Service: "keyvault", Language: "python", Plane: "data-plane", Category: "encryption", Tags: []string{"keys"}},
-		{ID: "p3", Service: "storage", Language: "java", Plane: "management-plane", Category: "authentication", Tags: []string{"blob"}},
+		{ID: "p1", Properties: map[string]string{"service": "storage", "language": "dotnet", "plane": "data-plane", "category": "authentication"}, Tags: []string{"blob", "identity"}},
+		{ID: "p2", Properties: map[string]string{"service": "keyvault", "language": "python", "plane": "data-plane", "category": "encryption"}, Tags: []string{"keys"}},
+		{ID: "p3", Properties: map[string]string{"service": "storage", "language": "java", "plane": "management-plane", "category": "authentication"}, Tags: []string{"blob"}},
 	}
 
 	tests := []struct {
@@ -312,23 +312,23 @@ t.Fatalf("unexpected error: %v", err)
 if p.ID != "storage-auth-dotnet" {
 t.Errorf("expected ID 'storage-auth-dotnet', got %q", p.ID)
 }
-if p.Service != "storage" {
-t.Errorf("expected service 'storage', got %q", p.Service)
+if p.Service() != "storage" {
+t.Errorf("expected service 'storage', got %q", p.Service())
 }
-if p.Plane != "data-plane" {
-t.Errorf("expected plane 'data-plane', got %q", p.Plane)
+if p.Plane() != "data-plane" {
+t.Errorf("expected plane 'data-plane', got %q", p.Plane())
 }
-if p.Language != "dotnet" {
-t.Errorf("expected language 'dotnet', got %q", p.Language)
+if p.Language() != "dotnet" {
+t.Errorf("expected language 'dotnet', got %q", p.Language())
 }
-if p.Category != "authentication" {
-t.Errorf("expected category 'authentication', got %q", p.Category)
+if p.Category() != "authentication" {
+t.Errorf("expected category 'authentication', got %q", p.Category())
 }
-if p.Difficulty != "beginner" {
-t.Errorf("expected difficulty 'beginner', got %q", p.Difficulty)
+if p.Difficulty() != "beginner" {
+t.Errorf("expected difficulty 'beginner', got %q", p.Difficulty())
 }
-if p.SDKPackage != "Azure.Storage.Blobs" {
-t.Errorf("expected sdk_package 'Azure.Storage.Blobs', got %q", p.SDKPackage)
+if p.SDKPackage() != "Azure.Storage.Blobs" {
+t.Errorf("expected sdk_package 'Azure.Storage.Blobs', got %q", p.SDKPackage())
 }
 if len(p.Tags) != 3 {
 t.Errorf("expected 3 tags, got %d", len(p.Tags))
@@ -358,12 +358,17 @@ t.Fatal("expected error for missing ID")
 }
 }
 
-func TestParsePromptYAMLInvalidField(t *testing.T) {
-content := []byte("id: test\nunknown_field: bad\nprompt_text: hello\n")
-_, err := ParsePromptYAML(content, "bad.prompt.yaml")
-if err == nil {
-t.Fatal("expected error for unknown field with KnownFields(true)")
-}
+func TestParsePromptYAMLUnknownFieldIgnored(t *testing.T) {
+	// Unknown fields are silently ignored since KnownFields is no longer enforced.
+	// This supports forward-compatible frontmatter with arbitrary properties.
+	content := []byte("id: test\nunknown_field: bad\nprompt_text: hello\n")
+	p, err := ParsePromptYAML(content, "ok.prompt.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ID != "test" {
+		t.Errorf("expected ID 'test', got %q", p.ID)
+	}
 }
 
 func TestLoadPromptsYAML(t *testing.T) {

--- a/hyoka/internal/prompt/parser.go
+++ b/hyoka/internal/prompt/parser.go
@@ -12,7 +12,77 @@ import (
 var promptSectionRe = regexp.MustCompile(`(?m)^## Prompt\s*\n`)
 var evaluationCriteriaRe = regexp.MustCompile(`(?m)^## Evaluation Criteria\s*\n`)
 
+// rawFrontmatter is an intermediate struct used to decode frontmatter.
+// It accepts both the old flat format and the new nested properties format.
+type rawFrontmatter struct {
+ID              string            `yaml:"id"`
+Tags            []string          `yaml:"tags"`
+ProjectContext  map[string]string `yaml:"project_context"`
+StarterProject  string            `yaml:"starter_project"`
+ReferenceAnswer string            `yaml:"reference_answer"`
+Timeout         int               `yaml:"timeout"`
+ExpectedPkgs    []string          `yaml:"expected_packages"`
+ExpectedTools   []string          `yaml:"expected_tools"`
+
+// New nested format
+Properties map[string]string `yaml:"properties"`
+
+// Old flat format fields — populated only when properties: is absent
+Service     string `yaml:"service"`
+Plane       string `yaml:"plane"`
+Language    string `yaml:"language"`
+Category    string `yaml:"category"`
+Difficulty  string `yaml:"difficulty"`
+Description string `yaml:"description"`
+SDKPackage  string `yaml:"sdk_package"`
+DocURL      string `yaml:"doc_url"`
+Created     string `yaml:"created"`
+Author      string `yaml:"author"`
+
+// YAML-only prompt fields
+PromptTextField         string `yaml:"prompt_text"`
+EvaluationCriteriaField string `yaml:"evaluation_criteria"`
+}
+
+// rawToPrompt converts a decoded rawFrontmatter into a Prompt,
+// populating Properties from flat fields when the nested format is absent.
+func rawToPrompt(raw *rawFrontmatter) *Prompt {
+p := &Prompt{
+ID:              raw.ID,
+Tags:            raw.Tags,
+ProjectContext:  raw.ProjectContext,
+StarterProject:  raw.StarterProject,
+ReferenceAnswer: raw.ReferenceAnswer,
+Timeout:         raw.Timeout,
+ExpectedPkgs:    raw.ExpectedPkgs,
+ExpectedTools:   raw.ExpectedTools,
+}
+
+if raw.Properties != nil {
+p.Properties = raw.Properties
+} else {
+p.Properties = make(map[string]string)
+setIfNonEmpty := func(k, v string) {
+if v != "" {
+p.Properties[k] = v
+}
+}
+setIfNonEmpty("service", raw.Service)
+setIfNonEmpty("plane", raw.Plane)
+setIfNonEmpty("language", raw.Language)
+setIfNonEmpty("category", raw.Category)
+setIfNonEmpty("difficulty", raw.Difficulty)
+setIfNonEmpty("description", raw.Description)
+setIfNonEmpty("sdk_package", raw.SDKPackage)
+setIfNonEmpty("doc_url", raw.DocURL)
+setIfNonEmpty("created", raw.Created)
+setIfNonEmpty("author", raw.Author)
+}
+return p
+}
+
 // ParsePromptFile parses a .prompt.md file's content into a Prompt struct.
+// It supports both the new nested properties format and the old flat format.
 // For .prompt.yaml/.prompt.yml files, use ParsePromptYAML instead.
 func ParsePromptFile(content []byte, filePath string) (*Prompt, error) {
 text := string(content)
@@ -27,12 +97,13 @@ return nil, fmt.Errorf("missing closing frontmatter delimiter: %s", filePath)
 frontmatter := strings.TrimSpace(parts[0])
 body := parts[1]
 
-var p Prompt
+var raw rawFrontmatter
 dec := yaml.NewDecoder(bytes.NewReader([]byte(frontmatter)))
-dec.KnownFields(true)
-if err := dec.Decode(&p); err != nil {
+if err := dec.Decode(&raw); err != nil {
 return nil, fmt.Errorf("parsing frontmatter in %s: %w", filePath, err)
 }
+
+p := rawToPrompt(&raw)
 
 loc := promptSectionRe.FindStringIndex(body)
 if loc != nil {
@@ -63,31 +134,23 @@ if p.ID == "" {
 return nil, fmt.Errorf("prompt missing required 'id' field: %s", filePath)
 }
 
-return &p, nil
-}
-
-// yamlPromptFile is used internally to parse .prompt.yaml files where
-// prompt_text and evaluation_criteria are YAML fields rather than Markdown sections.
-type yamlPromptFile struct {
-Prompt                  `yaml:",inline"`
-PromptTextField         string `yaml:"prompt_text"`
-EvaluationCriteriaField string `yaml:"evaluation_criteria"`
+return p, nil
 }
 
 // ParsePromptYAML parses a pure YAML prompt file (.prompt.yaml or .prompt.yml)
 // into a Prompt struct. All fields including prompt_text and evaluation_criteria
 // are expressed as top-level YAML keys.
+// It supports both the new nested properties format and the old flat format.
 func ParsePromptYAML(content []byte, filePath string) (*Prompt, error) {
-var yf yamlPromptFile
+var raw rawFrontmatter
 dec := yaml.NewDecoder(bytes.NewReader(content))
-dec.KnownFields(true)
-if err := dec.Decode(&yf); err != nil {
+if err := dec.Decode(&raw); err != nil {
 return nil, fmt.Errorf("parsing YAML prompt %s: %w", filePath, err)
 }
 
-p := &yf.Prompt
-p.PromptText = yf.PromptTextField
-p.EvaluationCriteria = yf.EvaluationCriteriaField
+p := rawToPrompt(&raw)
+p.PromptText = raw.PromptTextField
+p.EvaluationCriteria = raw.EvaluationCriteriaField
 p.FilePath = filePath
 
 if p.ID == "" {

--- a/hyoka/internal/prompt/types.go
+++ b/hyoka/internal/prompt/types.go
@@ -2,75 +2,92 @@ package prompt
 
 // Prompt represents a parsed prompt file (.prompt.md, .prompt.yaml, or .prompt.yml)
 // with metadata and prompt text.
+//
+// Metadata string fields (service, language, plane, etc.) are stored in the
+// Properties map rather than as dedicated struct fields. Use the getter methods
+// (Service(), Language(), etc.) or the generic Property() method to access them.
+// Non-string typed fields (Tags, Timeout, etc.) remain as struct fields.
 type Prompt struct {
-	ID              string            `yaml:"id" json:"id"`
-	Service         string            `yaml:"service" json:"service"`
-	Plane           string            `yaml:"plane" json:"plane"`
-	Language        string            `yaml:"language" json:"language"`
-	Category        string            `yaml:"category" json:"category"`
-	Difficulty      string            `yaml:"difficulty" json:"difficulty"`
-	Description     string            `yaml:"description" json:"description"`
-	SDKPackage      string            `yaml:"sdk_package" json:"sdk_package"`
-	DocURL          string            `yaml:"doc_url" json:"doc_url"`
-	Tags            []string          `yaml:"tags" json:"tags"`
-	Created         string            `yaml:"created" json:"created"`
-	Author          string            `yaml:"author" json:"author"`
-	ProjectContext  map[string]string `yaml:"project_context" json:"project_context,omitempty"`
-	StarterProject  string            `yaml:"starter_project" json:"starter_project,omitempty"`
-	ReferenceAnswer string            `yaml:"reference_answer" json:"reference_answer,omitempty"`
-	Timeout         int               `yaml:"timeout" json:"timeout,omitempty"`
-	ExpectedPkgs    []string          `yaml:"expected_packages" json:"expected_packages,omitempty"`
-	ExpectedTools   []string          `yaml:"expected_tools" json:"expected_tools,omitempty"`
+ID              string            `yaml:"id" json:"id"`
+Tags            []string          `yaml:"tags" json:"tags"`
+ProjectContext  map[string]string `yaml:"project_context" json:"project_context,omitempty"`
+StarterProject  string            `yaml:"starter_project" json:"starter_project,omitempty"`
+ReferenceAnswer string            `yaml:"reference_answer" json:"reference_answer,omitempty"`
+Timeout         int               `yaml:"timeout" json:"timeout,omitempty"`
+ExpectedPkgs    []string          `yaml:"expected_packages" json:"expected_packages,omitempty"`
+ExpectedTools   []string          `yaml:"expected_tools" json:"expected_tools,omitempty"`
 
-	// The prompt text: extracted from ## Prompt section (.prompt.md)
-	// or from the prompt_text field (.prompt.yaml/.prompt.yml)
-	PromptText string `yaml:"-" json:"prompt_text"`
+// Properties holds all metadata string fields (service, language, plane, etc.).
+// Keys must be snake_case.
+Properties map[string]string `yaml:"properties" json:"properties"`
 
-	// The evaluation criteria: extracted from ## Evaluation Criteria section (.prompt.md)
-	// or from the evaluation_criteria field (.prompt.yaml/.prompt.yml)
-	EvaluationCriteria string `yaml:"-" json:"evaluation_criteria,omitempty"`
+// The prompt text: extracted from ## Prompt section (.prompt.md)
+// or from the prompt_text field (.prompt.yaml/.prompt.yml)
+PromptText string `yaml:"-" json:"prompt_text"`
 
-	// Source file path
-	FilePath string `yaml:"-" json:"file_path"`
+// The evaluation criteria: extracted from ## Evaluation Criteria section (.prompt.md)
+// or from the evaluation_criteria field (.prompt.yaml/.prompt.yml)
+EvaluationCriteria string `yaml:"-" json:"evaluation_criteria,omitempty"`
+
+// Source file path
+FilePath string `yaml:"-" json:"file_path"`
 }
+
+// Property returns the value of a metadata property by key.
+func (p *Prompt) Property(key string) string {
+return p.Properties[key]
+}
+
+// Convenience getters for well-known metadata properties.
+
+func (p *Prompt) Service() string     { return p.Properties["service"] }
+func (p *Prompt) Plane() string       { return p.Properties["plane"] }
+func (p *Prompt) Language() string    { return p.Properties["language"] }
+func (p *Prompt) Category() string    { return p.Properties["category"] }
+func (p *Prompt) Difficulty() string  { return p.Properties["difficulty"] }
+func (p *Prompt) Description() string { return p.Properties["description"] }
+func (p *Prompt) SDKPackage() string  { return p.Properties["sdk_package"] }
+func (p *Prompt) DocURL() string      { return p.Properties["doc_url"] }
+func (p *Prompt) Created() string     { return p.Properties["created"] }
+func (p *Prompt) Author() string      { return p.Properties["author"] }
 
 // Filter defines criteria for selecting prompts.
 type Filter struct {
-	Service  string
-	Plane    string
-	Language string
-	Category string
-	Tags     []string
-	PromptID string
+Service  string
+Plane    string
+Language string
+Category string
+Tags     []string
+PromptID string
 }
 
 // Matches returns true if the prompt matches all non-empty filter criteria.
 func (p *Prompt) Matches(f Filter) bool {
-	if f.PromptID != "" && p.ID != f.PromptID {
-		return false
-	}
-	if f.Service != "" && p.Service != f.Service {
-		return false
-	}
-	if f.Plane != "" && p.Plane != f.Plane {
-		return false
-	}
-	if f.Language != "" && p.Language != f.Language {
-		return false
-	}
-	if f.Category != "" && p.Category != f.Category {
-		return false
-	}
-	if len(f.Tags) > 0 {
-		tagSet := make(map[string]bool, len(p.Tags))
-		for _, t := range p.Tags {
-			tagSet[t] = true
-		}
-		for _, required := range f.Tags {
-			if !tagSet[required] {
-				return false
-			}
-		}
-	}
-	return true
+if f.PromptID != "" && p.ID != f.PromptID {
+return false
+}
+if f.Service != "" && p.Service() != f.Service {
+return false
+}
+if f.Plane != "" && p.Plane() != f.Plane {
+return false
+}
+if f.Language != "" && p.Language() != f.Language {
+return false
+}
+if f.Category != "" && p.Category() != f.Category {
+return false
+}
+if len(f.Tags) > 0 {
+tagSet := make(map[string]bool, len(p.Tags))
+for _, t := range p.Tags {
+tagSet[t] = true
+}
+for _, required := range f.Tags {
+if !tagSet[required] {
+return false
+}
+}
+}
+return true
 }

--- a/hyoka/internal/report/generator.go
+++ b/hyoka/internal/report/generator.go
@@ -17,7 +17,7 @@ import (
 func ReportDir(outputDir string, runID string, p *prompt.Prompt) string {
 	return filepath.Join(
 		outputDir, runID, "results",
-		p.Service, p.Plane, p.Language, p.Category, p.ID,
+		p.Service(), p.Plane(), p.Language(), p.Category(), p.ID,
 	)
 }
 

--- a/hyoka/internal/report/generator_test.go
+++ b/hyoka/internal/report/generator_test.go
@@ -26,12 +26,16 @@ func TestWriteReport(t *testing.T) {
 	}
 
 	p := &prompt.Prompt{
-		ID:       "test-prompt",
-		Service:  "storage",
-		Plane:    "data-plane",
-		Language: "dotnet",
-		Category: "authentication",
+		ID:         "test-prompt",
+		Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "dotnet", "category": "authentication"},
 	}
+
+
+
+
+
+
+
 
 	reportPath, err := WriteReport(r, dir, "20240115-100000", p)
 	if err != nil {
@@ -109,7 +113,7 @@ func TestWriteSummary(t *testing.T) {
 
 func TestWriteReportInvalidDir(t *testing.T) {
 	r := &EvalReport{PromptID: "test", ConfigName: "cfg"}
-	p := &prompt.Prompt{ID: "test", Service: "svc", Plane: "plane", Language: "lang", Category: "cat"}
+	p := &prompt.Prompt{ID: "test", Properties: map[string]string{"service": "svc", "plane": "plane", "language": "lang", "category": "cat"}}
 
 	// Use a path containing characters that are invalid on both Unix and Windows.
 	// On Windows, /nonexistent is treated as drive-relative and MkdirAll may succeed.

--- a/hyoka/internal/serve/serve_test.go
+++ b/hyoka/internal/serve/serve_test.go
@@ -527,9 +527,16 @@ func TestAPIPromptDetailEndpoint(t *testing.T) {
 	if p["id"] != "test-prompt-one" {
 		t.Errorf("expected id test-prompt-one, got %v", p["id"])
 	}
-	if p["service"] != "identity" {
-		t.Errorf("expected service identity, got %v", p["service"])
+	props, ok := p["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties map in response")
 	}
+	if props["service"] != "identity" {
+		t.Errorf("expected service identity, got %v", props["service"])
+	}
+
+
+
 }
 
 func TestAPIPromptDetailNotFound(t *testing.T) {

--- a/hyoka/internal/validate/validate.go
+++ b/hyoka/internal/validate/validate.go
@@ -97,9 +97,9 @@ errs = append(errs, ValidationError{File: p.FilePath, Message: msg})
 
 // Required fields (id is already enforced by parser, but check anyway)
 requiredFields := map[string]string{
-"id": p.ID, "service": p.Service, "plane": p.Plane,
-"language": p.Language, "category": p.Category, "difficulty": p.Difficulty,
-"description": p.Description, "created": p.Created, "author": p.Author,
+"id": p.ID, "service": p.Service(), "plane": p.Plane(),
+"language": p.Language(), "category": p.Category(), "difficulty": p.Difficulty(),
+"description": p.Description(), "created": p.Created(), "author": p.Author(),
 }
 for field, val := range requiredFields {
 if val == "" {
@@ -108,27 +108,27 @@ addErr(fmt.Sprintf("missing required field: %s", field))
 }
 
 // Enum validation
-if p.Service != "" && !validServicesMap[p.Service] {
-addErr(fmt.Sprintf("invalid service %q; must be one of: %s", p.Service, joinKeys(validServicesMap)))
+if p.Service() != "" && !validServicesMap[p.Service()] {
+addErr(fmt.Sprintf("invalid service %q; must be one of: %s", p.Service(), joinKeys(validServicesMap)))
 }
-if p.Plane != "" && !validPlanesMap[p.Plane] {
-addErr(fmt.Sprintf("invalid plane %q; must be one of: %s", p.Plane, joinKeys(validPlanesMap)))
+if p.Plane() != "" && !validPlanesMap[p.Plane()] {
+addErr(fmt.Sprintf("invalid plane %q; must be one of: %s", p.Plane(), joinKeys(validPlanesMap)))
 }
-if p.Language != "" && !validLanguagesMap[p.Language] {
-addErr(fmt.Sprintf("invalid language %q; must be one of: %s", p.Language, joinKeys(validLanguagesMap)))
+if p.Language() != "" && !validLanguagesMap[p.Language()] {
+addErr(fmt.Sprintf("invalid language %q; must be one of: %s", p.Language(), joinKeys(validLanguagesMap)))
 }
-if p.Category != "" && !validCategoriesMap[p.Category] {
-addErr(fmt.Sprintf("invalid category %q; must be one of: %s", p.Category, joinKeys(validCategoriesMap)))
+if p.Category() != "" && !validCategoriesMap[p.Category()] {
+addErr(fmt.Sprintf("invalid category %q; must be one of: %s", p.Category(), joinKeys(validCategoriesMap)))
 }
-if p.Difficulty != "" && !validDifficultiesMap[p.Difficulty] {
-addErr(fmt.Sprintf("invalid difficulty %q; must be one of: %s", p.Difficulty, joinKeys(validDifficultiesMap)))
+if p.Difficulty() != "" && !validDifficultiesMap[p.Difficulty()] {
+addErr(fmt.Sprintf("invalid difficulty %q; must be one of: %s", p.Difficulty(), joinKeys(validDifficultiesMap)))
 }
 
 // ID naming convention: {service}-{dp|mp}-{language}-
-if p.Service != "" && p.Plane != "" && p.Language != "" {
-abbrev := planeAbbrev[p.Plane]
+if p.Service() != "" && p.Plane() != "" && p.Language() != "" {
+abbrev := planeAbbrev[p.Plane()]
 if abbrev != "" {
-expectedPrefix := fmt.Sprintf("%s-%s-%s-", p.Service, abbrev, p.Language)
+expectedPrefix := fmt.Sprintf("%s-%s-%s-", p.Service(), abbrev, p.Language())
 if !strings.HasPrefix(p.ID, expectedPrefix) {
 addErr(fmt.Sprintf("id %q must start with %q", p.ID, expectedPrefix))
 }

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -606,9 +606,9 @@ func listCmd() *cobra.Command {
 
 			fmt.Printf("Found %d prompt(s):\n\n", len(filtered))
 			for _, p := range filtered {
-				fmt.Printf("  %-30s %s/%s/%s [%s]\n", p.ID, p.Service, p.Plane, p.Language, p.Category)
-				if p.Description != "" {
-					fmt.Printf("  %-30s %s\n", "", p.Description)
+				fmt.Printf("  %-30s %s/%s/%s [%s]\n", p.ID, p.Service(), p.Plane(), p.Language(), p.Category())
+				if p.Description() != "" {
+					fmt.Printf("  %-30s %s\n", "", p.Description())
 				}
 			}
 			return nil


### PR DESCRIPTION
## Summary

Replaces 10 hardcoded typed string fields on the `Prompt` struct with a `Properties map[string]string` for metadata, while keeping non-string fields (Tags, Timeout, StarterProject, etc.) as typed struct fields.

## Changes

### Core (`internal/prompt/`)
- **`types.go`**: Removed `Service`, `Plane`, `Language`, `Category`, `Difficulty`, `Description`, `SDKPackage`, `DocURL`, `Created`, `Author` as struct fields. Added `Properties map[string]string` field with convenience getter methods (`Service()`, `Language()`, etc.) and a generic `Property(key)` method.
- **`parser.go`**: Uses intermediate `rawFrontmatter` struct to support both old flat format and new nested `properties:` format. Removed `KnownFields(true)` to allow forward-compatible frontmatter. 

### Consumers Updated
- `eval/engine.go` — getter methods for metadata access
- `manifest/manifest.go` — getter methods for entry creation
- `validate/validate.go` — getter methods for validation
- `report/generator.go` — getter methods for path construction
- `main.go` — getter methods for CLI output

### Tests Updated  
All test files updated to construct `Prompt` structs with `Properties` map instead of flat fields.

## Design Decisions
- **DM2**: Properties map is metadata-only. Tags, Timeout, StarterProject stay typed.
- **DM13**: All property keys use snake_case.

## Backward Compatibility
Parser supports BOTH formats:
```yaml
# Old (still works)
id: key-vault-dp-python-crud
service: key-vault
language: python

# New
id: key-vault-dp-python-crud
properties:
  service: key-vault
  language: python
```

Closes #100