### PR TITLE
docs: design grader config YAML schema (#103)

### DIFF
--- a/docs/grader-config-schema.md
+++ b/docs/grader-config-schema.md
@@ -1,0 +1,349 @@
+# Grader Config YAML Schema
+
+**Status:** DRAFT  
+**Issue:** #103 (Task 1.2a)  
+**Decisions:** DM3 (gate semantics), DM4 (typed result fields), DM19 (one model per prompt grader)
+
+## Overview
+
+The grader config schema replaces the three-tier criteria system with a flat,
+composable list of typed graders. Each grader is a single concern — file
+existence, build success, LLM review — evaluated independently and aggregated
+by weighted scoring. Hard constraints use `gate: true` to override weighted
+averages (DM3).
+
+### Design Principles
+
+1. **Deterministic where possible** — Use file checks, build commands, and
+   schema validators instead of LLMs when the answer is objective.
+2. **One concern per grader** — Each grader checks exactly one thing.
+3. **Composable via weights** — The framework aggregates; graders don't know
+   about each other.
+4. **Explicit over implicit** — No tier merging, no hidden precedence rules.
+
+## Root Schema
+
+```yaml
+graders:
+  - kind: <string>              # Required: grader type (see Grader Kinds below)
+    name: <string>              # Required: human-readable name, unique within config
+    config: <object>            # Required: kind-specific configuration (see below)
+    weight: <float>             # Optional: scoring weight 0.0–1.0 (default: 1.0)
+    gate: <bool>                # Optional: hard pass/fail (default: false) — DM3
+    when: <map[string]string>   # Optional: property-based applicability conditions
+```
+
+### Field Reference
+
+| Field    | Type                | Required | Default | Description                                                                |
+|----------|---------------------|----------|---------|----------------------------------------------------------------------------|
+| `kind`   | string              | yes      | —       | Grader type identifier. One of the six supported kinds.                    |
+| `name`   | string              | yes      | —       | Human-readable name. Must be unique within the grader list.                |
+| `config` | object              | yes      | —       | Kind-specific configuration. Schema varies by `kind`.                      |
+| `weight` | float64             | no       | 1.0     | Scoring weight for weighted average. Normalized across all graders.        |
+| `gate`   | bool                | no       | false   | When true, failure causes the entire evaluation to fail (DM3).             |
+| `when`   | map\[string\]string | no       | —       | Property conditions for applicability. All entries must match (AND logic).  |
+
+### Applicability (`when`)
+
+The `when` field uses exact case-insensitive string matching against prompt
+properties. All specified keys must match for the grader to apply. If `when`
+is omitted, the grader applies to all prompts.
+
+```yaml
+when:
+  language: python        # Only apply to Python prompts
+  service: key-vault      # AND only Key Vault service
+```
+
+This replaces the `MatchCondition` struct from the criteria system. Property
+keys are not restricted to a fixed set — any prompt property can be used.
+
+### Gate Semantics (DM3)
+
+When `gate: true`, the grader acts as a hard constraint. If a gate grader
+fails, the entire evaluation fails regardless of the weighted average from
+other graders. Use gates for objective requirements:
+
+- File must exist → `gate: true`
+- Code must compile → `gate: true`
+- No forbidden tools used → `gate: true`
+
+Non-gate graders contribute to the weighted score only.
+
+## Grader Kinds
+
+### `file` — File Existence and Content Check
+
+Checks whether a generated file exists and optionally matches a content
+pattern. Fully deterministic — no LLM involved.
+
+```yaml
+- kind: file
+  name: "main_file_exists"
+  config:
+    path: "main.py"              # Required: file path relative to work dir
+    pattern: "def main"          # Optional: regex pattern to match in content
+    must_exist: true             # Optional: default true
+  weight: 1.0
+  gate: true
+```
+
+| Config Field  | Type   | Required | Default | Description                                       |
+|---------------|--------|----------|---------|---------------------------------------------------|
+| `path`        | string | yes      | —       | File path relative to the generated output dir.    |
+| `pattern`     | string | no       | —       | Regex pattern that must match file content.         |
+| `must_exist`  | bool   | no       | true    | Whether the file must exist. False inverts check.   |
+
+**Result:** Pass if file exists (or doesn't, per `must_exist`) and content
+matches `pattern` (if specified).
+
+---
+
+### `program` — External Command Execution
+
+Runs an external command (compiler, linter, test suite) and grades based on
+exit code. Deterministic for build/lint checks.
+
+```yaml
+- kind: program
+  name: "builds_successfully"
+  config:
+    command: "python"                # Required: executable to run
+    args: ["-m", "py_compile", "main.py"]  # Optional: command arguments
+    timeout: 30                      # Optional: seconds (default: 30)
+  weight: 1.0
+  gate: true
+```
+
+| Config Field | Type     | Required | Default | Description                                    |
+|--------------|----------|----------|---------|------------------------------------------------|
+| `command`    | string   | yes      | —       | Executable to run.                              |
+| `args`       | []string | no       | —       | Command-line arguments.                         |
+| `timeout`    | int      | no       | 30      | Maximum execution time in seconds.              |
+
+**Result:** Pass if exit code is 0. Stdout/stderr captured in result details.
+
+---
+
+### `prompt` — LLM-as-Judge Review
+
+Sends generated code to a single LLM model for rubric-based review. Each
+`prompt` grader uses exactly one model (DM19). For multi-model review,
+configure multiple `prompt` graders with different models and weights.
+
+```yaml
+# Multi-model review via separate grader instances (DM19)
+- kind: prompt
+  name: "code_quality_opus"
+  config:
+    model: "claude-opus-4.6"         # Required: single model per instance
+    rubric: |                        # Required: evaluation instructions
+      Evaluate the code for correctness, SDK best practices,
+      error handling, and documentation quality.
+  weight: 0.7
+
+- kind: prompt
+  name: "code_quality_sonnet"
+  config:
+    model: "claude-sonnet-4.5"
+    rubric: |
+      Evaluate the code for correctness, SDK best practices,
+      error handling, and documentation quality.
+  weight: 0.3
+```
+
+| Config Field | Type   | Required | Default | Description                                    |
+|--------------|--------|----------|---------|------------------------------------------------|
+| `model`      | string | yes      | —       | LLM model to use for review.                   |
+| `rubric`     | string | yes      | —       | Evaluation instructions sent to the model.      |
+
+**Result:** Score from LLM response, plus per-criterion pass/fail breakdown,
+summary, issues, and strengths.
+
+---
+
+### `behavior` — Session Behavior Constraints
+
+Validates the generator's session behavior — which tools were used, how many
+turns were taken. Checks against the session event log.
+
+```yaml
+- kind: behavior
+  name: "uses_azure_mcp"
+  config:
+    required_tools: ["azure-mcp"]    # Optional: tools that must be called
+    forbidden_tools: ["rm", "sudo"]  # Optional: tools that must NOT be called
+    max_turns: 25                    # Optional: max generation turns allowed
+  weight: 1.0
+  gate: true
+  when:
+    service: key-vault
+```
+
+| Config Field      | Type     | Required | Default | Description                                   |
+|-------------------|----------|----------|---------|-----------------------------------------------|
+| `required_tools`  | []string | no       | —       | Tools that must appear in session events.      |
+| `forbidden_tools` | []string | no       | —       | Tools that must NOT appear in session events.  |
+| `max_turns`       | int      | no       | —       | Maximum number of generation turns allowed.    |
+
+**Result:** Pass if all constraints are satisfied. Details include which
+tools were found/missing.
+
+---
+
+### `action_sequence` — Ordered Action Verification
+
+Verifies that the generator performed actions in a specific order. Checks
+the session event log for ordered subsequence matching.
+
+```yaml
+- kind: action_sequence
+  name: "read_before_write"
+  config:
+    expected_actions:                # Required: ordered list of expected actions
+      - "read_file"
+      - "edit_file"
+  weight: 0.5
+```
+
+| Config Field       | Type     | Required | Default | Description                                     |
+|--------------------|----------|----------|---------|-------------------------------------------------|
+| `expected_actions` | []string | yes      | —       | Ordered list of actions (subsequence match).     |
+
+**Result:** Pass if all expected actions appear in order in the session log.
+Other actions may appear between expected actions (subsequence, not exact).
+
+---
+
+### `tool_constraint` — Fine-Grained Tool Usage Rules
+
+Enforces specific tool usage constraints — required tools, forbidden tools,
+and call count bounds. More granular than `behavior` for tool-specific rules.
+
+```yaml
+- kind: tool_constraint
+  name: "mcp_tool_limits"
+  config:
+    required: ["azure-mcp"]          # Optional: tools that must be called
+    forbidden: ["dangerous-tool"]    # Optional: tools that must NOT be called
+    min_calls: 1                     # Optional: min total tool calls
+    max_calls: 50                    # Optional: max total tool calls
+  weight: 1.0
+```
+
+| Config Field | Type     | Required | Default | Description                                     |
+|--------------|----------|----------|---------|-------------------------------------------------|
+| `required`   | []string | no       | —       | Tools that must be called at least once.         |
+| `forbidden`  | []string | no       | —       | Tools that must never be called.                 |
+| `min_calls`  | int      | no       | —       | Minimum total tool invocations required.         |
+| `max_calls`  | int      | no       | —       | Maximum total tool invocations allowed.          |
+
+**Result:** Pass if all constraints are satisfied. Details include observed
+tool call counts.
+
+## Complete Example
+
+```yaml
+graders:
+  # Gate: file must exist
+  - kind: file
+    name: "main_file_exists"
+    config:
+      path: "main.py"
+    weight: 1.0
+    gate: true
+    when:
+      language: python
+
+  # Gate: code must compile
+  - kind: program
+    name: "compiles_successfully"
+    config:
+      command: "python"
+      args: ["-m", "py_compile", "main.py"]
+      timeout: 30
+    weight: 1.0
+    gate: true
+    when:
+      language: python
+
+  # Multi-model LLM review (DM19)
+  - kind: prompt
+    name: "code_review_opus"
+    config:
+      model: "claude-opus-4.6"
+      rubric: |
+        Evaluate the generated code for:
+        1. Correctness — does it solve the prompt requirements?
+        2. SDK best practices — proper use of Azure SDK patterns
+        3. Error handling — appropriate try/except with specific exceptions
+        4. Documentation — clear docstrings and comments where needed
+    weight: 0.7
+
+  - kind: prompt
+    name: "code_review_sonnet"
+    config:
+      model: "claude-sonnet-4.5"
+      rubric: |
+        Evaluate the generated code for:
+        1. Correctness — does it solve the prompt requirements?
+        2. SDK best practices — proper use of Azure SDK patterns
+        3. Error handling — appropriate try/except with specific exceptions
+        4. Documentation — clear docstrings and comments where needed
+    weight: 0.3
+
+  # Behavioral: must use Azure MCP, must not exceed turn limit
+  - kind: behavior
+    name: "azure_tool_usage"
+    config:
+      required_tools: ["azure-mcp"]
+      max_turns: 25
+    weight: 1.0
+    gate: true
+    when:
+      service: key-vault
+
+  # Sequence: should read prompt context before editing
+  - kind: action_sequence
+    name: "reads_before_writes"
+    config:
+      expected_actions:
+        - "read_file"
+        - "edit_file"
+    weight: 0.5
+
+  # Tool constraint: bounded tool usage
+  - kind: tool_constraint
+    name: "reasonable_tool_usage"
+    config:
+      forbidden: ["rm"]
+      max_calls: 50
+    weight: 0.5
+```
+
+## Scoring Algorithm
+
+1. **Filter** — Select graders where all `when` conditions match the prompt properties.
+2. **Execute** — Run each applicable grader independently.
+3. **Gate check** — If any grader with `gate: true` fails, the evaluation fails (score = 0).
+4. **Weighted average** — For non-gate graders (and passing gates):
+   `final_score = Σ(grader_score × weight) / Σ(weight)`
+
+## Migration from Criteria System
+
+| Criteria System              | Grader System                              |
+|------------------------------|--------------------------------------------|
+| `MatchCondition` struct      | `when: map[string]string`                  |
+| `Criterion{Name,Description}`| `prompt` grader with `rubric`              |
+| Tier 1 (general rubric)      | `prompt` grader with no `when` conditions  |
+| Tier 2 (attribute-matched)   | `prompt` grader with `when` conditions     |
+| Tier 3 (prompt-specific)     | `prompt` grader or inline rubric extension |
+| `MergeCriteria()`            | Removed — no merging needed                |
+| `FormatCriteria()`           | Removed — rubric is grader-native          |
+
+## Go Types
+
+See `hyoka/internal/graders/types.go` for the Go type definitions that
+implement this schema. The types use dual `yaml`/`json` struct tags
+consistent with the existing `config` package patterns.

--- a/hyoka/internal/graders/types.go
+++ b/hyoka/internal/graders/types.go
@@ -1,0 +1,265 @@
+// Package graders defines the configuration schema for the pluggable grader
+// system that replaces the three-tier criteria approach.
+//
+// Each grader is a single-concern evaluator (file check, build verification,
+// LLM review, etc.) defined in YAML config and executed independently.
+// Results are aggregated by weighted scoring, with gate graders acting as
+// hard pass/fail constraints (DM3).
+//
+// See docs/grader-config-schema.md for the full schema specification.
+package graders
+
+import (
+"bytes"
+"fmt"
+"os"
+"path/filepath"
+"strings"
+
+"gopkg.in/yaml.v3"
+)
+
+// Supported grader kinds.
+const (
+KindFile           = "file"
+KindProgram        = "program"
+KindPrompt         = "prompt"
+KindBehavior       = "behavior"
+KindActionSequence = "action_sequence"
+KindToolConstraint = "tool_constraint"
+)
+
+// validKinds is the set of recognized grader kind values.
+var validKinds = map[string]bool{
+KindFile:           true,
+KindProgram:        true,
+KindPrompt:         true,
+KindBehavior:       true,
+KindActionSequence: true,
+KindToolConstraint: true,
+}
+
+// GraderConfigFile is the top-level YAML structure containing a list of graders.
+type GraderConfigFile struct {
+Graders []GraderConfig `yaml:"graders" json:"graders"`
+}
+
+// GraderConfig defines a single grader instance in the evaluation pipeline.
+type GraderConfig struct {
+Kind   string    `yaml:"kind" json:"kind"`
+Name   string    `yaml:"name" json:"name"`
+Config yaml.Node `yaml:"config" json:"config"`
+Weight float64   `yaml:"weight,omitempty" json:"weight,omitempty"`
+Gate   bool      `yaml:"gate,omitempty" json:"gate,omitempty"`
+When   WhenMap   `yaml:"when,omitempty" json:"when,omitempty"`
+}
+
+// WhenMap holds property-based applicability conditions.
+// All entries must match for the grader to apply (AND logic).
+// Matching is case-insensitive.
+type WhenMap map[string]string
+
+// Matches returns true if all conditions in the map match the given properties.
+// An empty WhenMap matches everything.
+func (w WhenMap) Matches(props map[string]string) bool {
+for k, v := range w {
+pv, ok := props[k]
+if !ok || !strings.EqualFold(v, pv) {
+return false
+}
+}
+return true
+}
+
+// FileConfig holds configuration for the "file" grader kind.
+type FileConfig struct {
+Path      string `yaml:"path" json:"path"`
+Pattern   string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
+MustExist *bool  `yaml:"must_exist,omitempty" json:"must_exist,omitempty"`
+}
+
+// ProgramConfig holds configuration for the "program" grader kind.
+type ProgramConfig struct {
+Command string   `yaml:"command" json:"command"`
+Args    []string `yaml:"args,omitempty" json:"args,omitempty"`
+Timeout int      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+}
+
+// PromptConfig holds configuration for the "prompt" grader kind.
+// Each prompt grader runs exactly one model (DM19).
+type PromptConfig struct {
+Model  string `yaml:"model" json:"model"`
+Rubric string `yaml:"rubric" json:"rubric"`
+}
+
+// BehaviorConfig holds configuration for the "behavior" grader kind.
+type BehaviorConfig struct {
+RequiredTools  []string `yaml:"required_tools,omitempty" json:"required_tools,omitempty"`
+ForbiddenTools []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`
+MaxTurns       int      `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
+}
+
+// ActionSequenceConfig holds configuration for the "action_sequence" grader kind.
+type ActionSequenceConfig struct {
+ExpectedActions []string `yaml:"expected_actions" json:"expected_actions"`
+}
+
+// ToolConstraintConfig holds configuration for the "tool_constraint" grader kind.
+type ToolConstraintConfig struct {
+Required  []string `yaml:"required,omitempty" json:"required,omitempty"`
+Forbidden []string `yaml:"forbidden,omitempty" json:"forbidden,omitempty"`
+MinCalls  int      `yaml:"min_calls,omitempty" json:"min_calls,omitempty"`
+MaxCalls  int      `yaml:"max_calls,omitempty" json:"max_calls,omitempty"`
+}
+
+// EffectiveWeight returns the grader's weight, defaulting to 1.0 if unset.
+func (g *GraderConfig) EffectiveWeight() float64 {
+if g.Weight == 0 {
+return 1.0
+}
+return g.Weight
+}
+
+// DecodeConfig decodes the raw YAML config node into the appropriate
+// kind-specific config struct. Returns an error if the kind is unknown
+// or the config doesn't match the expected schema.
+func (g *GraderConfig) DecodeConfig() (any, error) {
+switch g.Kind {
+case KindFile:
+var c FileConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding file config for %q: %w", g.Name, err)
+}
+return &c, nil
+case KindProgram:
+var c ProgramConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding program config for %q: %w", g.Name, err)
+}
+return &c, nil
+case KindPrompt:
+var c PromptConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding prompt config for %q: %w", g.Name, err)
+}
+return &c, nil
+case KindBehavior:
+var c BehaviorConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding behavior config for %q: %w", g.Name, err)
+}
+return &c, nil
+case KindActionSequence:
+var c ActionSequenceConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding action_sequence config for %q: %w", g.Name, err)
+}
+return &c, nil
+case KindToolConstraint:
+var c ToolConstraintConfig
+if err := g.Config.Decode(&c); err != nil {
+return nil, fmt.Errorf("decoding tool_constraint config for %q: %w", g.Name, err)
+}
+return &c, nil
+default:
+return nil, fmt.Errorf("unknown grader kind %q for %q", g.Kind, g.Name)
+}
+}
+
+// Parse decodes YAML bytes into a GraderConfigFile and validates it.
+func Parse(data []byte) (*GraderConfigFile, error) {
+var gcf GraderConfigFile
+dec := yaml.NewDecoder(bytes.NewReader(data))
+dec.KnownFields(true)
+if err := dec.Decode(&gcf); err != nil {
+return nil, fmt.Errorf("parsing grader config: %w", err)
+}
+if err := Validate(&gcf); err != nil {
+return nil, err
+}
+return &gcf, nil
+}
+
+// LoadFile loads and parses a single grader config YAML file.
+func LoadFile(path string) (*GraderConfigFile, error) {
+data, err := os.ReadFile(path)
+if err != nil {
+return nil, fmt.Errorf("reading grader config %s: %w", path, err)
+}
+gcf, err := Parse(data)
+if err != nil {
+return nil, fmt.Errorf("in %s: %w", path, err)
+}
+return gcf, nil
+}
+
+// LoadDir loads all grader config YAML files from a directory tree.
+func LoadDir(dir string) (*GraderConfigFile, error) {
+merged := &GraderConfigFile{}
+
+err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+if err != nil {
+return err
+}
+if info.IsDir() {
+return nil
+}
+ext := filepath.Ext(path)
+if ext != ".yaml" && ext != ".yml" {
+return nil
+}
+gcf, err := LoadFile(path)
+if err != nil {
+return err
+}
+merged.Graders = append(merged.Graders, gcf.Graders...)
+return nil
+})
+if err != nil {
+return nil, fmt.Errorf("walking grader config directory %s: %w", dir, err)
+}
+return merged, nil
+}
+
+// Validate checks a GraderConfigFile for structural correctness.
+func Validate(gcf *GraderConfigFile) error {
+if len(gcf.Graders) == 0 {
+return fmt.Errorf("no graders defined")
+}
+
+names := make(map[string]bool, len(gcf.Graders))
+for i, g := range gcf.Graders {
+if g.Name == "" {
+return fmt.Errorf("grader at index %d: name is required", i)
+}
+if g.Kind == "" {
+return fmt.Errorf("grader %q: kind is required", g.Name)
+}
+if !validKinds[g.Kind] {
+return fmt.Errorf("grader %q: unknown kind %q", g.Name, g.Kind)
+}
+if names[g.Name] {
+return fmt.Errorf("grader %q: duplicate name", g.Name)
+}
+names[g.Name] = true
+if g.Weight < 0 || g.Weight > 1 {
+return fmt.Errorf("grader %q: weight must be between 0.0 and 1.0, got %f", g.Name, g.Weight)
+}
+if _, err := g.DecodeConfig(); err != nil {
+return err
+}
+}
+return nil
+}
+
+// ApplicableGraders filters graders by the given prompt properties,
+// returning only those whose When conditions match.
+func ApplicableGraders(graders []GraderConfig, props map[string]string) []GraderConfig {
+var applicable []GraderConfig
+for _, g := range graders {
+if g.When.Matches(props) {
+applicable = append(applicable, g)
+}
+}
+return applicable
+}

