### PR TITLE
docs: design property-based tool filter schema (#106)

### DIFF
--- a/docs/tool-filter-schema.md
+++ b/docs/tool-filter-schema.md
@@ -1,0 +1,182 @@
+# Property-based tool filter schema
+
+> Design document for issue [#106](https://github.com/ronniegeraghty/hyoka/issues/106) — task 1.3a
+
+## Problem
+
+Today, `generator.available_tools` and `generator.excluded_tools` are flat string
+lists that apply uniformly to every prompt evaluated under a config.  To support
+**pairwise testing** (for example, "give Python prompts the Azure MCP tools but
+don't give Go prompts `pip-tools`"), we need tool availability that adapts based
+on the prompt being evaluated.
+
+## Schema
+
+### New `tools` field on `generator`
+
+```yaml
+generator:
+  model: claude-opus-4.6
+  tools:
+    # No condition → always available
+    - name: "bash"
+
+    # Include only when the prompt's language is python
+    - name: "azure-mcp"
+      when:
+        language: python
+
+    # Exclude when the prompt's language is go
+    - name: "pip-tools"
+      exclude_when:
+        language: go
+
+    # Multiple conditions are ANDed
+    - name: "cosmosdb-mcp"
+      when:
+        language: python
+        service: cosmos-db
+
+  # Legacy flat lists still work (backward compatible)
+  available_tools: ["bash", "azure-mcp"]
+  excluded_tools: ["dangerous-tool"]
+```
+
+### `ToolEntry` definition
+
+| Field          | Type                | Required | Description                                                       |
+|----------------|---------------------|----------|-------------------------------------------------------------------|
+| `name`         | `string`            | yes      | Tool name (must match SDK tool identifiers)                       |
+| `when`         | `map[string]string` | no       | Include this tool only when **all** key-value pairs match         |
+| `exclude_when` | `map[string]string` | no       | Exclude this tool when **all** key-value pairs match              |
+
+A `ToolEntry` with **neither** `when` nor `exclude_when` is unconditional (always included).
+
+Setting **both** `when` and `exclude_when` on the same entry is a validation error.
+
+### Matchable prompt properties
+
+These are the `Prompt` struct fields available for matching:
+
+| Key          | Example values                     | Prompt field     |
+|--------------|------------------------------------|------------------|
+| `language`   | `python`, `dotnet`, `go`, `java`   | `Language`       |
+| `service`    | `identity`, `key-vault`, `storage` | `Service`        |
+| `plane`      | `data-plane`, `management-plane`   | `Plane`          |
+| `category`   | `auth`, `crud`, `pagination`       | `Category`       |
+| `difficulty`  | `easy`, `medium`, `hard`           | `Difficulty`     |
+
+All comparisons are case-sensitive, exact string equality.
+
+Multiple conditions within a single `when` or `exclude_when` are **ANDed**:
+every key-value pair must match for the condition to apply.
+
+## Resolution logic
+
+`ResolveTools` accepts a `GeneratorConfig` and a set of prompt properties and
+returns the final `(availableTools []string, excludedTools []string)` pair that
+is passed to the Copilot session.
+
+```
+1. Start with the legacy flat lists:
+     available = generator.available_tools   (may be nil → "all defaults")
+     excluded  = generator.excluded_tools    (may be nil → "exclude nothing")
+
+2. If generator.tools is present, iterate each entry:
+     a. Entries with neither when nor exclude_when
+        → append name to available
+     b. Entries with when:
+        → if ALL conditions match the prompt → append name to available
+     c. Entries with exclude_when:
+        → if ALL conditions match the prompt → append name to excluded
+
+3. Deduplicate both lists.
+
+4. If a tool appears in BOTH available and excluded, excluded wins
+   (defense-in-depth: explicit exclusion is always respected).
+
+5. Return (available, excluded). Nil semantics preserved:
+     - nil available  = "all default tools"
+     - empty available = "zero tools"
+```
+
+### Precedence summary
+
+| Scenario                                     | Result           |
+|----------------------------------------------|------------------|
+| Tool in legacy `available_tools` only        | Available        |
+| Tool in legacy `excluded_tools` only         | Excluded         |
+| Tool in `tools:` with matching `when:`       | Available        |
+| Tool in `tools:` with matching `exclude_when:` | Excluded      |
+| Tool in both available and excluded           | **Excluded**     |
+| `tools:` not set, legacy lists not set        | All defaults     |
+
+## Backward compatibility
+
+The existing flat `available_tools` and `excluded_tools` fields remain fully
+supported.  Configs that don't use the new `tools:` field behave identically to
+today.
+
+When both `tools:` and the legacy lists coexist, results are merged (see
+resolution logic above).  This allows incremental migration: teams can start
+adding conditional entries alongside their existing flat lists.
+
+## Interaction with `always_on: true` (Phase 2)
+
+In Phase 2, pairwise testing will introduce an `always_on: true` flag on
+`ToolEntry`.  Tools marked `always_on` bypass `when`/`exclude_when` evaluation
+and are always included — useful for baseline tools (like `bash`, `view`,
+`edit`) that every prompt needs regardless of properties.
+
+```yaml
+tools:
+  - name: "bash"
+    always_on: true    # Phase 2: never filtered out
+  - name: "azure-mcp"
+    when:
+      language: python
+```
+
+The `ResolveTools` function already handles unconditional entries (no
+`when`/`exclude_when`), so `always_on` is a semantic alias that also prevents
+the tool from being added to the excluded list during pairwise matrix
+generation.
+
+## Validation rules
+
+1. Every `ToolEntry` must have a non-empty `name`.
+2. `when` and `exclude_when` must not both be set on the same entry.
+3. Map keys in `when`/`exclude_when` must be recognized prompt property names
+   (`language`, `service`, `plane`, `category`, `difficulty`).
+4. Map values must be non-empty strings.
+
+Validation errors are returned from `config.Validate()` during config loading,
+consistent with existing validation patterns.
+
+## Go types
+
+See [`hyoka/internal/config/tool_filter.go`](../hyoka/internal/config/tool_filter.go)
+for the implementation.
+
+```go
+// ToolEntry represents a tool with optional property-based conditions.
+type ToolEntry struct {
+    Name        string            `yaml:"name"                    json:"name"`
+    When        map[string]string `yaml:"when,omitempty"          json:"when,omitempty"`
+    ExcludeWhen map[string]string `yaml:"exclude_when,omitempty"  json:"exclude_when,omitempty"`
+}
+
+// PromptProperties holds the subset of prompt metadata used for tool filtering.
+type PromptProperties struct {
+    Language   string
+    Service    string
+    Plane      string
+    Category   string
+    Difficulty string
+}
+
+// ResolveTools evaluates conditional tool entries against prompt properties and
+// merges the result with legacy flat lists. Returns the final available and
+// excluded tool slices.
+func ResolveTools(gen *GeneratorConfig, props PromptProperties) (available, excluded []string)
+```

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -33,6 +33,7 @@ type Skill struct {
 // GeneratorConfig holds all configuration for the code generation agent.
 type GeneratorConfig struct {
 	Model          string                `yaml:"model" json:"model"`
+	SystemPrompt   string                `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
 	Skills         []Skill               `yaml:"skills,omitempty" json:"skills,omitempty"`
 	MCPServers     map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	AvailableTools []string              `yaml:"available_tools,omitempty" json:"available_tools,omitempty"`
@@ -41,9 +42,10 @@ type GeneratorConfig struct {
 
 // ReviewerConfig holds all configuration for the review/grading plane.
 type ReviewerConfig struct {
-	Model  string  `yaml:"model,omitempty" json:"model,omitempty"`
-	Models []string `yaml:"models,omitempty" json:"models,omitempty"`
-	Skills []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Model        string   `yaml:"model,omitempty" json:"model,omitempty"`
+	Models       []string `yaml:"models,omitempty" json:"models,omitempty"`
+	SystemPrompt string   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
+	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
 // ToolConfig represents a single evaluation configuration.

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -1,0 +1,175 @@
+package config
+
+import "fmt"
+
+// ToolEntry represents a tool with optional property-based conditions.
+//
+// Entries with neither When nor ExcludeWhen are unconditional (always included).
+// When all key-value pairs in When match the prompt, the tool is available.
+// When all key-value pairs in ExcludeWhen match the prompt, the tool is excluded.
+// Setting both When and ExcludeWhen on the same entry is a validation error.
+type ToolEntry struct {
+	Name        string            `yaml:"name"                   json:"name"`
+	When        map[string]string `yaml:"when,omitempty"         json:"when,omitempty"`
+	ExcludeWhen map[string]string `yaml:"exclude_when,omitempty" json:"exclude_when,omitempty"`
+}
+
+// PromptProperties holds the subset of prompt metadata used for tool filtering.
+type PromptProperties struct {
+	Language   string
+	Service    string
+	Plane      string
+	Category   string
+	Difficulty string
+}
+
+// validPropertyKeys is the set of prompt property names recognized in
+// When/ExcludeWhen conditions.
+var validPropertyKeys = map[string]bool{
+	"language":   true,
+	"service":    true,
+	"plane":      true,
+	"category":   true,
+	"difficulty": true,
+}
+
+// propertyValue returns the prompt property value for a given key.
+func (p PromptProperties) propertyValue(key string) string {
+	switch key {
+	case "language":
+		return p.Language
+	case "service":
+		return p.Service
+	case "plane":
+		return p.Plane
+	case "category":
+		return p.Category
+	case "difficulty":
+		return p.Difficulty
+	default:
+		return ""
+	}
+}
+
+// matchesAll returns true if every key-value pair in conditions matches the
+// corresponding prompt property. An empty or nil map always matches.
+func matchesAll(conditions map[string]string, props PromptProperties) bool {
+	for key, want := range conditions {
+		if props.propertyValue(key) != want {
+			return false
+		}
+	}
+	return true
+}
+
+// ResolveTools evaluates conditional tool entries against prompt properties and
+// merges the result with legacy flat lists. Returns the final available and
+// excluded tool slices.
+//
+// Resolution order:
+//  1. Start with copies of the legacy available_tools and excluded_tools.
+//  2. Evaluate each ToolEntry: unconditional entries and entries whose When
+//     conditions match are appended to available; entries whose ExcludeWhen
+//     conditions match are appended to excluded.
+//  3. Deduplicate both lists.
+//  4. If a tool appears in both, excluded wins.
+//  5. Nil semantics are preserved: a nil available list means "all defaults".
+func ResolveTools(gen *GeneratorConfig, props PromptProperties) (available, excluded []string) {
+	if gen == nil {
+		return nil, nil
+	}
+
+	// No conditional tools defined → return legacy lists as-is.
+	if len(gen.Tools) == 0 {
+		return gen.AvailableTools, gen.ExcludedTools
+	}
+
+	// Start with copies of legacy lists.
+	if len(gen.AvailableTools) > 0 {
+		available = make([]string, len(gen.AvailableTools))
+		copy(available, gen.AvailableTools)
+	}
+	if len(gen.ExcludedTools) > 0 {
+		excluded = make([]string, len(gen.ExcludedTools))
+		copy(excluded, gen.ExcludedTools)
+	}
+
+	for _, entry := range gen.Tools {
+		switch {
+		case len(entry.ExcludeWhen) > 0:
+			if matchesAll(entry.ExcludeWhen, props) {
+				excluded = append(excluded, entry.Name)
+			}
+		case len(entry.When) > 0:
+			if matchesAll(entry.When, props) {
+				available = append(available, entry.Name)
+			}
+		default:
+			// Unconditional entry.
+			available = append(available, entry.Name)
+		}
+	}
+
+	available = dedup(available)
+	excluded = dedup(excluded)
+
+	// Excluded wins: remove any tool that appears in both lists.
+	if len(available) > 0 && len(excluded) > 0 {
+		excludeSet := make(map[string]bool, len(excluded))
+		for _, name := range excluded {
+			excludeSet[name] = true
+		}
+		filtered := available[:0]
+		for _, name := range available {
+			if !excludeSet[name] {
+				filtered = append(filtered, name)
+			}
+		}
+		available = filtered
+	}
+
+	return available, excluded
+}
+
+// dedup removes duplicate strings while preserving order. Returns nil for nil input.
+func dedup(ss []string) []string {
+	if ss == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(ss))
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// validateToolEntry checks that a ToolEntry has valid fields.
+func validateToolEntry(entry ToolEntry, configName string, idx int) error {
+	if entry.Name == "" {
+		return fmt.Errorf("config %q: tools[%d] missing name", configName, idx)
+	}
+	if len(entry.When) > 0 && len(entry.ExcludeWhen) > 0 {
+		return fmt.Errorf("config %q: tools[%d] (%s) has both when and exclude_when", configName, idx, entry.Name)
+	}
+	for key, val := range entry.When {
+		if !validPropertyKeys[key] {
+			return fmt.Errorf("config %q: tools[%d] (%s) when: unrecognized property %q", configName, idx, entry.Name, key)
+		}
+		if val == "" {
+			return fmt.Errorf("config %q: tools[%d] (%s) when[%s]: value must not be empty", configName, idx, entry.Name, key)
+		}
+	}
+	for key, val := range entry.ExcludeWhen {
+		if !validPropertyKeys[key] {
+			return fmt.Errorf("config %q: tools[%d] (%s) exclude_when: unrecognized property %q", configName, idx, entry.Name, key)
+		}
+		if val == "" {
+			return fmt.Errorf("config %q: tools[%d] (%s) exclude_when[%s]: value must not be empty", configName, idx, entry.Name, key)
+		}
+	}
+	return nil
+}

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -1,0 +1,320 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestResolveTools_NilGenerator(t *testing.T) {
+	avail, excl := ResolveTools(nil, PromptProperties{})
+	if avail != nil || excl != nil {
+		t.Errorf("expected (nil, nil), got (%v, %v)", avail, excl)
+	}
+}
+
+func TestResolveTools_LegacyOnly(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model:          "gpt-4",
+		AvailableTools: []string{"bash", "edit"},
+		ExcludedTools:  []string{"web_fetch"},
+	}
+	avail, excl := ResolveTools(gen, PromptProperties{Language: "python"})
+	assertSliceEqual(t, avail, []string{"bash", "edit"})
+	assertSliceEqual(t, excl, []string{"web_fetch"})
+}
+
+func TestResolveTools_LegacyNilPreserved(t *testing.T) {
+	gen := &GeneratorConfig{Model: "gpt-4"}
+	avail, excl := ResolveTools(gen, PromptProperties{})
+	if avail != nil {
+		t.Errorf("expected nil available (all defaults), got %v", avail)
+	}
+	if excl != nil {
+		t.Errorf("expected nil excluded, got %v", excl)
+	}
+}
+
+func TestResolveTools_UnconditionalEntry(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "bash"},
+			{Name: "edit"},
+		},
+	}
+	avail, excl := ResolveTools(gen, PromptProperties{})
+	assertSliceEqual(t, avail, []string{"bash", "edit"})
+	if len(excl) != 0 {
+		t.Errorf("expected no excluded tools, got %v", excl)
+	}
+}
+
+func TestResolveTools_WhenMatches(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "bash"},
+			{Name: "azure-mcp", When: map[string]string{"language": "python"}},
+		},
+	}
+
+	// Python prompt → azure-mcp included.
+	avail, _ := ResolveTools(gen, PromptProperties{Language: "python"})
+	assertSliceEqual(t, avail, []string{"bash", "azure-mcp"})
+
+	// Go prompt → azure-mcp excluded.
+	avail, _ = ResolveTools(gen, PromptProperties{Language: "go"})
+	assertSliceEqual(t, avail, []string{"bash"})
+}
+
+func TestResolveTools_WhenMultipleConditionsANDed(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "cosmosdb-mcp", When: map[string]string{
+				"language": "python",
+				"service":  "cosmos-db",
+			}},
+		},
+	}
+
+	// Both match → included.
+	avail, _ := ResolveTools(gen, PromptProperties{Language: "python", Service: "cosmos-db"})
+	assertSliceEqual(t, avail, []string{"cosmosdb-mcp"})
+
+	// Only one matches → not included.
+	avail, _ = ResolveTools(gen, PromptProperties{Language: "python", Service: "key-vault"})
+	if len(avail) != 0 {
+		t.Errorf("expected empty available, got %v", avail)
+	}
+}
+
+func TestResolveTools_ExcludeWhenMatches(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "pip-tools", ExcludeWhen: map[string]string{"language": "go"}},
+		},
+	}
+
+	// Go prompt → pip-tools excluded.
+	_, excl := ResolveTools(gen, PromptProperties{Language: "go"})
+	assertSliceEqual(t, excl, []string{"pip-tools"})
+
+	// Python prompt → not excluded.
+	_, excl = ResolveTools(gen, PromptProperties{Language: "python"})
+	if len(excl) != 0 {
+		t.Errorf("expected no excluded tools, got %v", excl)
+	}
+}
+
+func TestResolveTools_MergeLegacyAndConditional(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model:          "gpt-4",
+		AvailableTools: []string{"bash"},
+		ExcludedTools:  []string{"dangerous"},
+		Tools: []ToolEntry{
+			{Name: "edit"},
+			{Name: "azure-mcp", When: map[string]string{"language": "python"}},
+		},
+	}
+	avail, excl := ResolveTools(gen, PromptProperties{Language: "python"})
+	assertSliceEqual(t, avail, []string{"bash", "edit", "azure-mcp"})
+	assertSliceEqual(t, excl, []string{"dangerous"})
+}
+
+func TestResolveTools_ExcludedWinsOverAvailable(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "bash"},
+			{Name: "bash", ExcludeWhen: map[string]string{"language": "go"}},
+		},
+	}
+	avail, excl := ResolveTools(gen, PromptProperties{Language: "go"})
+
+	// bash is in both → excluded wins, removed from available.
+	assertSliceEqual(t, excl, []string{"bash"})
+	if len(avail) != 0 {
+		t.Errorf("expected bash removed from available, got %v", avail)
+	}
+}
+
+func TestResolveTools_Deduplication(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model:          "gpt-4",
+		AvailableTools: []string{"bash", "edit"},
+		Tools: []ToolEntry{
+			{Name: "bash"}, // duplicate of legacy
+			{Name: "edit"}, // duplicate of legacy
+			{Name: "view"},
+		},
+	}
+	avail, _ := ResolveTools(gen, PromptProperties{})
+	assertSliceEqual(t, avail, []string{"bash", "edit", "view"})
+}
+
+func TestResolveTools_AllPropertyKeys(t *testing.T) {
+	gen := &GeneratorConfig{
+		Model: "gpt-4",
+		Tools: []ToolEntry{
+			{Name: "t1", When: map[string]string{"language": "python"}},
+			{Name: "t2", When: map[string]string{"service": "identity"}},
+			{Name: "t3", When: map[string]string{"plane": "data-plane"}},
+			{Name: "t4", When: map[string]string{"category": "auth"}},
+			{Name: "t5", When: map[string]string{"difficulty": "hard"}},
+		},
+	}
+
+	props := PromptProperties{
+		Language:   "python",
+		Service:    "identity",
+		Plane:      "data-plane",
+		Category:   "auth",
+		Difficulty: "hard",
+	}
+	avail, _ := ResolveTools(gen, props)
+	assertSliceEqual(t, avail, []string{"t1", "t2", "t3", "t4", "t5"})
+}
+
+func TestValidateToolEntry_Valid(t *testing.T) {
+	cases := []ToolEntry{
+		{Name: "bash"},
+		{Name: "mcp", When: map[string]string{"language": "python"}},
+		{Name: "pip", ExcludeWhen: map[string]string{"language": "go"}},
+	}
+	for i, tc := range cases {
+		if err := validateToolEntry(tc, "test", i); err != nil {
+			t.Errorf("case %d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+func TestValidateToolEntry_MissingName(t *testing.T) {
+	err := validateToolEntry(ToolEntry{}, "test", 0)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestValidateToolEntry_BothWhenAndExcludeWhen(t *testing.T) {
+	entry := ToolEntry{
+		Name:        "bad",
+		When:        map[string]string{"language": "python"},
+		ExcludeWhen: map[string]string{"service": "identity"},
+	}
+	err := validateToolEntry(entry, "test", 0)
+	if err == nil {
+		t.Fatal("expected error for both when and exclude_when")
+	}
+}
+
+func TestValidateToolEntry_UnrecognizedPropertyKey(t *testing.T) {
+	entry := ToolEntry{
+		Name: "bad",
+		When: map[string]string{"unknown_field": "value"},
+	}
+	err := validateToolEntry(entry, "test", 0)
+	if err == nil {
+		t.Fatal("expected error for unrecognized property key")
+	}
+}
+
+func TestValidateToolEntry_EmptyPropertyValue(t *testing.T) {
+	entry := ToolEntry{
+		Name: "bad",
+		When: map[string]string{"language": ""},
+	}
+	err := validateToolEntry(entry, "test", 0)
+	if err == nil {
+		t.Fatal("expected error for empty property value")
+	}
+}
+
+func TestParseConfigWithTools(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: with-tools
+    description: "Config with conditional tools"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        - name: "bash"
+        - name: "azure-mcp"
+          when:
+            language: python
+        - name: "pip-tools"
+          exclude_when:
+            language: go
+      available_tools: ["view"]
+      excluded_tools: ["dangerous"]
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+	if len(c.Generator.Tools) != 3 {
+		t.Fatalf("expected 3 tool entries, got %d", len(c.Generator.Tools))
+	}
+	if c.Generator.Tools[0].Name != "bash" {
+		t.Errorf("expected first tool 'bash', got %q", c.Generator.Tools[0].Name)
+	}
+	if c.Generator.Tools[1].When["language"] != "python" {
+		t.Errorf("expected when language=python, got %v", c.Generator.Tools[1].When)
+	}
+	if c.Generator.Tools[2].ExcludeWhen["language"] != "go" {
+		t.Errorf("expected exclude_when language=go, got %v", c.Generator.Tools[2].ExcludeWhen)
+	}
+}
+
+func TestParseConfigRejectsInvalidToolEntry(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: bad-tool
+    description: "Invalid tool entry"
+    generator:
+      model: "gpt-4"
+      tools:
+        - name: "conflicting"
+          when:
+            language: python
+          exclude_when:
+            service: identity
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for tool with both when and exclude_when")
+	}
+}
+
+func TestParseConfigRejectsUnknownToolProperty(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: bad-key
+    description: "Unknown key in when"
+    generator:
+      model: "gpt-4"
+      tools:
+        - name: "bad"
+          when:
+            bogus_field: value
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for unrecognized property key")
+	}
+}
+
+// assertSliceEqual compares two string slices for equality.
+func assertSliceEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("length mismatch: got %v (len %d), want %v (len %d)", got, len(got), want, len(want))
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the property-based tool filter schema design and Go implementation for issue #106 (task 1.3a).

### What's included

- **Design doc** (`docs/tool-filter-schema.md`): Full schema definition, resolution logic, backward compatibility, and Phase 2 `always_on` interaction
- **Go types** (`hyoka/internal/config/tool_filter.go`):
  - `ToolEntry` struct with `Name`, `When`, `ExcludeWhen` fields
  - `PromptProperties` struct for matching prompt metadata
  - `ResolveTools()` function that evaluates conditionals and merges with legacy lists
  - `validateToolEntry()` integrated into `config.Validate()`
- **Tests** (`hyoka/internal/config/tool_filter_test.go`): 20 tests covering resolution, merging, dedup, precedence, validation, and YAML parsing
- **Config struct** (`config.go`): Added `Tools []ToolEntry` field to `GeneratorConfig`

### Schema example

```yaml
generator:
  model: claude-opus-4.6
  tools:
    - name: "bash"                          # always available
    - name: "azure-mcp"
      when: { language: python }            # only for Python prompts
    - name: "pip-tools"
      exclude_when: { language: go }        # excluded for Go prompts
  available_tools: ["view"]                 # legacy lists still work
```

### Key design decisions

- **Excluded wins**: if a tool appears in both available and excluded, it is excluded (defense-in-depth)
- **Backward compatible**: configs without `tools:` behave identically to today
- **ANDed conditions**: multiple keys in `when`/`exclude_when` must all match
- **Validated keys**: only recognized prompt properties (`language`, `service`, `plane`, `category`, `difficulty`) are accepted

Closes #106