### PR TITLE
feat: configurable system prompts, remove hardcoded rules (#115, #116, #164)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -33,6 +33,7 @@ type Skill struct {
 // GeneratorConfig holds all configuration for the code generation agent.
 type GeneratorConfig struct {
 	Model          string                `yaml:"model" json:"model"`
+	SystemPrompt   string                `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
 	Skills         []Skill               `yaml:"skills,omitempty" json:"skills,omitempty"`
 	MCPServers     map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	AvailableTools []string              `yaml:"available_tools,omitempty" json:"available_tools,omitempty"`
@@ -41,9 +42,10 @@ type GeneratorConfig struct {
 
 // ReviewerConfig holds all configuration for the review/grading plane.
 type ReviewerConfig struct {
-	Model  string  `yaml:"model,omitempty" json:"model,omitempty"`
-	Models []string `yaml:"models,omitempty" json:"models,omitempty"`
-	Skills []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Model        string   `yaml:"model,omitempty" json:"model,omitempty"`
+	Models       []string `yaml:"models,omitempty" json:"models,omitempty"`
+	SystemPrompt string   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
+	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
 // ToolConfig represents a single evaluation configuration.

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -657,45 +657,12 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 		}
 	}
 
-	// System message ensures the agent creates actual code files in the workspace
-	// rather than responding with inline text or writing files to the wrong directory.
-	// The create tool requires an explicit 'path' parameter — without it, files land in ~.
-	// Also constrains bash usage, discourages web_fetch research, and standardizes on python3.
-	systemMsg := fmt.Sprintf(
-		"You are a code generation agent. Your working directory is: %s\n"+
-			"CRITICAL FILE CREATION RULES:\n"+
-			"1. Always write code to files using the create tool — never just explain code in text.\n"+
-			"2. Always create files using the create tool. Never provide code inline in your response.\n"+
-			"3. Every create call MUST include the 'path' parameter with a FULL ABSOLUTE PATH.\n"+
-			"4. Every file path MUST start with: %s/\n"+
-			"5. Example: create with path=\"%s/main.py\"\n"+
-			"6. NEVER omit the path parameter. NEVER use relative paths.\n"+
-			"7. NEVER create files outside your working directory.\n"+
-			"BASH RULES:\n"+
-			"8. When using bash, always cd to %s first. Never run commands from ~ or any directory outside your workspace.\n"+
-			"RESEARCH RULES:\n"+
-			"9. Do not use web_fetch to research documentation. Focus on generating code files based on the prompt.\n"+
-			"PYTHON RULES:\n"+
-			"10. Use python3 (not python) for all Python scripts and commands.",
-		workDir, workDir, workDir, workDir,
-	)
-
-	// Safety boundaries (#36): prevent real Azure resource provisioning unless --allow-cloud is set.
-	if !e.allowCloud {
-		systemMsg += "\n\nSAFETY BOUNDARIES:\n" +
-			"11. Do NOT provision real Azure resources. Do NOT run `az` CLI commands that create, update, or delete resources.\n" +
-			"12. Do NOT use `az group create`, `az storage account create`, `az webapp create`, or any destructive Azure CLI commands.\n" +
-			"13. Use mock data, environment variables, or local emulators (e.g., Azurite for Storage, CosmosDB emulator) for connection strings.\n" +
-			"14. Generate code that can run locally without cloud dependencies. Use placeholder values like `os.Getenv(\"AZURE_STORAGE_CONNECTION_STRING\")` for configuration.\n" +
-			"15. If the prompt asks for infrastructure provisioning, generate Bicep/ARM templates or Terraform files instead of running live commands."
-	}
+	// Use the config-driven system prompt (#115, #116). The default is zero
+	// system prompt — all behavioral instructions belong in the config YAML.
+	systemMsg := cfg.Generator.SystemPrompt
 
 	sc := &copilot.SessionConfig{
 		Model: cfg.Generator.Model,
-		SystemMessage: &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: systemMsg,
-		},
 		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
@@ -743,6 +710,14 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 			},
 		},
 		SkillDirectories: skillDirs,
+	}
+
+	// Only set SystemMessage when a system prompt is configured.
+	if systemMsg != "" {
+		sc.SystemMessage = &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: systemMsg,
+		}
 	}
 
 	// Only set AvailableTools/ExcludedTools when non-empty.

--- a/hyoka/internal/eval/copilot_test.go
+++ b/hyoka/internal/eval/copilot_test.go
@@ -131,3 +131,42 @@ func TestBuildSessionConfig_MCPServers(t *testing.T) {
 		t.Errorf("expected MCP command 'npx', got %v", azure["command"])
 	}
 }