--- a/hyoka/internal/graders/types_test.go
+++ b/hyoka/internal/graders/types_test.go
@@ -1,0 +1,247 @@
+package graders
+
+import (
+"testing"
+)
+
+func TestParseValidConfig(t *testing.T) {
+yaml := `
+graders:
+  - kind: file
+    name: "main_exists"
+    config:
+      path: "main.py"
+      must_exist: true
+    weight: 1.0
+    gate: true
+    when:
+      language: python
+
+  - kind: program
+    name: "builds"
+    config:
+      command: "python"
+      args: ["-m", "py_compile", "main.py"]
+      timeout: 30
+    weight: 1.0
+    gate: true
+
+  - kind: prompt
+    name: "review_opus"
+    config:
+      model: "claude-opus-4.6"
+      rubric: "Evaluate correctness."
+    weight: 0.7
+
+  - kind: prompt
+    name: "review_sonnet"
+    config:
+      model: "claude-sonnet-4.5"
+      rubric: "Evaluate correctness."
+    weight: 0.3
+
+  - kind: behavior
+    name: "tool_usage"
+    config:
+      required_tools: ["azure-mcp"]
+      forbidden_tools: ["rm"]
+      max_turns: 25
+    weight: 1.0
+
+  - kind: action_sequence
+    name: "read_before_write"
+    config:
+      expected_actions: ["read_file", "edit_file"]
+    weight: 0.5
+
+  - kind: tool_constraint
+    name: "bounded_tools"
+    config:
+      required: ["azure-mcp"]
+      forbidden: ["dangerous"]
+      min_calls: 1
+      max_calls: 50
+    weight: 0.5
+`
+gcf, err := Parse([]byte(yaml))
+if err != nil {
+t.Fatalf("Parse failed: %v", err)
+}
+if len(gcf.Graders) != 7 {
+t.Fatalf("expected 7 graders, got %d", len(gcf.Graders))
+}
+
+// Verify file grader
+g := gcf.Graders[0]
+if g.Kind != KindFile || g.Name != "main_exists" || !g.Gate {
+t.Errorf("file grader: unexpected values: kind=%s name=%s gate=%v", g.Kind, g.Name, g.Gate)
+}
+cfg, err := g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig file: %v", err)
+}
+fc := cfg.(*FileConfig)
+if fc.Path != "main.py" {
+t.Errorf("file config path: expected main.py, got %s", fc.Path)
+}
+if fc.MustExist == nil || !*fc.MustExist {
+t.Error("file config must_exist: expected true")
+}
+
+// Verify prompt grader
+g = gcf.Graders[2]
+cfg, err = g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig prompt: %v", err)
+}
+pc := cfg.(*PromptConfig)
+if pc.Model != "claude-opus-4.6" {
+t.Errorf("prompt config model: expected claude-opus-4.6, got %s", pc.Model)
+}
+
+// Verify program grader
+g = gcf.Graders[1]
+cfg, err = g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig program: %v", err)
+}
+pgc := cfg.(*ProgramConfig)
+if pgc.Command != "python" || len(pgc.Args) != 3 {
+t.Errorf("program config: command=%s args=%v", pgc.Command, pgc.Args)
+}
+
+// Verify behavior grader
+g = gcf.Graders[4]
+cfg, err = g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig behavior: %v", err)
+}
+bc := cfg.(*BehaviorConfig)
+if len(bc.RequiredTools) != 1 || bc.RequiredTools[0] != "azure-mcp" {
+t.Errorf("behavior required_tools: %v", bc.RequiredTools)
+}
+if bc.MaxTurns != 25 {
+t.Errorf("behavior max_turns: expected 25, got %d", bc.MaxTurns)
+}
+
+// Verify action_sequence grader
+g = gcf.Graders[5]
+cfg, err = g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig action_sequence: %v", err)
+}
+asc := cfg.(*ActionSequenceConfig)
+if len(asc.ExpectedActions) != 2 {
+t.Errorf("action_sequence expected_actions: %v", asc.ExpectedActions)
+}
+
+// Verify tool_constraint grader
+g = gcf.Graders[6]
+cfg, err = g.DecodeConfig()
+if err != nil {
+t.Fatalf("DecodeConfig tool_constraint: %v", err)
+}
+tc := cfg.(*ToolConstraintConfig)
+if tc.MinCalls != 1 || tc.MaxCalls != 50 {
+t.Errorf("tool_constraint: min=%d max=%d", tc.MinCalls, tc.MaxCalls)
+}
+}
+
+func TestParseRejectsDuplicateNames(t *testing.T) {
+yaml := `
+graders:
+  - kind: file
+    name: "dupe"
+    config:
+      path: "a.py"
+  - kind: file
+    name: "dupe"
+    config:
+      path: "b.py"
+`
+_, err := Parse([]byte(yaml))
+if err == nil {
+t.Fatal("expected error for duplicate names")
+}
+}
+
+func TestParseRejectsUnknownKind(t *testing.T) {
+yaml := `
+graders:
+  - kind: unknown_kind
+    name: "bad"
+    config:
+      path: "a.py"
+`
+_, err := Parse([]byte(yaml))
+if err == nil {
+t.Fatal("expected error for unknown kind")
+}
+}
+
+func TestParseRejectsInvalidWeight(t *testing.T) {
+yaml := `
+graders:
+  - kind: file
+    name: "bad_weight"
+    config:
+      path: "a.py"
+    weight: 1.5
+`
+_, err := Parse([]byte(yaml))
+if err == nil {
+t.Fatal("expected error for weight > 1.0")
+}
+}
+
+func TestWhenMapMatches(t *testing.T) {
+tests := []struct {
+name  string
+when  WhenMap
+props map[string]string
+want  bool
+}{
+{"empty when matches all", WhenMap{}, map[string]string{"language": "python"}, true},
+{"nil when matches all", nil, map[string]string{"language": "python"}, true},
+{"exact match", WhenMap{"language": "python"}, map[string]string{"language": "python"}, true},
+{"case insensitive", WhenMap{"language": "Python"}, map[string]string{"language": "python"}, true},
+{"missing property", WhenMap{"language": "python"}, map[string]string{}, false},
+{"wrong value", WhenMap{"language": "python"}, map[string]string{"language": "go"}, false},
+{"multi match", WhenMap{"language": "python", "service": "kv"}, map[string]string{"language": "python", "service": "kv"}, true},
+{"partial match fails", WhenMap{"language": "python", "service": "kv"}, map[string]string{"language": "python"}, false},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+if got := tt.when.Matches(tt.props); got != tt.want {
+t.Errorf("WhenMap.Matches() = %v, want %v", got, tt.want)
+}
+})
+}
+}
+
+func TestApplicableGraders(t *testing.T) {
+graders := []GraderConfig{
+{Kind: KindFile, Name: "py_only", When: WhenMap{"language": "python"}},
+{Kind: KindFile, Name: "all", When: nil},
+{Kind: KindFile, Name: "go_only", When: WhenMap{"language": "go"}},
+}
+
+applicable := ApplicableGraders(graders, map[string]string{"language": "python"})
+if len(applicable) != 2 {
+t.Fatalf("expected 2 applicable graders, got %d", len(applicable))
+}
+if applicable[0].Name != "py_only" || applicable[1].Name != "all" {
+t.Errorf("unexpected graders: %s, %s", applicable[0].Name, applicable[1].Name)
+}
+}
+
+func TestEffectiveWeight(t *testing.T) {
+g := GraderConfig{Weight: 0}
+if g.EffectiveWeight() != 1.0 {
+t.Errorf("expected default weight 1.0, got %f", g.EffectiveWeight())
+}
+g.Weight = 0.5
+if g.EffectiveWeight() != 0.5 {
+t.Errorf("expected weight 0.5, got %f", g.EffectiveWeight())
+}
+}


