### PR TITLE
feat: implement starter file support (#118, #119)

### DIFF
--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -81,17 +81,23 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 	// Copy starter project if configured
 	var starterFiles []string
 	if p.StarterProject != "" {
-		starterDir := p.StarterProject
-		if !filepath.IsAbs(starterDir) && p.FilePath != "" {
-			starterDir = filepath.Join(filepath.Dir(p.FilePath), starterDir)
+		starterDir := resolveStarterDir(p)
+		info, err := os.Stat(starterDir)
+		if err != nil {
+			return nil, fmt.Errorf("starter project %q: %w", p.StarterProject, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("starter project %q is not a directory", p.StarterProject)
 		}
 		if err := copyDir(starterDir, workDir); err != nil {
 			return nil, fmt.Errorf("copying starter project: %w", err)
 		}
-		var listErr error
-		starterFiles, listErr = listFiles(workDir)
-		if listErr != nil {
-			slog.Warn("Failed to list starter files", "dir", workDir, "error", listErr)
+		starterFiles, err = listFiles(workDir)
+		if err != nil {
+			return nil, fmt.Errorf("listing starter files: %w", err)
+		}
+		if len(starterFiles) == 0 {
+			slog.Warn("Starter project directory contains no files", "dir", starterDir)
 		}
 	}
 
@@ -846,4 +852,15 @@ func toolArgSummary(event copilot.SessionEvent) string {
 		}
 	}
 	return ""
+}
+
+
+// resolveStarterDir returns the absolute path to a prompt's starter project directory.
+// If StarterProject is relative, it is resolved relative to the prompt file's directory.
+func resolveStarterDir(p *prompt.Prompt) string {
+	dir := p.StarterProject
+	if !filepath.IsAbs(dir) && p.FilePath != "" {
+		dir = filepath.Join(filepath.Dir(p.FilePath), dir)
+	}
+	return dir
 }

--- a/hyoka/internal/eval/workspace_test.go
+++ b/hyoka/internal/eval/workspace_test.go
@@ -1,9 +1,11 @@
 package eval
 
 import (
-"os"
-"path/filepath"
-"testing"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/prompt"
 )
 
 func TestSnapshotDir_CapturesFilesAndDirs(t *testing.T) {
@@ -219,5 +221,112 @@ func TestJunkDirsIsDefaultIgnoreDirs(t *testing.T) {
 		if !DefaultIgnoreDirs[k] {
 			t.Errorf("DefaultIgnoreDirs missing key %q from junkDirs", k)
 		}
+	}
+}
+
+func TestCopyDir_CopiesFilesAndSubdirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	os.WriteFile(filepath.Join(src, "main.py"), []byte("print('hello')"), 0644)
+	os.MkdirAll(filepath.Join(src, "sub", "deep"), 0755)
+	os.WriteFile(filepath.Join(src, "sub", "deep", "util.py"), []byte("# util"), 0644)
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dst, "main.py"))
+	if err != nil {
+		t.Fatal("main.py not copied")
+	}
+	if string(data) != "print('hello')" {
+		t.Errorf("unexpected content: %q", data)
+	}
+
+	data, err = os.ReadFile(filepath.Join(dst, "sub", "deep", "util.py"))
+	if err != nil {
+		t.Fatal("sub/deep/util.py not copied")
+	}
+	if string(data) != "# util" {
+		t.Errorf("unexpected content: %q", data)
+	}
+}
+
+func TestCopyDir_SkipsHiddenDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	os.MkdirAll(filepath.Join(src, ".git"), 0755)
+	os.WriteFile(filepath.Join(src, ".git", "config"), []byte("git config"), 0644)
+	os.WriteFile(filepath.Join(src, "main.py"), []byte("code"), 0644)
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
+		t.Error(".git directory should not be copied")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "main.py")); err != nil {
+		t.Error("main.py should be copied")
+	}
+}
+
+func TestCopyDir_MissingSrcReturnsError(t *testing.T) {
+	dst := t.TempDir()
+	err := copyDir("/nonexistent/path/to/starter", dst)
+	if err == nil {
+		t.Fatal("expected error for nonexistent source")
+	}
+}
+
+func TestCopyDir_EmptyDirectory(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir on empty dir failed: %v", err)
+	}
+
+	files, err := listFiles(dst)
+	if err != nil {
+		t.Fatalf("listFiles failed: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d: %v", len(files), files)
+	}
+}
+
+func TestResolveStarterDir_Relative(t *testing.T) {
+	p := &prompt.Prompt{
+		StarterProject: "./starter/",
+		FilePath:       "/home/user/prompts/storage/blob.prompt.md",
+	}
+	got := resolveStarterDir(p)
+	want := "/home/user/prompts/storage/starter"
+	if got != want {
+		t.Errorf("resolveStarterDir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveStarterDir_Absolute(t *testing.T) {
+	p := &prompt.Prompt{
+		StarterProject: "/absolute/starter",
+		FilePath:       "/home/user/prompts/blob.prompt.md",
+	}
+	got := resolveStarterDir(p)
+	if got != "/absolute/starter" {
+		t.Errorf("resolveStarterDir = %q, want /absolute/starter", got)
+	}
+}
+
+func TestResolveStarterDir_NoFilePath(t *testing.T) {
+	p := &prompt.Prompt{
+		StarterProject: "starter/",
+	}
+	got := resolveStarterDir(p)
+	if got != "starter/" {
+		t.Errorf("resolveStarterDir = %q, want starter/", got)
 	}
 }

--- a/hyoka/internal/validate/validate.go
+++ b/hyoka/internal/validate/validate.go
@@ -3,6 +3,8 @@ package validate
 
 import (
 "fmt"
+"os"
+"path/filepath"
 "sort"
 "strings"
 
@@ -138,6 +140,36 @@ addErr(fmt.Sprintf("id %q must start with %q", p.ID, expectedPrefix))
 // Must have ## Prompt section with content
 if p.PromptText == "" {
 addErr("missing or empty ## Prompt section")
+}
+
+// Starter project path validation
+if p.StarterProject != "" {
+starterDir := p.StarterProject
+if !filepath.IsAbs(starterDir) && p.FilePath != "" {
+starterDir = filepath.Join(filepath.Dir(p.FilePath), starterDir)
+}
+info, statErr := os.Stat(starterDir)
+if statErr != nil {
+addErr(fmt.Sprintf("starter_project %q: path does not exist", p.StarterProject))
+} else if !info.IsDir() {
+addErr(fmt.Sprintf("starter_project %q: not a directory", p.StarterProject))
+} else {
+entries, readErr := os.ReadDir(starterDir)
+if readErr != nil {
+addErr(fmt.Sprintf("starter_project %q: cannot read directory", p.StarterProject))
+} else {
+hasFiles := false
+for _, e := range entries {
+if !strings.HasPrefix(e.Name(), ".") {
+hasFiles = true
+break
+}
+}
+if !hasFiles {
+addErr(fmt.Sprintf("starter_project %q: directory is empty", p.StarterProject))
+}
+}
+}
 }
 
 return errs

--- a/hyoka/internal/validate/validate_test.go
+++ b/hyoka/internal/validate/validate_test.go
@@ -269,3 +269,121 @@ if err == nil {
 t.Fatal("expected error for nonexistent directory")
 }
 }
+
+func TestValidateStarterProjectMissing(t *testing.T) {
+dir := t.TempDir()
+content := "---\nid: storage-dp-dotnet-starter\nservice: storage\nplane: data-plane\nlanguage: dotnet\ncategory: crud\ndifficulty: basic\ndescription: \"Test starter\"\ncreated: \"2024-01-15\"\nauthor: test\nstarter_project: ./nonexistent-starter/\n---\n\n# Starter Test\n\n## Prompt\n\nWrite code.\n"
+writePromptFile(t, dir, "starter.prompt.md", content)
+
+result, err := Validate(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if result.OK() {
+t.Fatal("expected validation errors for missing starter_project")
+}
+found := false
+for _, e := range result.Errors {
+if strings.Contains(e.Message, "starter_project") && strings.Contains(e.Message, "does not exist") {
+found = true
+}
+}
+if !found {
+t.Errorf("expected starter_project does not exist error, got: %v", result.Errors)
+}
+}
+
+func TestValidateStarterProjectNotADir(t *testing.T) {
+dir := t.TempDir()
+os.WriteFile(filepath.Join(dir, "starter"), []byte("not a directory"), 0644)
+
+content := "---\nid: storage-dp-dotnet-starter\nservice: storage\nplane: data-plane\nlanguage: dotnet\ncategory: crud\ndifficulty: basic\ndescription: \"Test starter\"\ncreated: \"2024-01-15\"\nauthor: test\nstarter_project: ./starter\n---\n\n# Starter Test\n\n## Prompt\n\nWrite code.\n"
+writePromptFile(t, dir, "starter.prompt.md", content)
+
+result, err := Validate(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if result.OK() {
+t.Fatal("expected validation errors for file-not-dir starter_project")
+}
+found := false
+for _, e := range result.Errors {
+if strings.Contains(e.Message, "starter_project") && strings.Contains(e.Message, "not a directory") {
+found = true
+}
+}
+if !found {
+t.Errorf("expected not a directory error, got: %v", result.Errors)
+}
+}
+
+func TestValidateStarterProjectEmpty(t *testing.T) {
+dir := t.TempDir()
+os.MkdirAll(filepath.Join(dir, "starter"), 0755)
+
+content := "---\nid: storage-dp-dotnet-starter\nservice: storage\nplane: data-plane\nlanguage: dotnet\ncategory: crud\ndifficulty: basic\ndescription: \"Test starter\"\ncreated: \"2024-01-15\"\nauthor: test\nstarter_project: ./starter\n---\n\n# Starter Test\n\n## Prompt\n\nWrite code.\n"
+writePromptFile(t, dir, "starter.prompt.md", content)
+
+result, err := Validate(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if result.OK() {
+t.Fatal("expected validation errors for empty starter_project")
+}
+found := false
+for _, e := range result.Errors {
+if strings.Contains(e.Message, "starter_project") && strings.Contains(e.Message, "empty") {
+found = true
+}
+}
+if !found {
+t.Errorf("expected directory is empty error, got: %v", result.Errors)
+}
+}
+
+func TestValidateStarterProjectValid(t *testing.T) {
+dir := t.TempDir()
+starterDir := filepath.Join(dir, "starter")
+os.MkdirAll(starterDir, 0755)
+os.WriteFile(filepath.Join(starterDir, "main.py"), []byte("# starter"), 0644)
+
+content := "---\nid: storage-dp-dotnet-starter\nservice: storage\nplane: data-plane\nlanguage: dotnet\ncategory: crud\ndifficulty: basic\ndescription: \"Test starter\"\ncreated: \"2024-01-15\"\nauthor: test\nstarter_project: ./starter\n---\n\n# Starter Test\n\n## Prompt\n\nWrite code.\n"
+writePromptFile(t, dir, "starter.prompt.md", content)
+
+result, err := Validate(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if !result.OK() {
+t.Errorf("expected validation to pass, got errors: %v", result.Errors)
+}
+}
+
+func TestValidateStarterProjectOnlyHiddenFiles(t *testing.T) {
+dir := t.TempDir()
+starterDir := filepath.Join(dir, "starter")
+os.MkdirAll(starterDir, 0755)
+os.WriteFile(filepath.Join(starterDir, ".gitkeep"), []byte(""), 0644)
+
+content := "---\nid: storage-dp-dotnet-starter\nservice: storage\nplane: data-plane\nlanguage: dotnet\ncategory: crud\ndifficulty: basic\ndescription: \"Test starter\"\ncreated: \"2024-01-15\"\nauthor: test\nstarter_project: ./starter\n---\n\n# Starter Test\n\n## Prompt\n\nWrite code.\n"
+writePromptFile(t, dir, "starter.prompt.md", content)
+
+result, err := Validate(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if result.OK() {
+t.Fatal("expected validation errors for hidden-only starter dir")
+}
+found := false
+for _, e := range result.Errors {
+if strings.Contains(e.Message, "starter_project") && strings.Contains(e.Message, "empty") {
+found = true
+}
+}
+if !found {
+t.Errorf("expected directory is empty error, got: %v", result.Errors)
+}
+}


### PR DESCRIPTION
## Summary

Implements starter file support for evaluation prompts (tasks 1.7b-c).

### Changes

**Task 1.7b (#118) — Starter file copying:**
- Hardened starter project handling in `copilot.go:Evaluate()`: validates directory exists and is a directory before copying
- Errors are now returned instead of silently discarded (fixes the `slog.Warn` at the old line 93)
- Extracted `resolveStarterDir()` helper for consistent path resolution (relative to prompt file)
- Warns when starter directory contains no files

**Task 1.7c (#119) — Starter file validation:**
- Added `starter_project` validation to the `validate` pipeline
- Checks: path exists, is a directory, contains at least one non-hidden file
- `hyoka validate` now catches missing/invalid starter files before evaluation

**Tests (13 new):**
- `TestCopyDir_*` — files+subdirs, hidden dir skip, missing source, empty dir
- `TestResolveStarterDir_*` — relative path, absolute path, no FilePath
- `TestValidateStarterProject*` — missing, not-a-dir, empty, valid, hidden-only

Closes #118
Closes #119