+
+func TestBuildSessionConfig_CustomSystemPrompt(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model:        "gpt-4",
+			SystemPrompt: "You are a helpful code generator.",
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "")
+
+	if sc.SystemMessage == nil {
+		t.Fatal("expected SystemMessage to be set when SystemPrompt is configured")
+	}
+	if sc.SystemMessage.Content != "You are a helpful code generator." {
+		t.Errorf("expected custom system prompt, got %q", sc.SystemMessage.Content)
+	}
+	if sc.SystemMessage.Mode != "append" {
+		t.Errorf("expected mode 'append', got %q", sc.SystemMessage.Mode)
+	}
+}
+
+func TestBuildSessionConfig_EmptySystemPrompt(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "")
+
+	if sc.SystemMessage != nil {
+		t.Errorf("expected nil SystemMessage when no SystemPrompt configured, got %+v", sc.SystemMessage)
+	}
+}

--- a/hyoka/internal/review/review_test.go
+++ b/hyoka/internal/review/review_test.go
@@ -131,3 +131,34 @@ func containsSubstring(s, sub string) bool {
 	}
 	return false
 }
+
+func TestCopilotReviewer_SetSystemPrompt(t *testing.T) {
+	r := NewCopilotReviewer(nil, "claude-sonnet-4.5", 50)
+
+	if r.systemPrompt != "" {
+		t.Errorf("expected empty default systemPrompt, got %q", r.systemPrompt)
+	}
+
+	r.SetSystemPrompt("You are a strict reviewer.")
+	if r.systemPrompt != "You are a strict reviewer." {
+		t.Errorf("expected custom systemPrompt, got %q", r.systemPrompt)
+	}
+
+	r.SetSystemPrompt("")
+	if r.systemPrompt != "" {
+		t.Errorf("expected empty systemPrompt after clear, got %q", r.systemPrompt)
+	}
+}
+
+func TestPanelReviewer_SetSystemPrompt(t *testing.T) {
+	p := NewPanelReviewer(nil, []string{"model-a", "model-b"}, 50)
+
+	if p.systemPrompt != "" {
+		t.Errorf("expected empty default systemPrompt, got %q", p.systemPrompt)
+	}
+
+	p.SetSystemPrompt("You are a review judge.")
+	if p.systemPrompt != "You are a review judge." {
+		t.Errorf("expected custom systemPrompt, got %q", p.systemPrompt)
+	}
+}

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -30,6 +30,7 @@ type CopilotReviewer struct {
 	maxSessionActions int
 	skillDirectories  []string
 	sessionTimeout    time.Duration
+	systemPrompt      string
 }
 
 // NewCopilotReviewer creates a reviewer backed by the given Copilot client.