### PR DESCRIPTION
## Summary

Defines the grader config YAML schema that replaces the three-tier criteria system (Task 1.2a).

### Artifacts

- **`docs/grader-config-schema.md`** — Full schema specification:
  - Root schema with `kind`, `name`, `config`, `weight`, `gate`, `when` fields
  - Six grader kinds: `file`, `program`, `prompt`, `behavior`, `action_sequence`, `tool_constraint`
  - Kind-specific config field reference tables
  - Complete example with all grader kinds
  - Scoring algorithm (filter → execute → gate check → weighted average)
  - Migration guide from criteria system

- **`hyoka/internal/graders/types.go`** — Go type definitions:
  - `GraderConfig` with `yaml.Node` for polymorphic config decoding
  - `WhenMap` with case-insensitive property matching
  - Per-kind config structs (`FileConfig`, `ProgramConfig`, `PromptConfig`, etc.)
  - `Parse`, `LoadFile`, `LoadDir`, `Validate`, `ApplicableGraders` functions

- **`hyoka/internal/graders/types_test.go`** — Tests covering:
  - Full config parsing (all 6 kinds)
  - Validation: duplicate names, unknown kinds, invalid weights
  - `WhenMap.Matches()`: 8 sub-tests (nil, empty, exact, case-insensitive, missing, wrong, multi, partial)
  - `ApplicableGraders` filtering
  - `EffectiveWeight` default behavior

### Key Design Decisions

- **DM3**: `gate: bool` for hard pass/fail — failing gate overrides weighted scoring
- **DM19**: `prompt` grader uses one model per instance — multi-model review via multiple grader instances
- **`when: map[string]string`** replaces fixed `MatchCondition` struct — any prompt property can be used
- **`yaml.Node`** for polymorphic config — decoded per-kind via `DecodeConfig()`

Closes #103