### PR TITLE
refactor: update filter flags to use Properties map (#102)

### DIFF
--- a/hyoka/internal/prompt/loader_test.go
+++ b/hyoka/internal/prompt/loader_test.go
@@ -149,15 +149,15 @@ func TestFilterPrompts(t *testing.T) {
 		expected int
 	}{
 		{"no filter", Filter{}, 3},
-		{"by service", Filter{Service: "storage"}, 2},
-		{"by language", Filter{Language: "dotnet"}, 1},
-		{"by plane", Filter{Plane: "data-plane"}, 2},
-		{"by category", Filter{Category: "authentication"}, 2},
+		{"by service", Filter{Filters: map[string]string{"service": "storage"}}, 2},
+		{"by language", Filter{Filters: map[string]string{"language": "dotnet"}}, 1},
+		{"by plane", Filter{Filters: map[string]string{"plane": "data-plane"}}, 2},
+		{"by category", Filter{Filters: map[string]string{"category": "authentication"}}, 2},
 		{"by tags", Filter{Tags: []string{"blob"}}, 2},
 		{"by multiple tags", Filter{Tags: []string{"blob", "identity"}}, 1},
 		{"by prompt ID", Filter{PromptID: "p2"}, 1},
-		{"combined filters", Filter{Service: "storage", Language: "dotnet"}, 1},
-		{"no match", Filter{Service: "cosmos"}, 0},
+		{"combined filters", Filter{Filters: map[string]string{"service": "storage", "language": "dotnet"}}, 1},
+		{"no match", Filter{Filters: map[string]string{"service": "cosmos"}}, 0},
 	}
 
 	for _, tt := range tests {
@@ -165,6 +165,72 @@ func TestFilterPrompts(t *testing.T) {
 			result := FilterPrompts(prompts, tt.filter)
 			if len(result) != tt.expected {
 				t.Errorf("expected %d results, got %d", tt.expected, len(result))
+			}
+		})
+	}
+}
+
+func TestFilterPromptsGenericFilter(t *testing.T) {
+	prompts := []*Prompt{
+		{ID: "p1", Properties: map[string]string{"service": "storage", "language": "dotnet", "difficulty": "beginner", "author": "alice"}},
+		{ID: "p2", Properties: map[string]string{"service": "keyvault", "language": "python", "difficulty": "advanced", "author": "bob"}},
+		{ID: "p3", Properties: map[string]string{"service": "storage", "language": "java", "difficulty": "beginner", "author": "bob"}},
+	}
+
+	tests := []struct {
+		name     string
+		filter   Filter
+		expected int
+	}{
+		{"by difficulty", Filter{Filters: map[string]string{"difficulty": "beginner"}}, 2},
+		{"by author", Filter{Filters: map[string]string{"author": "bob"}}, 2},
+		{"combined generic and alias", Filter{Filters: map[string]string{"service": "storage", "difficulty": "beginner"}}, 2},
+		{"all three", Filter{Filters: map[string]string{"service": "storage", "difficulty": "beginner", "author": "alice"}}, 1},
+		{"unknown key returns empty", Filter{Filters: map[string]string{"nonexistent": "val"}}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterPrompts(prompts, tt.filter)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d results, got %d", tt.expected, len(result))
+			}
+		})
+	}
+}
+
+func TestPromptProperty(t *testing.T) {
+	p := &Prompt{
+		Properties: map[string]string{
+			"service":     "storage",
+			"plane":       "data-plane",
+			"language":    "dotnet",
+			"category":    "authentication",
+			"difficulty":  "beginner",
+			"author":      "alice",
+			"sdk_package": "Azure.Storage.Blobs",
+		},
+	}
+
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"service", "storage"},
+		{"plane", "data-plane"},
+		{"language", "dotnet"},
+		{"category", "authentication"},
+		{"difficulty", "beginner"},
+		{"author", "alice"},
+		{"sdk_package", "Azure.Storage.Blobs"},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := p.Property(tt.key)
+			if got != tt.expected {
+				t.Errorf("Property(%q) = %q, want %q", tt.key, got, tt.expected)
 			}
 		})
 	}

--- a/hyoka/internal/prompt/types.go
+++ b/hyoka/internal/prompt/types.go
@@ -52,11 +52,10 @@ func (p *Prompt) Created() string     { return p.Properties["created"] }
 func (p *Prompt) Author() string      { return p.Properties["author"] }
 
 // Filter defines criteria for selecting prompts.
+// Filters is a map of property key to value pairs; all must match.
+// Tags and PromptID are handled separately.
 type Filter struct {
-Service  string
-Plane    string
-Language string
-Category string
+Filters  map[string]string
 Tags     []string
 PromptID string
 }