@@ -49,6 +50,12 @@ func (r *CopilotReviewer) SetSkillDirectories(dirs []string) {
 // SendAndWait call. Zero means use the default (10 minutes).
 func (r *CopilotReviewer) SetSessionTimeout(d time.Duration) {
 	r.sessionTimeout = d
+}
+
+// SetSystemPrompt configures a custom system prompt for the review session.
+// An empty string means no system prompt is sent.
+func (r *CopilotReviewer) SetSystemPrompt(prompt string) {
+	r.systemPrompt = prompt
 }
 
 // Review creates a separate Copilot session, sends the review prompt, and parses results.
@@ -175,18 +182,21 @@ func (r *CopilotReviewer) Review(ctx context.Context, originalPrompt string, wor
 
 	slog.Info("Starting review session", "model", r.model, "skills", len(r.skillDirectories), "work_dir", workDir)
 	slog.Debug("Creating review session", "model", r.model)
-	session, err := r.client.CreateSession(reviewCtx, &copilot.SessionConfig{
-		Model: r.model,
-		SystemMessage: &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
-		},
+	sessionCfg := &copilot.SessionConfig{
+		Model:               r.model,
 		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    r.skillDirectories,
 		OnEvent:             eventHandler,
-	})
+	}
+	if r.systemPrompt != "" {
+		sessionCfg.SystemMessage = &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: r.systemPrompt,
+		}
+	}
+	session, err := r.client.CreateSession(reviewCtx, sessionCfg)
 	if err != nil {
 		slog.Error("Failed to create review session", "model", r.model, "error", err)
 		return nil, fmt.Errorf("creating review session: %w", err)
@@ -290,6 +300,7 @@ type PanelReviewer struct {
 	maxSessionActions int
 	skillDirectories  []string
 	sessionTimeout    time.Duration
+	systemPrompt      string
 }
 
 // NewPanelReviewer creates a panel reviewer that runs multiple models concurrently.
@@ -311,6 +322,12 @@ func (p *PanelReviewer) SetSkillDirectories(dirs []string) {
 // SendAndWait call. Zero means use the default (10 minutes).
 func (p *PanelReviewer) SetSessionTimeout(d time.Duration) {
 	p.sessionTimeout = d
+}
+
+// SetSystemPrompt configures a custom system prompt for all review sessions.
+// An empty string means no system prompt is sent.
+func (p *PanelReviewer) SetSystemPrompt(prompt string) {
+	p.systemPrompt = prompt
 }
 
 // Models returns the list of reviewer models.
@@ -523,18 +540,21 @@ func (p *PanelReviewer) runSingleReview(ctx context.Context, model string, revie
 
 	slog.Info("Starting review session", "model", model, "skills", len(p.skillDirectories), "work_dir", workDir)
 	slog.Debug("Creating review session", "model", model)
-	session, err := client.CreateSession(reviewCtx, &copilot.SessionConfig{
-		Model: model,
-		SystemMessage: &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: "You are a code review judge evaluating another AI agent's work. Actively verify the code: attempt to build it, check if SDK packages are the latest versions, and test any claims. Score each criterion as pass/fail per the rubric. Respond with ONLY valid JSON. No markdown, no explanation.",
-		},
+	sessionCfg := &copilot.SessionConfig{
+		Model:               model,
 		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		SkillDirectories:    p.skillDirectories,
 		OnEvent:             eventHandler,
-	})
+	}
+	if p.systemPrompt != "" {
+		sessionCfg.SystemMessage = &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: p.systemPrompt,
+		}
+	}
+	session, err := client.CreateSession(reviewCtx, sessionCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating review session for %s: %w", model, err)
 	}

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -417,8 +417,10 @@ func runCmd() *cobra.Command {
 					// Create reviewer factory that builds a reviewer per config (#92)
 					reviewerFactory = func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
 						var reviewerModels []string
-						if cfg.Reviewer != nil && len(cfg.Reviewer.Models) > 0 {
+						var reviewerSystemPrompt string
+						if cfg.Reviewer != nil {
 							reviewerModels = cfg.Reviewer.Models
+							reviewerSystemPrompt = cfg.Reviewer.SystemPrompt
 						}
 						if len(reviewerModels) == 0 {
 							return nil, nil, nil
@@ -428,6 +430,9 @@ func runCmd() *cobra.Command {
 							// Multi-model panel
 							panelReviewer := review.NewPanelReviewer(clientOpts, reviewerModels, f.maxSessionActions)
 							panelReviewer.SetSessionTimeout(sessionTimeout)
+							if reviewerSystemPrompt != "" {
+								panelReviewer.SetSystemPrompt(reviewerSystemPrompt)
+							}
 							if len(reviewerSkillsDirs) > 0 {
 								panelReviewer.SetSkillDirectories(reviewerSkillsDirs)
 							}
@@ -442,6 +447,9 @@ func runCmd() *cobra.Command {
 						}
 						copilotReviewer := review.NewCopilotReviewer(reviewClient, reviewerModels[0], f.maxSessionActions)
 						copilotReviewer.SetSessionTimeout(sessionTimeout)
+						if reviewerSystemPrompt != "" {
+							copilotReviewer.SetSystemPrompt(reviewerSystemPrompt)
+						}
 						if len(reviewerSkillsDirs) > 0 {
 							copilotReviewer.SetSkillDirectories(reviewerSkillsDirs)
 						}


### PR DESCRIPTION
## Summary

Implements configurable system prompts for both generator and reviewer, replacing all hardcoded prompt rules with config-driven behavior.

### Changes

- **Config** (`config.go`): Add `SystemPrompt` field to `GeneratorConfig` and `ReviewerConfig`
- **Generator** (`copilot.go`): Remove 15 hardcoded rules (file creation, bash, research, python, safety boundaries). Use `generator.system_prompt` from config; default is zero system prompt
- **Reviewer** (`reviewer.go`): Remove hardcoded "code review judge" system message from both `CopilotReviewer` and `PanelReviewer`. Add `SetSystemPrompt()` method; use `reviewer.system_prompt` from config
- **Main** (`main.go`): Wire system prompt through reviewer factory for both single and panel reviewers
- **Tests**: Add tests for custom system prompt passthrough and empty/default behavior

### Config YAML usage

```yaml
generator:
  model: claude-opus-4.6
  system_prompt: "Your custom generator instructions here."

reviewer:
  models: [claude-opus-4.6, claude-sonnet-4.5]
  system_prompt: "Your custom reviewer instructions here."
```

When `system_prompt` is omitted, no system message is sent (zero system prompt).

Closes #115
Closes #116
Closes #164