### PR TITLE
refactor: migrate all prompts to nested properties format (#101)

### DIFF
--- a/hyoka/internal/prompt/loader_test.go
+++ b/hyoka/internal/prompt/loader_test.go
@@ -42,6 +42,77 @@ using DefaultAzureCredential and lists all containers in the storage account.
 This is a beginner-level prompt for testing.
 `
 
+const testPromptContentNested = `---
+id: storage-auth-dotnet
+properties:
+  service: storage
+  plane: data-plane
+  language: dotnet
+  category: authentication
+  difficulty: beginner
+  description: "Authenticate to Azure Blob Storage using DefaultAzureCredential"
+  sdk_package: Azure.Storage.Blobs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs
+  created: "2024-01-15"
+  author: test
+tags:
+  - authentication
+  - blob
+  - identity
+expected_packages:
+  - Azure.Storage.Blobs
+  - Azure.Identity
+expected_tools:
+  - create_file
+  - run_terminal_command
+---
+
+# Storage Authentication (.NET)
+
+## Prompt
+
+Write a C# console application that authenticates to Azure Blob Storage
+using DefaultAzureCredential and lists all containers in the storage account.
+
+## Notes
+
+This is a beginner-level prompt for testing.
+`
+
+func TestParsePromptFileNested(t *testing.T) {
+	p, err := ParsePromptFile([]byte(testPromptContentNested), "test-nested.prompt.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ID != "storage-auth-dotnet" {
+		t.Errorf("expected ID 'storage-auth-dotnet', got %q", p.ID)
+	}
+	if p.Service() != "storage" {
+		t.Errorf("expected service 'storage', got %q", p.Service())
+	}
+	if p.Plane() != "data-plane" {
+		t.Errorf("expected plane 'data-plane', got %q", p.Plane())
+	}
+	if p.Language() != "dotnet" {
+		t.Errorf("expected language 'dotnet', got %q", p.Language())
+	}
+	if p.Category() != "authentication" {
+		t.Errorf("expected category 'authentication', got %q", p.Category())
+	}
+	if p.Properties == nil || p.Properties["service"] != "storage" {
+		t.Errorf("expected properties[service] 'storage', got %v", p.Properties)
+	}
+	if len(p.Tags) != 3 {
+		t.Errorf("expected 3 tags, got %d", len(p.Tags))
+	}
+	if len(p.ExpectedPkgs) != 2 {
+		t.Errorf("expected 2 expected_packages, got %d", len(p.ExpectedPkgs))
+	}
+	if p.PromptText == "" {
+		t.Error("expected non-empty prompt text")
+	}
+}
+
 func TestParsePromptFile(t *testing.T) {
 	p, err := ParsePromptFile([]byte(testPromptContent), "test.prompt.md")
 	if err != nil {

--- a/prompts/app-configuration/data-plane/dotnet/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/dotnet/config-values.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: app-configuration-dp-dotnet-crud
-service: app-configuration
-plane: data-plane
-language: dotnet
-category: crud
-difficulty: basic
-description: >
-  Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the .NET SDK?
-sdk_package: Azure.Data.AppConfiguration
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/data.appconfiguration-readme
+properties:
+  service: app-configuration
+  plane: data-plane
+  language: dotnet
+  category: crud
+  difficulty: basic
+  description: 'Can a developer read and write configuration values and feature flags in Azure App Configuration using the
+    .NET SDK?
+
+    '
+  sdk_package: Azure.Data.AppConfiguration
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/data.appconfiguration-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - app-configuration
-  - configuration
-  - feature-flags
-  - crud
-created: 2025-07-28
-author: ronniegeraghty
+- app-configuration
+- configuration
+- feature-flags
+- crud
 ---
 
 # Configuration Values: Azure App Configuration (.NET)

--- a/prompts/app-configuration/data-plane/java/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/java/config-values.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: app-configuration-dp-java-crud
-service: app-configuration
-plane: data-plane
-language: java
-category: crud
-difficulty: basic
-description: >
-  Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the Java SDK?
-sdk_package: azure-data-appconfiguration
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/data-appconfiguration-readme
+properties:
+  service: app-configuration
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: basic
+  description: 'Can a developer read and write configuration values and feature flags in Azure App Configuration using the
+    Java SDK?
+
+    '
+  sdk_package: azure-data-appconfiguration
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/data-appconfiguration-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - app-configuration
-  - configuration
-  - feature-flags
-  - crud
-created: 2025-07-28
-author: ronniegeraghty
+- app-configuration
+- configuration
+- feature-flags
+- crud
 ---
 
 # Configuration Values: Azure App Configuration (Java)

--- a/prompts/app-configuration/data-plane/java/feature-flags.prompt.md
+++ b/prompts/app-configuration/data-plane/java/feature-flags.prompt.md
@@ -1,28 +1,29 @@
 ---
 id: app-configuration-dp-java-feature-flags
-service: app-configuration
-plane: data-plane
-language: java
-category: crud
-difficulty: intermediate
-description: >
-  Can an agent generate a feature flag and configuration management system using
-  Azure App Configuration with label-based settings, conditional reads with ETags,
-  percentage-based rollout, and sentinel key watching?
-sdk_package: com.azure:azure-data-appconfiguration
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/data-appconfiguration-readme
+properties:
+  service: app-configuration
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: intermediate
+  description: 'Can an agent generate a feature flag and configuration management system using Azure App Configuration with
+    label-based settings, conditional reads with ETags, percentage-based rollout, and sentinel key watching?
+
+    '
+  sdk_package: com.azure:azure-data-appconfiguration
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/data-appconfiguration-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - app-configuration
-  - feature-flags
-  - etag
-  - conditional-reads
-  - labels
-  - sentinel-key
-  - percentage-rollout
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- app-configuration
+- feature-flags
+- etag
+- conditional-reads
+- labels
+- sentinel-key
+- percentage-rollout
+- async
+- reactor
 ---
 
 # Feature Flag Management: Azure App Configuration (Java)

--- a/prompts/app-configuration/data-plane/js-ts/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/js-ts/config-values.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: app-configuration-dp-js-ts-crud
-service: app-configuration
-plane: data-plane
-language: js-ts
-category: crud
-difficulty: basic
-description: >
-  Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/app-configuration"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/app-configuration-readme
+properties:
+  service: app-configuration
+  plane: data-plane
+  language: js-ts
+  category: crud
+  difficulty: basic
+  description: 'Can a developer read and write configuration values and feature flags in Azure App Configuration using the
+    JavaScript/TypeScript SDK?
+
+    '
+  sdk_package: '@azure/app-configuration'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/app-configuration-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - app-configuration
-  - configuration
-  - feature-flags
-  - crud
-created: 2025-07-28
-author: ronniegeraghty
+- app-configuration
+- configuration
+- feature-flags
+- crud
 ---
 
 # Configuration Values: Azure App Configuration (JavaScript/TypeScript)

--- a/prompts/app-configuration/data-plane/python/config-values.prompt.md
+++ b/prompts/app-configuration/data-plane/python/config-values.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: app-configuration-dp-python-crud
-service: app-configuration
-plane: data-plane
-language: python
-category: crud
-difficulty: basic
-description: >
-  Can a developer read and write configuration values and feature flags
-  in Azure App Configuration using the Python SDK?
-sdk_package: azure-appconfiguration
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/appconfiguration-readme
+properties:
+  service: app-configuration
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Can a developer read and write configuration values and feature flags in Azure App Configuration using the
+    Python SDK?
+
+    '
+  sdk_package: azure-appconfiguration
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/appconfiguration-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - app-configuration
-  - configuration
-  - feature-flags
-  - crud
-created: 2025-07-28
-author: ronniegeraghty
+- app-configuration
+- configuration
+- feature-flags
+- crud
 ---
 
 # Configuration Values: Azure App Configuration (Python)

--- a/prompts/cosmos-db/data-plane/dotnet/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/crud-items.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: cosmos-db-dp-dotnet-crud
-service: cosmos-db
-plane: data-plane
-language: dotnet
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the .NET SDK?
-sdk_package: Microsoft.Azure.Cosmos
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: dotnet
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, query, and delete items in an Azure Cosmos DB container using the .NET SDK?
+
+    '
+  sdk_package: Microsoft.Azure.Cosmos
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - cosmos-db
-  - nosql
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- cosmos-db
+- nosql
+- crud
+- getting-started
 ---
 
 # CRUD Items: Azure Cosmos DB (.NET)

--- a/prompts/cosmos-db/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/error-handling.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: cosmos-db-dp-dotnet-error-handling
-service: cosmos-db
-plane: data-plane
-language: dotnet
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle Cosmos DB errors including
-  throttling (429), conflicts (409), and not-found (404) in .NET?
-sdk_package: Microsoft.Azure.Cosmos
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: dotnet
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle Cosmos DB errors including throttling (429), conflicts (409), and not-found (404) in
+    .NET?
+
+    '
+  sdk_package: Microsoft.Azure.Cosmos
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - throttling
-  - request-units
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- throttling
+- request-units
 ---
 
 # Error Handling: Azure Cosmos DB (.NET)

--- a/prompts/cosmos-db/data-plane/dotnet/pagination-query-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/dotnet/pagination-query-items.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: cosmos-db-dp-dotnet-pagination
-service: cosmos-db
-plane: data-plane
-language: dotnet
-category: pagination
-difficulty: intermediate
-description: >
-  Can a developer paginate through large Cosmos DB query results
-  using continuation tokens in .NET?
-sdk_package: Microsoft.Azure.Cosmos
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: dotnet
+  category: pagination
+  difficulty: intermediate
+  description: 'Can a developer paginate through large Cosmos DB query results using continuation tokens in .NET?
+
+    '
+  sdk_package: Microsoft.Azure.Cosmos
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.cosmos-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - pagination
-  - query
-  - continuation-token
-  - feed-iterator
-created: 2025-07-27
-author: ronniegeraghty
+- pagination
+- query
+- continuation-token
+- feed-iterator
 ---
 
 # Pagination: Query Items in Azure Cosmos DB (.NET)

--- a/prompts/cosmos-db/data-plane/java/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/java/crud-items.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: cosmos-db-dp-java-crud
-service: cosmos-db
-plane: data-plane
-language: java
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the Java SDK?
-sdk_package: azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, query, and delete items in an Azure Cosmos DB container using the Java SDK?
+
+    '
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/cosmos-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - cosmos-db
-  - nosql
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- cosmos-db
+- nosql
+- crud
+- getting-started
 ---
 
 # CRUD Items: Azure Cosmos DB (Java)

--- a/prompts/cosmos-db/data-plane/java/todo-repository.prompt.md
+++ b/prompts/cosmos-db/data-plane/java/todo-repository.prompt.md
@@ -1,29 +1,30 @@
 ---
 id: cosmos-db-dp-java-todo-repository
-service: cosmos-db
-plane: data-plane
-language: java
-category: crud
-difficulty: intermediate
-description: >
-  Can an agent generate a Cosmos DB CRUD repository with optimistic concurrency
-  (ETags), parameterized queries, page-by-page pagination, TTL configuration,
-  custom indexing policy, and RU cost logging?
-sdk_package: com.azure:azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: intermediate
+  description: 'Can an agent generate a Cosmos DB CRUD repository with optimistic concurrency (ETags), parameterized queries,
+    page-by-page pagination, TTL configuration, custom indexing policy, and RU cost logging?
+
+    '
+  sdk_package: com.azure:azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/cosmos-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - cosmos-db
-  - etag
-  - optimistic-concurrency
-  - pagination
-  - parameterized-query
-  - ttl
-  - indexing-policy
-  - request-charge
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- cosmos-db
+- etag
+- optimistic-concurrency
+- pagination
+- parameterized-query
+- ttl
+- indexing-policy
+- request-charge
+- async
+- reactor
 ---
 
 # ToDo Repository: Azure Cosmos DB (Java)

--- a/prompts/cosmos-db/data-plane/js-ts/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/js-ts/crud-items.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: cosmos-db-dp-js-ts-crud
-service: cosmos-db
-plane: data-plane
-language: js-ts
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/cosmos"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: js-ts
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, query, and delete items in an Azure Cosmos DB container using the JavaScript/TypeScript
+    SDK?
+
+    '
+  sdk_package: '@azure/cosmos'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/cosmos-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - cosmos-db
-  - nosql
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- cosmos-db
+- nosql
+- crud
+- getting-started
 ---
 
 # CRUD Items: Azure Cosmos DB (JavaScript/TypeScript)

--- a/prompts/cosmos-db/data-plane/python/crud-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/crud-items.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: cosmos-db-dp-python-crud
-service: cosmos-db
-plane: data-plane
-language: python
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, query, and delete items in an Azure Cosmos DB
-  container using the Python SDK?
-sdk_package: azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, query, and delete items in an Azure Cosmos DB container using the Python SDK?
+
+    '
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - cosmos-db
-  - nosql
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- cosmos-db
+- nosql
+- crud
+- getting-started
 ---
 
 # CRUD Items: Azure Cosmos DB (Python)

--- a/prompts/cosmos-db/data-plane/python/error-handling.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/error-handling.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: cosmos-db-dp-python-error-handling
-service: cosmos-db
-plane: data-plane
-language: python
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle Cosmos DB errors including
-  throttling (429), conflicts (409), and not-found (404) in Python?
-sdk_package: azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: python
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle Cosmos DB errors including throttling (429), conflicts (409), and not-found (404) in
+    Python?
+
+    '
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - throttling
-  - request-units
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- throttling
+- request-units
 ---
 
 # Error Handling: Azure Cosmos DB (Python)

--- a/prompts/cosmos-db/data-plane/python/pagination-query-items.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/pagination-query-items.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: cosmos-db-dp-python-pagination
-service: cosmos-db
-plane: data-plane
-language: python
-category: pagination
-difficulty: intermediate
-description: >
-  Can a developer paginate through large Cosmos DB query results
-  using continuation tokens in Python?
-sdk_package: azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: python
+  category: pagination
+  difficulty: intermediate
+  description: 'Can a developer paginate through large Cosmos DB query results using continuation tokens in Python?
+
+    '
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - pagination
-  - query
-  - continuation-token
-created: 2025-07-27
-author: ronniegeraghty
+- pagination
+- query
+- continuation-token
 ---
 
 # Pagination: Query Items in Azure Cosmos DB (Python)

--- a/prompts/cosmos-db/data-plane/python/retry-configuration.prompt.md
+++ b/prompts/cosmos-db/data-plane/python/retry-configuration.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: cosmos-db-dp-python-retries
-service: cosmos-db
-plane: data-plane
-language: python
-category: retries
-difficulty: advanced
-description: >
-  Can a developer configure custom retry policies for Azure Cosmos DB
-  including 429 throttle handling and connection retry in Python?
-sdk_package: azure-cosmos
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: python
+  category: retries
+  difficulty: advanced
+  description: 'Can a developer configure custom retry policies for Azure Cosmos DB including 429 throttle handling and connection
+    retry in Python?
+
+    '
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/cosmos-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - retries
-  - retry-policy
-  - throttling
-  - request-units
-created: 2025-07-27
-author: ronniegeraghty
+- retries
+- retry-policy
+- throttling
+- request-units
 ---
 
 # Retry Configuration: Azure Cosmos DB (Python)

--- a/prompts/event-hubs/data-plane/dotnet/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/dotnet/send-receive-events.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: event-hubs-dp-dotnet-streaming
-service: event-hubs
-plane: data-plane
-language: dotnet
-category: streaming
-difficulty: intermediate
-description: >
-  Can a developer send and receive events using Azure Event Hubs
-  with the .NET SDK?
-sdk_package: Azure.Messaging.EventHubs
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.eventhubs-readme
+properties:
+  service: event-hubs
+  plane: data-plane
+  language: dotnet
+  category: streaming
+  difficulty: intermediate
+  description: 'Can a developer send and receive events using Azure Event Hubs with the .NET SDK?
+
+    '
+  sdk_package: Azure.Messaging.EventHubs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.eventhubs-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - event-hubs
-  - streaming
-  - producer
-  - consumer
-created: 2025-07-28
-author: ronniegeraghty
+- event-hubs
+- streaming
+- producer
+- consumer
 ---
 
 # Send and Receive Events: Azure Event Hubs (.NET)

--- a/prompts/event-hubs/data-plane/java/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/java/send-receive-events.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: event-hubs-dp-java-streaming
-service: event-hubs
-plane: data-plane
-language: java
-category: streaming
-difficulty: intermediate
-description: >
-  Can a developer send and receive events using Azure Event Hubs
-  with the Java SDK?
-sdk_package: azure-messaging-eventhubs
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-eventhubs-readme
+properties:
+  service: event-hubs
+  plane: data-plane
+  language: java
+  category: streaming
+  difficulty: intermediate
+  description: 'Can a developer send and receive events using Azure Event Hubs with the Java SDK?
+
+    '
+  sdk_package: azure-messaging-eventhubs
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-eventhubs-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - event-hubs
-  - streaming
-  - producer
-  - consumer
-created: 2025-07-28
-author: ronniegeraghty
+- event-hubs
+- streaming
+- producer
+- consumer
 ---
 
 # Send and Receive Events: Azure Event Hubs (Java)

--- a/prompts/event-hubs/data-plane/js-ts/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/js-ts/send-receive-events.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: event-hubs-dp-js-ts-streaming
-service: event-hubs
-plane: data-plane
-language: js-ts
-category: streaming
-difficulty: intermediate
-description: >
-  Can a developer send and receive events using Azure Event Hubs
-  with the JavaScript/TypeScript SDK?
-sdk_package: "@azure/event-hubs"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/event-hubs-readme
+properties:
+  service: event-hubs
+  plane: data-plane
+  language: js-ts
+  category: streaming
+  difficulty: intermediate
+  description: 'Can a developer send and receive events using Azure Event Hubs with the JavaScript/TypeScript SDK?
+
+    '
+  sdk_package: '@azure/event-hubs'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/event-hubs-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - event-hubs
-  - streaming
-  - producer
-  - consumer
-created: 2025-07-28
-author: ronniegeraghty
+- event-hubs
+- streaming
+- producer
+- consumer
 ---
 
 # Send and Receive Events: Azure Event Hubs (JavaScript/TypeScript)

--- a/prompts/event-hubs/data-plane/python/send-receive-events.prompt.md
+++ b/prompts/event-hubs/data-plane/python/send-receive-events.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: event-hubs-dp-python-streaming
-service: event-hubs
-plane: data-plane
-language: python
-category: streaming
-difficulty: intermediate
-description: >
-  Can a developer send and receive events using Azure Event Hubs
-  with the Python SDK?
-sdk_package: azure-eventhub
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/eventhub-readme
+properties:
+  service: event-hubs
+  plane: data-plane
+  language: python
+  category: streaming
+  difficulty: intermediate
+  description: 'Can a developer send and receive events using Azure Event Hubs with the Python SDK?
+
+    '
+  sdk_package: azure-eventhub
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/eventhub-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - event-hubs
-  - streaming
-  - producer
-  - consumer
-created: 2025-07-28
-author: ronniegeraghty
+- event-hubs
+- streaming
+- producer
+- consumer
 ---
 
 # Send and Receive Events: Azure Event Hubs (Python)

--- a/prompts/identity/data-plane/cpp/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/cpp/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-cpp-default-credential
-service: identity
-plane: data-plane
-language: cpp
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the C++ SDK?
-sdk_package: azure-identity-cpp
-doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+properties:
+  service: identity
+  plane: data-plane
+  language: cpp
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the C++ SDK?
+
+    '
+  sdk_package: azure-identity-cpp
+  doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (C++)

--- a/prompts/identity/data-plane/cpp/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/cpp/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-cpp-managed-identity
-service: identity
-plane: data-plane
-language: cpp
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the C++ SDK?
-sdk_package: azure-identity-cpp
-doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+properties:
+  service: identity
+  plane: data-plane
+  language: cpp
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the C++ SDK?
+
+    '
+  sdk_package: azure-identity-cpp
+  doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (C++)

--- a/prompts/identity/data-plane/cpp/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/cpp/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-cpp-service-principal
-service: identity
-plane: data-plane
-language: cpp
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the C++ SDK?
-sdk_package: azure-identity-cpp
-doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+properties:
+  service: identity
+  plane: data-plane
+  language: cpp
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the C++ SDK?
+
+    '
+  sdk_package: azure-identity-cpp
+  doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (C++)

--- a/prompts/identity/data-plane/dotnet/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/dotnet/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-dotnet-default-credential
-service: identity
-plane: data-plane
-language: dotnet
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the .NET SDK?
-sdk_package: Azure.Identity
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: dotnet
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the .NET SDK?
+
+    '
+  sdk_package: Azure.Identity
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (.NET)

--- a/prompts/identity/data-plane/dotnet/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/dotnet/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-dotnet-managed-identity
-service: identity
-plane: data-plane
-language: dotnet
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the .NET SDK?
-sdk_package: Azure.Identity
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: dotnet
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the .NET SDK?
+
+    '
+  sdk_package: Azure.Identity
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (.NET)

--- a/prompts/identity/data-plane/dotnet/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/dotnet/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-dotnet-service-principal
-service: identity
-plane: data-plane
-language: dotnet
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the .NET SDK?
-sdk_package: Azure.Identity
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: dotnet
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the .NET SDK?
+
+    '
+  sdk_package: Azure.Identity
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (.NET)

--- a/prompts/identity/data-plane/go/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/go/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-go-default-credential
-service: identity
-plane: data-plane
-language: go
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Go SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+properties:
+  service: identity
+  plane: data-plane
+  language: go
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the Go SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (Go)

--- a/prompts/identity/data-plane/go/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/go/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-go-managed-identity
-service: identity
-plane: data-plane
-language: go
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Go SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+properties:
+  service: identity
+  plane: data-plane
+  language: go
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the Go SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (Go)

--- a/prompts/identity/data-plane/go/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/go/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-go-service-principal
-service: identity
-plane: data-plane
-language: go
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the Go SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+properties:
+  service: identity
+  plane: data-plane
+  language: go
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the Go SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (Go)

--- a/prompts/identity/data-plane/java/credential-chain.prompt.md
+++ b/prompts/identity/data-plane/java/credential-chain.prompt.md
@@ -1,28 +1,29 @@
 ---
 id: identity-dp-java-credential-chain
-service: identity
-plane: data-plane
-language: java
-category: auth
-difficulty: intermediate
-description: >
-  Can an agent build environment-specific Azure credential chains (dev, CI,
-  production) using ChainedTokenCredential, with managed identity, workload
-  identity, CAE support, and environment auto-detection?
-sdk_package: com.azure:azure-identity
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: java
+  category: auth
+  difficulty: intermediate
+  description: 'Can an agent build environment-specific Azure credential chains (dev, CI, production) using ChainedTokenCredential,
+    with managed identity, workload identity, CAE support, and environment auto-detection?
+
+    '
+  sdk_package: com.azure:azure-identity
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - identity
-  - chained-credential
-  - managed-identity
-  - workload-identity
-  - cae
-  - environment-detection
-  - azure-pipelines
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- identity
+- chained-credential
+- managed-identity
+- workload-identity
+- cae
+- environment-detection
+- azure-pipelines
+- async
+- reactor
 ---
 
 # Credential Chain Builder: Azure Identity (Java)

--- a/prompts/identity/data-plane/java/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/java/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-java-default-credential
-service: identity
-plane: data-plane
-language: java
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Java SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: java
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the Java SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (Java)

--- a/prompts/identity/data-plane/java/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/java/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-java-managed-identity
-service: identity
-plane: data-plane
-language: java
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Java SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: java
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the Java SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (Java)

--- a/prompts/identity/data-plane/java/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/java/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-java-service-principal
-service: identity
-plane: data-plane
-language: java
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the Java SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: java
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the Java SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (Java)

--- a/prompts/identity/data-plane/js-ts/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/js-ts/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-js-ts-default-credential
-service: identity
-plane: data-plane
-language: js-ts
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/identity"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: js-ts
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the JavaScript/TypeScript SDK?
+
+    '
+  sdk_package: '@azure/identity'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (JavaScript/TypeScript)

--- a/prompts/identity/data-plane/js-ts/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/js-ts/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-js-ts-managed-identity
-service: identity
-plane: data-plane
-language: js-ts
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/identity"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: js-ts
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the JavaScript/TypeScript SDK?
+
+    '
+  sdk_package: '@azure/identity'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (JavaScript/TypeScript)

--- a/prompts/identity/data-plane/js-ts/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/js-ts/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-js-ts-service-principal
-service: identity
-plane: data-plane
-language: js-ts
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/identity"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: js-ts
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the JavaScript/TypeScript SDK?
+
+    '
+  sdk_package: '@azure/identity'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (JavaScript/TypeScript)

--- a/prompts/identity/data-plane/python/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/python/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-python-default-credential
-service: identity
-plane: data-plane
-language: python
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Python SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: python
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the Python SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (Python)

--- a/prompts/identity/data-plane/python/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/python/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-python-managed-identity
-service: identity
-plane: data-plane
-language: python
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Python SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: python
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the Python SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (Python)

--- a/prompts/identity/data-plane/python/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/python/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-python-service-principal
-service: identity
-plane: data-plane
-language: python
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the Python SDK?
-sdk_package: azure-identity
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+properties:
+  service: identity
+  plane: data-plane
+  language: python
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the Python SDK?
+
+    '
+  sdk_package: azure-identity
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (Python)

--- a/prompts/identity/data-plane/rust/default-azure-credential.prompt.md
+++ b/prompts/identity/data-plane/rust/default-azure-credential.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-rust-default-credential
-service: identity
-plane: data-plane
-language: rust
-category: auth
-difficulty: basic
-description: >
-  Can a developer set up DefaultAzureCredential for Azure SDK clients
-  using the Rust SDK?
-sdk_package: azure_identity
-doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+properties:
+  service: identity
+  plane: data-plane
+  language: rust
+  category: auth
+  difficulty: basic
+  description: 'Can a developer set up DefaultAzureCredential for Azure SDK clients using the Rust SDK?
+
+    '
+  sdk_package: azure_identity
+  doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - default-azure-credential
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- default-azure-credential
+- getting-started
 ---
 
 # DefaultAzureCredential: Azure Identity (Rust)

--- a/prompts/identity/data-plane/rust/managed-identity-auth.prompt.md
+++ b/prompts/identity/data-plane/rust/managed-identity-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-rust-managed-identity
-service: identity
-plane: data-plane
-language: rust
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer use Managed Identity to authenticate Azure SDK clients
-  using the Rust SDK?
-sdk_package: azure_identity
-doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+properties:
+  service: identity
+  plane: data-plane
+  language: rust
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer use Managed Identity to authenticate Azure SDK clients using the Rust SDK?
+
+    '
+  sdk_package: azure_identity
+  doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - managed-identity
-  - azure-hosted
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- managed-identity
+- azure-hosted
 ---
 
 # Managed Identity Authentication: Azure Identity (Rust)

--- a/prompts/identity/data-plane/rust/service-principal-auth.prompt.md
+++ b/prompts/identity/data-plane/rust/service-principal-auth.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: identity-dp-rust-service-principal
-service: identity
-plane: data-plane
-language: rust
-category: auth
-difficulty: intermediate
-description: >
-  Can a developer authenticate with a Service Principal (client secret)
-  using the Rust SDK?
-sdk_package: azure_identity
-doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+properties:
+  service: identity
+  plane: data-plane
+  language: rust
+  category: auth
+  difficulty: intermediate
+  description: 'Can a developer authenticate with a Service Principal (client secret) using the Rust SDK?
+
+    '
+  sdk_package: azure_identity
+  doc_url: https://docs.rs/azure_identity/latest/azure_identity/
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - authentication
-  - service-principal
-  - client-secret
-created: 2025-07-28
-author: ronniegeraghty
+- authentication
+- service-principal
+- client-secret
 ---
 
 # Service Principal Authentication: Azure Identity (Rust)

--- a/prompts/key-vault/data-plane/cpp/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/cpp/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-cpp-crud
-service: key-vault
-plane: data-plane
-language: cpp
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the C++ SDK?
-sdk_package: azure-security-keyvault-secrets-cpp
-doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-secrets
+properties:
+  service: key-vault
+  plane: data-plane
+  language: cpp
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the C++ SDK?
+
+    '
+  sdk_package: azure-security-keyvault-secrets-cpp
+  doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-secrets
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (C++)

--- a/prompts/key-vault/data-plane/dotnet/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-dotnet-crud
-service: key-vault
-plane: data-plane
-language: dotnet
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the .NET SDK?
-sdk_package: Azure.Security.KeyVault.Secrets
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: dotnet
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the .NET SDK?
+
+    '
+  sdk_package: Azure.Security.KeyVault.Secrets
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (.NET)

--- a/prompts/key-vault/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/error-handling.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: key-vault-dp-dotnet-error-handling
-service: key-vault
-plane: data-plane
-language: dotnet
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle Key Vault errors including
-  access denied (403), secret not found (404), and throttling (429) in .NET?
-sdk_package: Azure.Security.KeyVault.Secrets
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: dotnet
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle Key Vault errors including access denied (403), secret not found (404), and throttling
+    (429) in .NET?
+
+    '
+  sdk_package: Azure.Security.KeyVault.Secrets
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - access-policy
-  - throttling
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- access-policy
+- throttling
 ---
 
 # Error Handling: Azure Key Vault Secrets (.NET)

--- a/prompts/key-vault/data-plane/dotnet/pagination-list-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/dotnet/pagination-list-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-dotnet-pagination
-service: key-vault
-plane: data-plane
-language: dotnet
-category: pagination
-difficulty: intermediate
-description: >
-  Can a developer paginate through a large list of Key Vault secrets
-  using the .NET SDK?
-sdk_package: Azure.Security.KeyVault.Secrets
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: dotnet
+  category: pagination
+  difficulty: intermediate
+  description: 'Can a developer paginate through a large list of Key Vault secrets using the .NET SDK?
+
+    '
+  sdk_package: Azure.Security.KeyVault.Secrets
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/security.keyvault.secrets-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - pagination
-  - list-secrets
-  - async
-created: 2025-07-27
-author: ronniegeraghty
+- pagination
+- list-secrets
+- async
 ---
 
 # Pagination: List Key Vault Secrets (.NET)

--- a/prompts/key-vault/data-plane/go/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/go/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-go-crud
-service: key-vault
-plane: data-plane
-language: go
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Go SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
+properties:
+  service: key-vault
+  plane: data-plane
+  language: go
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the Go SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (Go)

--- a/prompts/key-vault/data-plane/java/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/java/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-java-crud
-service: key-vault
-plane: data-plane
-language: java
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Java SDK?
-sdk_package: azure-security-keyvault-secrets
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/security-keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the Java SDK?
+
+    '
+  sdk_package: azure-security-keyvault-secrets
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/security-keyvault-secrets-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (Java)

--- a/prompts/key-vault/data-plane/java/secret-config.prompt.md
+++ b/prompts/key-vault/data-plane/java/secret-config.prompt.md
@@ -1,30 +1,31 @@
 ---
 id: key-vault-dp-java-secret-config
-service: key-vault
-plane: data-plane
-language: java
-category: crud
-difficulty: intermediate
-description: >
-  Can an agent generate a Key Vault-backed configuration provider with secret
-  versioning, expiry inspection, in-memory caching with bulk-load, and safe
-  secret rotation using long-running delete operations (SyncPoller/PollerFlux)?
-sdk_package: com.azure:azure-security-keyvault-secrets
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/security-keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: intermediate
+  description: 'Can an agent generate a Key Vault-backed configuration provider with secret versioning, expiry inspection,
+    in-memory caching with bulk-load, and safe secret rotation using long-running delete operations (SyncPoller/PollerFlux)?
+
+    '
+  sdk_package: com.azure:azure-security-keyvault-secrets
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/security-keyvault-secrets-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - key-vault
-  - secrets
-  - caching
-  - secret-rotation
-  - lro
-  - sync-poller
-  - poller-flux
-  - versioning
-  - expiry
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- key-vault
+- secrets
+- caching
+- secret-rotation
+- lro
+- sync-poller
+- poller-flux
+- versioning
+- expiry
+- async
+- reactor
 ---
 
 # Secret Config Provider: Azure Key Vault (Java)

--- a/prompts/key-vault/data-plane/js-ts/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/js-ts/crud-secrets.prompt.md
@@ -1,21 +1,23 @@
 ---
 id: key-vault-dp-js-ts-crud
-service: key-vault
-plane: data-plane
-language: js-ts
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/keyvault-secrets"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: js-ts
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the JavaScript/TypeScript
+    SDK?
+
+    '
+  sdk_package: '@azure/keyvault-secrets'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (JavaScript/TypeScript)

--- a/prompts/key-vault/data-plane/python/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/python/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-python-crud
-service: key-vault
-plane: data-plane
-language: python
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Python SDK?
-sdk_package: azure-keyvault-secrets
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the Python SDK?
+
+    '
+  sdk_package: azure-keyvault-secrets
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (Python)

--- a/prompts/key-vault/data-plane/python/error-handling.prompt.md
+++ b/prompts/key-vault/data-plane/python/error-handling.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: key-vault-dp-python-error-handling
-service: key-vault
-plane: data-plane
-language: python
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle Key Vault errors including
-  access denied (403), secret not found (404), and throttling (429) in Python?
-sdk_package: azure-keyvault-secrets
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: python
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle Key Vault errors including access denied (403), secret not found (404), and throttling
+    (429) in Python?
+
+    '
+  sdk_package: azure-keyvault-secrets
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - access-policy
-  - throttling
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- access-policy
+- throttling
 ---
 
 # Error Handling: Azure Key Vault Secrets (Python)

--- a/prompts/key-vault/data-plane/python/pagination-list-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/python/pagination-list-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-python-pagination
-service: key-vault
-plane: data-plane
-language: python
-category: pagination
-difficulty: intermediate
-description: >
-  Can a developer paginate through a large list of Key Vault secrets
-  using the Python SDK?
-sdk_package: azure-keyvault-secrets
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+properties:
+  service: key-vault
+  plane: data-plane
+  language: python
+  category: pagination
+  difficulty: intermediate
+  description: 'Can a developer paginate through a large list of Key Vault secrets using the Python SDK?
+
+    '
+  sdk_package: azure-keyvault-secrets
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - pagination
-  - list-secrets
-  - iteration
-created: 2025-07-27
-author: ronniegeraghty
+- pagination
+- list-secrets
+- iteration
 ---
 
 # Pagination: List Key Vault Secrets (Python)

--- a/prompts/key-vault/data-plane/rust/crud-secrets.prompt.md
+++ b/prompts/key-vault/data-plane/rust/crud-secrets.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: key-vault-dp-rust-crud
-service: key-vault
-plane: data-plane
-language: rust
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, read, update, and delete secrets in Azure Key Vault
-  using the Rust SDK?
-sdk_package: azure_security_keyvault_secrets
-doc_url: https://docs.rs/azure_security_keyvault_secrets/latest/azure_security_keyvault_secrets/
+properties:
+  service: key-vault
+  plane: data-plane
+  language: rust
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, read, update, and delete secrets in Azure Key Vault using the Rust SDK?
+
+    '
+  sdk_package: azure_security_keyvault_secrets
+  doc_url: https://docs.rs/azure_security_keyvault_secrets/latest/azure_security_keyvault_secrets/
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - secrets
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- secrets
+- crud
+- getting-started
 ---
 
 # CRUD Secrets: Azure Key Vault (Rust)

--- a/prompts/key-vault/management-plane/dotnet/polling-create-vault.prompt.md
+++ b/prompts/key-vault/management-plane/dotnet/polling-create-vault.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: key-vault-mp-dotnet-polling
-service: key-vault
-plane: management-plane
-language: dotnet
-category: polling
-difficulty: intermediate
-description: >
-  Can a developer use the LRO polling pattern to create a Key Vault
-  and wait for completion using the .NET management SDK?
-sdk_package: Azure.ResourceManager.KeyVault
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.keyvault-readme
+properties:
+  service: key-vault
+  plane: management-plane
+  language: dotnet
+  category: polling
+  difficulty: intermediate
+  description: 'Can a developer use the LRO polling pattern to create a Key Vault and wait for completion using the .NET management
+    SDK?
+
+    '
+  sdk_package: Azure.ResourceManager.KeyVault
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.keyvault-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - polling
-  - lro
-  - long-running-operation
-  - management-plane
-created: 2025-07-27
-author: ronniegeraghty
+- polling
+- lro
+- long-running-operation
+- management-plane
 ---
 
 # Polling/LRO: Create Key Vault (.NET)

--- a/prompts/key-vault/management-plane/python/polling-create-vault.prompt.md
+++ b/prompts/key-vault/management-plane/python/polling-create-vault.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: key-vault-mp-python-polling
-service: key-vault
-plane: management-plane
-language: python
-category: polling
-difficulty: intermediate
-description: >
-  Can a developer use the LRO polling pattern to create a Key Vault
-  and wait for completion using the Python management SDK?
-sdk_package: azure-mgmt-keyvault
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-keyvault-readme
+properties:
+  service: key-vault
+  plane: management-plane
+  language: python
+  category: polling
+  difficulty: intermediate
+  description: 'Can a developer use the LRO polling pattern to create a Key Vault and wait for completion using the Python
+    management SDK?
+
+    '
+  sdk_package: azure-mgmt-keyvault
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-keyvault-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - polling
-  - lro
-  - long-running-operation
-  - management-plane
-created: 2025-07-27
-author: ronniegeraghty
+- polling
+- lro
+- long-running-operation
+- management-plane
 ---
 
 # Polling/LRO: Create Key Vault (Python)

--- a/prompts/resource-manager/management-plane/dotnet/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/dotnet/resource-group-crud.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: resource-manager-mp-dotnet-rg-crud
-service: resource-manager
-plane: management-plane
-language: dotnet
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, list, update, and delete Azure Resource Groups
-  using the .NET management SDK?
-sdk_package: Azure.ResourceManager
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager-readme
+properties:
+  service: resource-manager
+  plane: management-plane
+  language: dotnet
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, list, update, and delete Azure Resource Groups using the .NET management SDK?
+
+    '
+  sdk_package: Azure.ResourceManager
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - resource-groups
-  - management-plane
-  - provisioning
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- resource-groups
+- management-plane
+- provisioning
+- getting-started
 ---
 
 # Resource Group Management: Azure Resource Manager (.NET)

--- a/prompts/resource-manager/management-plane/go/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/go/resource-group-crud.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: resource-manager-mp-go-rg-crud
-service: resource-manager
-plane: management-plane
-language: go
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, list, update, and delete Azure Resource Groups
-  using the Go management SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
+properties:
+  service: resource-manager
+  plane: management-plane
+  language: go
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, list, update, and delete Azure Resource Groups using the Go management SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - resource-groups
-  - management-plane
-  - provisioning
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- resource-groups
+- management-plane
+- provisioning
+- getting-started
 ---
 
 # Resource Group Management: Azure Resource Manager (Go)

--- a/prompts/resource-manager/management-plane/java/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/java/resource-group-crud.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: resource-manager-mp-java-rg-crud
-service: resource-manager
-plane: management-plane
-language: java
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, list, update, and delete Azure Resource Groups
-  using the Java management SDK?
-sdk_package: azure-resourcemanager-resources
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-resources-readme
+properties:
+  service: resource-manager
+  plane: management-plane
+  language: java
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, list, update, and delete Azure Resource Groups using the Java management SDK?
+
+    '
+  sdk_package: azure-resourcemanager-resources
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-resources-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - resource-groups
-  - management-plane
-  - provisioning
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- resource-groups
+- management-plane
+- provisioning
+- getting-started
 ---
 
 # Resource Group Management: Azure Resource Manager (Java)

--- a/prompts/resource-manager/management-plane/js-ts/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/js-ts/resource-group-crud.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: resource-manager-mp-js-ts-rg-crud
-service: resource-manager
-plane: management-plane
-language: js-ts
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, list, update, and delete Azure Resource Groups
-  using the JavaScript/TypeScript management SDK?
-sdk_package: "@azure/arm-resources"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-resources-readme
+properties:
+  service: resource-manager
+  plane: management-plane
+  language: js-ts
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, list, update, and delete Azure Resource Groups using the JavaScript/TypeScript management
+    SDK?
+
+    '
+  sdk_package: '@azure/arm-resources'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-resources-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - resource-groups
-  - management-plane
-  - provisioning
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- resource-groups
+- management-plane
+- provisioning
+- getting-started
 ---
 
 # Resource Group Management: Azure Resource Manager (JavaScript/TypeScript)

--- a/prompts/resource-manager/management-plane/python/resource-group-crud.prompt.md
+++ b/prompts/resource-manager/management-plane/python/resource-group-crud.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: resource-manager-mp-python-rg-crud
-service: resource-manager
-plane: management-plane
-language: python
-category: crud
-difficulty: basic
-description: >
-  Can a developer create, list, update, and delete Azure Resource Groups
-  using the Python management SDK?
-sdk_package: azure-mgmt-resource
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-resource-readme
+properties:
+  service: resource-manager
+  plane: management-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Can a developer create, list, update, and delete Azure Resource Groups using the Python management SDK?
+
+    '
+  sdk_package: azure-mgmt-resource
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-resource-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - resource-groups
-  - management-plane
-  - provisioning
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- resource-groups
+- management-plane
+- provisioning
+- getting-started
 ---
 
 # Resource Group Management: Azure Resource Manager (Python)

--- a/prompts/service-bus/data-plane/dotnet/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/dotnet/send-receive-messages.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: service-bus-dp-dotnet-crud
-service: service-bus
-plane: data-plane
-language: dotnet
-category: crud
-difficulty: intermediate
-description: >
-  Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the .NET SDK?
-sdk_package: Azure.Messaging.ServiceBus
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme
+properties:
+  service: service-bus
+  plane: data-plane
+  language: dotnet
+  category: crud
+  difficulty: intermediate
+  description: 'Can a developer send and receive messages using Azure Service Bus queues and topics with the .NET SDK?
+
+    '
+  sdk_package: Azure.Messaging.ServiceBus
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - service-bus
-  - messaging
-  - queues
-  - topics
-created: 2025-07-28
-author: ronniegeraghty
+- service-bus
+- messaging
+- queues
+- topics
 ---
 
 # Send and Receive Messages: Azure Service Bus (.NET)

--- a/prompts/service-bus/data-plane/java/order-processor.prompt.md
+++ b/prompts/service-bus/data-plane/java/order-processor.prompt.md
@@ -1,27 +1,28 @@
 ---
 id: service-bus-dp-java-order-processor
-service: service-bus
-plane: data-plane
-language: java
-category: streaming
-difficulty: intermediate
-description: >
-  Can an agent generate a Service Bus order processing system with batch sending,
-  scheduled delivery, dead-letter queue handling, session-aware processing, and
-  proper error categorization?
-sdk_package: com.azure:azure-messaging-servicebus
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme
+properties:
+  service: service-bus
+  plane: data-plane
+  language: java
+  category: streaming
+  difficulty: intermediate
+  description: 'Can an agent generate a Service Bus order processing system with batch sending, scheduled delivery, dead-letter
+    queue handling, session-aware processing, and proper error categorization?
+
+    '
+  sdk_package: com.azure:azure-messaging-servicebus
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - service-bus
-  - batch-sending
-  - scheduled-delivery
-  - dead-letter-queue
-  - session-aware
-  - correlation
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- service-bus
+- batch-sending
+- scheduled-delivery
+- dead-letter-queue
+- session-aware
+- correlation
+- async
+- reactor
 ---
 
 # Order Processor: Azure Service Bus (Java)

--- a/prompts/service-bus/data-plane/java/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/java/send-receive-messages.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: service-bus-dp-java-crud
-service: service-bus
-plane: data-plane
-language: java
-category: crud
-difficulty: intermediate
-description: >
-  Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the Java SDK?
-sdk_package: azure-messaging-servicebus
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme
+properties:
+  service: service-bus
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: intermediate
+  description: 'Can a developer send and receive messages using Azure Service Bus queues and topics with the Java SDK?
+
+    '
+  sdk_package: azure-messaging-servicebus
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-servicebus-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - service-bus
-  - messaging
-  - queues
-  - topics
-created: 2025-07-28
-author: ronniegeraghty
+- service-bus
+- messaging
+- queues
+- topics
 ---
 
 # Send and Receive Messages: Azure Service Bus (Java)

--- a/prompts/service-bus/data-plane/js-ts/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/js-ts/send-receive-messages.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: service-bus-dp-js-ts-crud
-service: service-bus
-plane: data-plane
-language: js-ts
-category: crud
-difficulty: intermediate
-description: >
-  Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the JavaScript/TypeScript SDK?
-sdk_package: "@azure/service-bus"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/service-bus-readme
+properties:
+  service: service-bus
+  plane: data-plane
+  language: js-ts
+  category: crud
+  difficulty: intermediate
+  description: 'Can a developer send and receive messages using Azure Service Bus queues and topics with the JavaScript/TypeScript
+    SDK?
+
+    '
+  sdk_package: '@azure/service-bus'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/service-bus-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - service-bus
-  - messaging
-  - queues
-  - topics
-created: 2025-07-28
-author: ronniegeraghty
+- service-bus
+- messaging
+- queues
+- topics
 ---
 
 # Send and Receive Messages: Azure Service Bus (JavaScript/TypeScript)

--- a/prompts/service-bus/data-plane/python/send-receive-messages.prompt.md
+++ b/prompts/service-bus/data-plane/python/send-receive-messages.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: service-bus-dp-python-crud
-service: service-bus
-plane: data-plane
-language: python
-category: crud
-difficulty: intermediate
-description: >
-  Can a developer send and receive messages using Azure Service Bus
-  queues and topics with the Python SDK?
-sdk_package: azure-servicebus
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/servicebus-readme
+properties:
+  service: service-bus
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: intermediate
+  description: 'Can a developer send and receive messages using Azure Service Bus queues and topics with the Python SDK?
+
+    '
+  sdk_package: azure-servicebus
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/servicebus-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - service-bus
-  - messaging
-  - queues
-  - topics
-created: 2025-07-28
-author: ronniegeraghty
+- service-bus
+- messaging
+- queues
+- topics
 ---
 
 # Send and Receive Messages: Azure Service Bus (Python)

--- a/prompts/storage/data-plane/cpp/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/cpp/crud-blobs.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-cpp-crud
-service: storage
-plane: data-plane
-language: cpp
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the C++ SDK?
-sdk_package: azure-storage-blobs-cpp
-doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs
+properties:
+  service: storage
+  plane: data-plane
+  language: cpp
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the C++ SDK?
+
+    '
+  sdk_package: azure-storage-blobs-cpp
+  doc_url: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - blobs
-  - crud
-  - getting-started
-created: 2025-07-28
-author: ronniegeraghty
+- blobs
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (C++)

--- a/prompts/storage/data-plane/dotnet/authentication.prompt.md
+++ b/prompts/storage/data-plane/dotnet/authentication.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-dotnet-auth
-service: storage
-plane: data-plane
-language: dotnet
-category: authentication
-difficulty: basic
-description: >
-  Can a developer authenticate to Azure Blob Storage
-  using DefaultAzureCredential in .NET?
-sdk_package: Azure.Storage.Blobs
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: dotnet
+  category: authentication
+  difficulty: basic
+  description: 'Can a developer authenticate to Azure Blob Storage using DefaultAzureCredential in .NET?
+
+    '
+  sdk_package: Azure.Storage.Blobs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - identity
-  - default-azure-credential
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- identity
+- default-azure-credential
+- getting-started
 ---
 
 # Authentication: Azure Blob Storage (.NET)

--- a/prompts/storage/data-plane/dotnet/batch-blob-operations.prompt.md
+++ b/prompts/storage/data-plane/dotnet/batch-blob-operations.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: storage-dp-dotnet-batch
-service: storage
-plane: data-plane
-language: dotnet
-category: batch
-difficulty: advanced
-description: >
-  Can a developer perform batch blob operations including bulk delete
-  and bulk set-tier using the .NET SDK?
-sdk_package: Azure.Storage.Blobs
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: dotnet
+  category: batch
+  difficulty: advanced
+  description: 'Can a developer perform batch blob operations including bulk delete and bulk set-tier using the .NET SDK?
+
+    '
+  sdk_package: Azure.Storage.Blobs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - batch
-  - bulk-operations
-  - delete
-  - set-tier
-created: 2025-07-27
-author: ronniegeraghty
+- batch
+- bulk-operations
+- delete
+- set-tier
 ---
 
 # Batch Operations: Azure Blob Storage (.NET)

--- a/prompts/storage/data-plane/dotnet/error-handling.prompt.md
+++ b/prompts/storage/data-plane/dotnet/error-handling.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-dotnet-error-handling
-service: storage
-plane: data-plane
-language: dotnet
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle common Azure Blob Storage errors
-  including 404, 403, and 429 responses in .NET?
-sdk_package: Azure.Storage.Blobs
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: dotnet
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle common Azure Blob Storage errors including 404, 403, and 429 responses in .NET?
+
+    '
+  sdk_package: Azure.Storage.Blobs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - retry
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- retry
 ---
 
 # Error Handling: Azure Blob Storage (.NET)

--- a/prompts/storage/data-plane/dotnet/retry-configuration.prompt.md
+++ b/prompts/storage/data-plane/dotnet/retry-configuration.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: storage-dp-dotnet-retries
-service: storage
-plane: data-plane
-language: dotnet
-category: retries
-difficulty: advanced
-description: >
-  Can a developer configure custom retry policies for Azure Blob Storage
-  including exponential backoff and per-operation timeouts in .NET?
-sdk_package: Azure.Storage.Blobs
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: dotnet
+  category: retries
+  difficulty: advanced
+  description: 'Can a developer configure custom retry policies for Azure Blob Storage including exponential backoff and per-operation
+    timeouts in .NET?
+
+    '
+  sdk_package: Azure.Storage.Blobs
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - retries
-  - retry-policy
-  - resilience
-  - exponential-backoff
-created: 2025-07-27
-author: ronniegeraghty
+- retries
+- retry-policy
+- resilience
+- exponential-backoff
 ---
 
 # Retry Configuration: Azure Blob Storage (.NET)

--- a/prompts/storage/data-plane/go/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/go/crud-blobs.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-go-crud
-service: storage
-plane: data-plane
-language: go
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Go SDK?
-sdk_package: azblob
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
+properties:
+  service: storage
+  plane: data-plane
+  language: go
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the Go SDK?
+
+    '
+  sdk_package: azblob
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - blob
-  - crud
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- blob
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (Go)

--- a/prompts/storage/data-plane/java/blob-event-notifier.prompt.md
+++ b/prompts/storage/data-plane/java/blob-event-notifier.prompt.md
@@ -1,26 +1,27 @@
 ---
 id: storage-dp-java-blob-event-notifier
-service: storage
-plane: data-plane
-language: java
-category: streaming
-difficulty: intermediate
-description: >
-  Can an agent generate a Blob Storage event processor using Event Grid, supporting
-  both EventGridEvent and CloudEvents 1.0 schemas, event routing by type, blob
-  subject parsing, custom event publishing, and race condition handling?
-sdk_package: com.azure:azure-messaging-eventgrid
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-eventgrid-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: java
+  category: streaming
+  difficulty: intermediate
+  description: 'Can an agent generate a Blob Storage event processor using Event Grid, supporting both EventGridEvent and
+    CloudEvents 1.0 schemas, event routing by type, blob subject parsing, custom event publishing, and race condition handling?
+
+    '
+  sdk_package: com.azure:azure-messaging-eventgrid
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/messaging-eventgrid-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - event-grid
-  - blob-storage
-  - cloud-events
-  - event-routing
-  - async
-  - reactor
-  - multi-service
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- event-grid
+- blob-storage
+- cloud-events
+- event-routing
+- async
+- reactor
+- multi-service
 ---
 
 # Blob Event Notifier: Azure Event Grid + Blob Storage (Java)

--- a/prompts/storage/data-plane/java/blob-storage-manager.prompt.md
+++ b/prompts/storage/data-plane/java/blob-storage-manager.prompt.md
@@ -1,28 +1,30 @@
 ---
 id: storage-dp-java-blob-manager
-service: storage
-plane: data-plane
-language: java
-category: crud
-difficulty: advanced
-description: >
-  Can an agent generate a complete, production-ready Azure Blob Storage management
-  utility with sync and async implementations, covering upload (large files, index tags),
-  download, list, delete, concurrency prevention, retry configuration, and HTTP logging?
-sdk_package: com.azure:azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: advanced
+  description: 'Can an agent generate a complete, production-ready Azure Blob Storage management utility with sync and async
+    implementations, covering upload (large files, index tags), download, list, delete, concurrency prevention, retry configuration,
+    and HTTP logging?
+
+    '
+  sdk_package: com.azure:azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+  created: '2026-03-19'
+  author: JonathanGiles, samvaity
 tags:
-  - identity
-  - default-azure-credential
-  - blob-storage
-  - async
-  - reactor
-  - retry
-  - lease
-  - parallel-upload
-  - index-tags
-created: 2026-03-19
-author: JonathanGiles, samvaity
+- identity
+- default-azure-credential
+- blob-storage
+- async
+- reactor
+- retry
+- lease
+- parallel-upload
+- index-tags
 ---
 
 # Blob Storage Manager: Azure Blob Storage (Java)

--- a/prompts/storage/data-plane/java/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/java/crud-blobs.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-java-crud
-service: storage
-plane: data-plane
-language: java
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Java SDK?
-sdk_package: azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the Java SDK?
+
+    '
+  sdk_package: azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - blob
-  - crud
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- blob
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (Java)

--- a/prompts/storage/data-plane/java/encrypted-uploader.prompt.md
+++ b/prompts/storage/data-plane/java/encrypted-uploader.prompt.md
@@ -1,29 +1,30 @@
 ---
 id: storage-dp-java-encrypted-uploader
-service: storage
-plane: data-plane
-language: java
-category: crud
-difficulty: advanced
-description: >
-  Can an agent implement client-side envelope encryption for Azure Blob Storage
-  using Key Vault Keys for key wrapping, with AES-GCM local encryption, wrapped
-  DEK stored as blob metadata, and proper key material lifecycle?
-sdk_package: com.azure:azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: java
+  category: crud
+  difficulty: advanced
+  description: 'Can an agent implement client-side envelope encryption for Azure Blob Storage using Key Vault Keys for key
+    wrapping, with AES-GCM local encryption, wrapped DEK stored as blob metadata, and proper key material lifecycle?
+
+    '
+  sdk_package: com.azure:azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme
+  created: '2026-03-25'
+  author: JonathanGiles, samvaity
 tags:
-  - blob-storage
-  - key-vault
-  - encryption
-  - envelope-encryption
-  - aes-gcm
-  - key-wrap
-  - cryptography-client
-  - multi-service
-  - async
-  - reactor
-created: 2026-03-25
-author: JonathanGiles, samvaity
+- blob-storage
+- key-vault
+- encryption
+- envelope-encryption
+- aes-gcm
+- key-wrap
+- cryptography-client
+- multi-service
+- async
+- reactor
 ---
 
 # Encrypted Uploader: Azure Blob Storage + Key Vault Keys (Java)

--- a/prompts/storage/data-plane/js-ts/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/js-ts/crud-blobs.prompt.md
@@ -1,21 +1,23 @@
 ---
 id: storage-dp-js-ts-crud
-service: storage
-plane: data-plane
-language: js-ts
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the JavaScript/TypeScript SDK?
-sdk_package: "@azure/storage-blob"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: js-ts
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the JavaScript/TypeScript
+    SDK?
+
+    '
+  sdk_package: '@azure/storage-blob'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - blob
-  - crud
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- blob
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (JavaScript/TypeScript)

--- a/prompts/storage/data-plane/python/batch-blob-operations.prompt.md
+++ b/prompts/storage/data-plane/python/batch-blob-operations.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: storage-dp-python-batch
-service: storage
-plane: data-plane
-language: python
-category: batch
-difficulty: advanced
-description: >
-  Can a developer perform batch blob operations including bulk delete
-  and bulk set-tier using the Python SDK?
-sdk_package: azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: python
+  category: batch
+  difficulty: advanced
+  description: 'Can a developer perform batch blob operations including bulk delete and bulk set-tier using the Python SDK?
+
+    '
+  sdk_package: azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - batch
-  - bulk-operations
-  - delete
-  - set-tier
-created: 2025-07-27
-author: ronniegeraghty
+- batch
+- bulk-operations
+- delete
+- set-tier
 ---
 
 # Batch Operations: Azure Blob Storage (Python)

--- a/prompts/storage/data-plane/python/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/python/crud-blobs.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-python-crud
-service: storage
-plane: data-plane
-language: python
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Python SDK?
-sdk_package: azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the Python SDK?
+
+    '
+  sdk_package: azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - blob
-  - crud
-  - getting-started
-created: 2025-07-27
-author: ronniegeraghty
+- blob
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (Python)

--- a/prompts/storage/data-plane/python/error-handling.prompt.md
+++ b/prompts/storage/data-plane/python/error-handling.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-python-error-handling
-service: storage
-plane: data-plane
-language: python
-category: error-handling
-difficulty: intermediate
-description: >
-  Can a developer handle common Azure Blob Storage errors
-  including 404, 403, and 429 responses in Python?
-sdk_package: azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: python
+  category: error-handling
+  difficulty: intermediate
+  description: 'Can a developer handle common Azure Blob Storage errors including 404, 403, and 429 responses in Python?
+
+    '
+  sdk_package: azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - error-handling
-  - exceptions
-  - retry
-created: 2025-07-27
-author: ronniegeraghty
+- error-handling
+- exceptions
+- retry
 ---
 
 # Error Handling: Azure Blob Storage (Python)

--- a/prompts/storage/data-plane/python/mcp-best-practices.prompt.md
+++ b/prompts/storage/data-plane/python/mcp-best-practices.prompt.md
@@ -1,20 +1,22 @@
 ---
 id: storage-dp-python-mcp-best-practices
-service: storage
-plane: data-plane
-language: python
-category: best-practices
-difficulty: basic
-description: >
-  Can the agent use the Azure MCP best practices tool
-  to generate Azure Blob Storage code following official guidance?
-sdk_package: azure-storage-blob
+properties:
+  service: storage
+  plane: data-plane
+  language: python
+  category: best-practices
+  difficulty: basic
+  description: 'Can the agent use the Azure MCP best practices tool to generate Azure Blob Storage code following official
+    guidance?
+
+    '
+  sdk_package: azure-storage-blob
+  created: '2026-04-02'
+  author: ronniegeraghty
 tags:
-  - mcp
-  - best-practices
-  - getting-started
-created: 2026-04-02
-author: ronniegeraghty
+- mcp
+- best-practices
+- getting-started
 ---
 
 # Azure Blob Storage Best Practices (Python)

--- a/prompts/storage/data-plane/python/pagination-list-blobs.prompt.md
+++ b/prompts/storage/data-plane/python/pagination-list-blobs.prompt.md
@@ -1,22 +1,23 @@
 ---
 id: storage-dp-python-pagination
-service: storage
-plane: data-plane
-language: python
-category: pagination
-difficulty: intermediate
-description: >
-  Can a developer correctly paginate through a large list of blobs in
-  Azure Storage using the Python SDK?
-sdk_package: azure-storage-blob
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+properties:
+  service: storage
+  plane: data-plane
+  language: python
+  category: pagination
+  difficulty: intermediate
+  description: 'Can a developer correctly paginate through a large list of blobs in Azure Storage using the Python SDK?
+
+    '
+  sdk_package: azure-storage-blob
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - blob
-  - pagination
-  - list-blobs
-  - continuation-token
-created: 2025-07-27
-author: ronniegeraghty
+- blob
+- pagination
+- list-blobs
+- continuation-token
 ---
 
 # Pagination: List Blobs in Azure Storage (Python)

--- a/prompts/storage/data-plane/rust/crud-blobs.prompt.md
+++ b/prompts/storage/data-plane/rust/crud-blobs.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-dp-rust-crud
-service: storage
-plane: data-plane
-language: rust
-category: crud
-difficulty: basic
-description: >
-  Can a developer upload, download, list, and delete blobs in Azure Blob Storage
-  using the Rust SDK?
-sdk_package: azure_storage_blob
-doc_url: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/storage/azure_storage_blobs
+properties:
+  service: storage
+  plane: data-plane
+  language: rust
+  category: crud
+  difficulty: basic
+  description: 'Can a developer upload, download, list, and delete blobs in Azure Blob Storage using the Rust SDK?
+
+    '
+  sdk_package: azure_storage_blob
+  doc_url: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/storage/azure_storage_blobs
+  created: '2026-03-26'
+  author: larryo
 tags:
-  - blobs
-  - crud
-  - getting-started
-created: 2026-03-26
-author: larryo
+- blobs
+- crud
+- getting-started
 ---
 
 # CRUD Blobs: Azure Blob Storage (Rust)

--- a/prompts/storage/management-plane/dotnet/polling-create-account.prompt.md
+++ b/prompts/storage/management-plane/dotnet/polling-create-account.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: storage-mp-dotnet-polling
-service: storage
-plane: management-plane
-language: dotnet
-category: polling
-difficulty: intermediate
-description: >
-  Can a developer use the LRO polling pattern to create a Storage Account
-  and wait for completion using the .NET management SDK?
-sdk_package: Azure.ResourceManager.Storage
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: dotnet
+  category: polling
+  difficulty: intermediate
+  description: 'Can a developer use the LRO polling pattern to create a Storage Account and wait for completion using the
+    .NET management SDK?
+
+    '
+  sdk_package: Azure.ResourceManager.Storage
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.storage-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - polling
-  - lro
-  - long-running-operation
-  - management-plane
-created: 2025-07-27
-author: ronniegeraghty
+- polling
+- lro
+- long-running-operation
+- management-plane
 ---
 
 # Polling/LRO: Create Storage Account (.NET)

--- a/prompts/storage/management-plane/dotnet/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/dotnet/storage-account-mgmt.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-mp-dotnet-account-mgmt
-service: storage
-plane: management-plane
-language: dotnet
-category: provisioning
-difficulty: intermediate
-description: >
-  Can a developer create, configure, and manage Azure Storage Accounts
-  using the .NET management SDK?
-sdk_package: Azure.ResourceManager.Storage
-doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: dotnet
+  category: provisioning
+  difficulty: intermediate
+  description: 'Can a developer create, configure, and manage Azure Storage Accounts using the .NET management SDK?
+
+    '
+  sdk_package: Azure.ResourceManager.Storage
+  doc_url: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.storage-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - storage-account
-  - management-plane
-  - provisioning
-created: 2025-07-28
-author: ronniegeraghty
+- storage-account
+- management-plane
+- provisioning
 ---
 
 # Storage Account Management: Azure Storage (.NET)

--- a/prompts/storage/management-plane/go/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/go/storage-account-mgmt.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-mp-go-account-mgmt
-service: storage
-plane: management-plane
-language: go
-category: provisioning
-difficulty: intermediate
-description: >
-  Can a developer create, configure, and manage Azure Storage Accounts
-  using the Go management SDK?
-sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
-doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
+properties:
+  service: storage
+  plane: management-plane
+  language: go
+  category: provisioning
+  difficulty: intermediate
+  description: 'Can a developer create, configure, and manage Azure Storage Accounts using the Go management SDK?
+
+    '
+  sdk_package: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
+  doc_url: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - storage-account
-  - management-plane
-  - provisioning
-created: 2025-07-28
-author: ronniegeraghty
+- storage-account
+- management-plane
+- provisioning
 ---
 
 # Storage Account Management: Azure Storage (Go)

--- a/prompts/storage/management-plane/java/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/java/storage-account-mgmt.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-mp-java-account-mgmt
-service: storage
-plane: management-plane
-language: java
-category: provisioning
-difficulty: intermediate
-description: >
-  Can a developer create, configure, and manage Azure Storage Accounts
-  using the Java management SDK?
-sdk_package: azure-resourcemanager-storage
-doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: java
+  category: provisioning
+  difficulty: intermediate
+  description: 'Can a developer create, configure, and manage Azure Storage Accounts using the Java management SDK?
+
+    '
+  sdk_package: azure-resourcemanager-storage
+  doc_url: https://learn.microsoft.com/en-us/java/api/overview/azure/resourcemanager-storage-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - storage-account
-  - management-plane
-  - provisioning
-created: 2025-07-28
-author: ronniegeraghty
+- storage-account
+- management-plane
+- provisioning
 ---
 
 # Storage Account Management: Azure Storage (Java)

--- a/prompts/storage/management-plane/js-ts/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/js-ts/storage-account-mgmt.prompt.md
@@ -1,21 +1,23 @@
 ---
 id: storage-mp-js-ts-account-mgmt
-service: storage
-plane: management-plane
-language: js-ts
-category: provisioning
-difficulty: intermediate
-description: >
-  Can a developer create, configure, and manage Azure Storage Accounts
-  using the JavaScript/TypeScript management SDK?
-sdk_package: "@azure/arm-storage"
-doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: js-ts
+  category: provisioning
+  difficulty: intermediate
+  description: 'Can a developer create, configure, and manage Azure Storage Accounts using the JavaScript/TypeScript management
+    SDK?
+
+    '
+  sdk_package: '@azure/arm-storage'
+  doc_url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/arm-storage-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - storage-account
-  - management-plane
-  - provisioning
-created: 2025-07-28
-author: ronniegeraghty
+- storage-account
+- management-plane
+- provisioning
 ---
 
 # Storage Account Management: Azure Storage (JavaScript/TypeScript)

--- a/prompts/storage/management-plane/python/polling-create-account.prompt.md
+++ b/prompts/storage/management-plane/python/polling-create-account.prompt.md
@@ -1,22 +1,24 @@
 ---
 id: storage-mp-python-polling
-service: storage
-plane: management-plane
-language: python
-category: polling
-difficulty: intermediate
-description: >
-  Can a developer use the LRO polling pattern to create a Storage Account
-  and wait for completion using the Python management SDK?
-sdk_package: azure-mgmt-storage
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: python
+  category: polling
+  difficulty: intermediate
+  description: 'Can a developer use the LRO polling pattern to create a Storage Account and wait for completion using the
+    Python management SDK?
+
+    '
+  sdk_package: azure-mgmt-storage
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-storage-readme
+  created: '2025-07-27'
+  author: ronniegeraghty
 tags:
-  - polling
-  - lro
-  - long-running-operation
-  - management-plane
-created: 2025-07-27
-author: ronniegeraghty
+- polling
+- lro
+- long-running-operation
+- management-plane
 ---
 
 # Polling/LRO: Create Storage Account (Python)

--- a/prompts/storage/management-plane/python/storage-account-mgmt.prompt.md
+++ b/prompts/storage/management-plane/python/storage-account-mgmt.prompt.md
@@ -1,21 +1,22 @@
 ---
 id: storage-mp-python-account-mgmt
-service: storage
-plane: management-plane
-language: python
-category: provisioning
-difficulty: intermediate
-description: >
-  Can a developer create, configure, and manage Azure Storage Accounts
-  using the Python management SDK?
-sdk_package: azure-mgmt-storage
-doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-storage-readme
+properties:
+  service: storage
+  plane: management-plane
+  language: python
+  category: provisioning
+  difficulty: intermediate
+  description: 'Can a developer create, configure, and manage Azure Storage Accounts using the Python management SDK?
+
+    '
+  sdk_package: azure-mgmt-storage
+  doc_url: https://learn.microsoft.com/en-us/python/api/overview/azure/mgmt-storage-readme
+  created: '2025-07-28'
+  author: ronniegeraghty
 tags:
-  - storage-account
-  - management-plane
-  - provisioning
-created: 2025-07-28
-author: ronniegeraghty
+- storage-account
+- management-plane
+- provisioning
 ---
 
 # Storage Account Management: Azure Storage (Python)

--- a/tools/migrate-prompts/migrate.py
+++ b/tools/migrate-prompts/migrate.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Migrate prompt frontmatter from flat fields to nested properties: format.
+
+Usage:
+    python3 tools/migrate-prompts/migrate.py [--dry-run] [prompts_dir]
+
+This script:
+- Finds all .prompt.md files in the prompts directory
+- Moves metadata fields (service, plane, language, etc.) into a nested properties: block
+- Keeps id, tags, timeout, starter_project, and other non-string fields at top level
+- Preserves the Markdown body below the frontmatter
+"""
+
+import os
+import sys
+import yaml
+from pathlib import Path
+from collections import OrderedDict
+
+# Fields that should be moved into properties:
+PROPERTY_FIELDS = [
+    "service", "plane", "language", "category", "difficulty",
+    "description", "sdk_package", "doc_url", "created", "author",
+]
+
+# Fields that stay at top level (besides 'id')
+TOP_LEVEL_FIELDS = {
+    "id", "tags", "timeout", "starter_project", "project_context",
+    "reference_answer", "expected_packages", "expected_tools",
+}
+
+
+class OrderedDumper(yaml.SafeDumper):
+    """YAML dumper that preserves dict insertion order."""
+    pass
+
+
+def _dict_representer(dumper, data):
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        data.items(),
+    )
+
+
+OrderedDumper.add_representer(OrderedDict, _dict_representer)
+OrderedDumper.add_representer(dict, _dict_representer)
+
+
+def migrate_prompt_file(filepath, dry_run=False):
+    """Migrate a single prompt file to nested properties format."""
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    if not content.startswith("---"):
+        return False, "no frontmatter"
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return False, "malformed frontmatter"
+
+    frontmatter_str = parts[1].strip()
+    body = parts[2]
+
+    data = yaml.safe_load(frontmatter_str)
+    if not isinstance(data, dict):
+        return False, "frontmatter is not a dict"
+
+    if "properties" in data:
+        return False, "already migrated"
+
+    new_data = OrderedDict()
+
+    if "id" in data:
+        new_data["id"] = data["id"]
+
+    properties = OrderedDict()
+    for key in PROPERTY_FIELDS:
+        if key in data:
+            val = data[key]
+            if hasattr(val, "isoformat"):
+                val = val.isoformat()
+            properties[key] = val
+    if properties:
+        new_data["properties"] = dict(properties)
+
+    for key in data:
+        if key == "id" or key in PROPERTY_FIELDS:
+            continue
+        new_data[key] = data[key]
+
+    yaml_str = yaml.dump(
+        dict(new_data),
+        Dumper=OrderedDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=120,
+    )
+
+    new_content = "---\n" + yaml_str + "---" + body
+
+    if not dry_run:
+        with open(filepath, "w") as f:
+            f.write(new_content)
+            f.flush()
+            os.fsync(f.fileno())
+
+    return True, "migrated"
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    prompts_dir = args[0] if args else "prompts"
+
+    files = sorted(Path(prompts_dir).rglob("*.prompt.md"))
+    print(f"Found {len(files)} prompt files in {prompts_dir}/")
+    if dry_run:
+        print("(dry-run mode — no files will be modified)\n")
+
+    migrated = 0
+    skipped = 0
+    errors = 0
+
+    for f in files:
+        try:
+            ok, reason = migrate_prompt_file(str(f), dry_run=dry_run)
+            if ok:
+                migrated += 1
+                print(f"  ✓ {f}")
+            else:
+                skipped += 1
+                if reason != "already migrated":
+                    print(f"  ⊘ {f} ({reason})")
+        except Exception as e:
+            errors += 1
+            print(f"  ✗ {f}: {e}")
+
+    print(f"\nResults: {migrated} migrated, {skipped} skipped, {errors} errors")
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Migrates all 89 prompt files from flat YAML frontmatter fields to a nested `properties:` block format.

### Changes

**Go code (backward-compatible parser):**
- Added `Properties map[string]string` field to `Prompt` struct
- Parser now supports both legacy flat format and new nested `properties:` format
- `reconcileProperties()` ensures flat fields and Properties map are always in sync
- `Property()` method checks Properties map first, then falls back to struct fields
- Added `TestParsePromptFileNested` test for the new format

**Prompt migration (89 files):**
- Metadata fields (`service`, `plane`, `language`, `category`, `difficulty`, `description`, `sdk_package`, `doc_url`, `created`, `author`) moved into nested `properties:` block
- Top-level fields retained: `id`, `tags`, `timeout`, `starter_project`, `expected_packages`, `expected_tools`
- Migration script included at `tools/migrate-prompts/migrate.py`

**Scaffold update:**
- `new-prompt` command now generates templates with the nested `properties:` format

### Verification
- `go build ./hyoka/...` ✓
- `go vet ./hyoka/...` ✓ 
- `go test ./hyoka/...` ✓ (all 22 packages pass)
- `go run ./hyoka list` lists all 89 prompts correctly
- `go run ./hyoka validate` — same pre-existing error as before migration

Closes #101