@@ -66,17 +65,10 @@ func (p *Prompt) Matches(f Filter) bool {
 if f.PromptID != "" && p.ID != f.PromptID {
 return false
 }
-if f.Service != "" && p.Service() != f.Service {
+for key, value := range f.Filters {
+if p.Property(key) != value {
 return false
 }
-if f.Plane != "" && p.Plane() != f.Plane {
-return false
-}
-if f.Language != "" && p.Language() != f.Language {
-return false
-}
-if f.Category != "" && p.Category() != f.Category {
-return false
 }
 if len(f.Tags) > 0 {
 tagSet := make(map[string]bool, len(p.Tags))

--- a/hyoka/main.go
+++ b/hyoka/main.go
@@ -129,6 +129,7 @@ type runFlags struct {
 	category     string
 	tags         string
 	promptID     string
+	filter       []string
 	configName   string
 	configFile   string
 	configDir    string
@@ -165,12 +166,13 @@ type runFlags struct {
 
 func addFilterFlags(cmd *cobra.Command, f *runFlags) {
 	cmd.Flags().StringVar(&f.prompts, "prompts", "./prompts", "Path to prompt library directory")
-	cmd.Flags().StringVar(&f.service, "service", "", "Filter by Azure service")
-	cmd.Flags().StringVar(&f.language, "language", "", "Filter by programming language")
-	cmd.Flags().StringVar(&f.plane, "plane", "", "Filter by data-plane/management-plane")
-	cmd.Flags().StringVar(&f.category, "category", "", "Filter by use-case category")
+	cmd.Flags().StringVar(&f.service, "service", "", "Filter by Azure service (shorthand for --filter service=VALUE)")
+	cmd.Flags().StringVar(&f.language, "language", "", "Filter by programming language (shorthand for --filter language=VALUE)")
+	cmd.Flags().StringVar(&f.plane, "plane", "", "Filter by data-plane/management-plane (shorthand for --filter plane=VALUE)")
+	cmd.Flags().StringVar(&f.category, "category", "", "Filter by use-case category (shorthand for --filter category=VALUE)")
 	cmd.Flags().StringVar(&f.tags, "tags", "", "Filter by tags (comma-separated)")
 	cmd.Flags().StringVar(&f.promptID, "prompt-id", "", "Run a single prompt by ID")
+	cmd.Flags().StringArrayVar(&f.filter, "filter", nil, "Filter by arbitrary property (key=value, repeatable)")
 	cmd.Flags().StringVar(&f.configName, "config", "", "Config name(s) from config file (comma-separated)")
 	cmd.Flags().StringVar(&f.configFile, "config-file", "", "Path to a specific configuration YAML file (default: load all from configs/)")
 	cmd.Flags().StringVar(&f.configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
@@ -253,11 +255,27 @@ func buildFilter(f *runFlags) prompt.Filter {
 			tags[i] = strings.TrimSpace(tags[i])
 		}
 	}
+	filters := make(map[string]string)
+	if f.service != "" {
+		filters["service"] = f.service
+	}
+	if f.plane != "" {
+		filters["plane"] = f.plane
+	}
+	if f.language != "" {
+		filters["language"] = f.language
+	}
+	if f.category != "" {
+		filters["category"] = f.category
+	}
+	for _, kv := range f.filter {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok && k != "" {
+			filters[k] = v
+		}
+	}
 	return prompt.Filter{
-		Service:  f.service,
-		Plane:    f.plane,
-		Language: f.language,
-		Category: f.category,
+		Filters:  filters,
 		Tags:     tags,
 		PromptID: f.promptID,
 	}


### PR DESCRIPTION
## Summary

Refactors the prompt filter system to use a generic `Filters map[string]string` instead of typed fields. This prepares for the Properties map migration (issue #102, task 1.1c).

### Changes

- **`Filter` struct**: Replaced typed fields (`Service`, `Plane`, `Language`, `Category`) with `Filters map[string]string`
- **`Prompt.Property(key)`**: New getter method bridging typed struct fields to map-based lookups
- **`--filter key=value` flag**: New generic CLI flag for arbitrary property filtering (repeatable)
- **CLI aliases preserved**: `--service`, `--language`, `--plane`, `--category` still work as shorthands that populate the Filters map
- **`Matches()`**: Now iterates the Filters map and calls `Property(key)` for each entry

### New tests

- `TestFilterPromptsGenericFilter` — tests difficulty, author, combined filters, unknown keys
- `TestPromptProperty` — validates all known property keys and unknown fallback

Closes #102