### PR TITLE
refactor: replace MatchCondition with property-based grader matching (#104)

### DIFF
--- a/criteria/language/dotnet.yaml
+++ b/criteria/language/dotnet.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   language: dotnet
 criteria:
   - name: NuGet Package References

--- a/criteria/language/go.yaml
+++ b/criteria/language/go.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   language: go
 criteria:
   - name: Module Dependencies

--- a/criteria/language/java.yaml
+++ b/criteria/language/java.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   language: java
 criteria:
   - name: Maven/Gradle Dependency Declaration

--- a/criteria/language/python.yaml
+++ b/criteria/language/python.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   language: python
 criteria:
   - name: Correct Package Imports

--- a/criteria/service/key-vault.yaml
+++ b/criteria/service/key-vault.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   service: key-vault
 criteria:
   - name: Secret/Key/Certificate Client Separation

--- a/criteria/service/storage.yaml
+++ b/criteria/service/storage.yaml
@@ -1,4 +1,4 @@
-match:
+when:
   service: storage
 criteria:
   - name: Storage Account URL Format

--- a/hyoka/internal/criteria/criteria.go
+++ b/hyoka/internal/criteria/criteria.go
@@ -1,166 +1,102 @@
 // Package criteria implements a tiered evaluation criteria system.
 //
-// Three tiers of criteria are merged at eval time:
-//   - Tier 1: General criteria from rubric.md (always applied)
-//   - Tier 2: Attribute-matched criteria from YAML files (applied when prompt metadata matches)
-//   - Tier 3: Prompt-specific criteria from the prompt's ## Evaluation Criteria section
+// Criteria YAML files use a "when" map to declare which prompts they apply to.
+// All entries in "when" must match the corresponding prompt property
+// (case-insensitive). An empty or absent "when" block matches every prompt.
 package criteria
 
 import (
-	"bytes"
-	"fmt"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
+"bytes"
+"fmt"
+"log/slog"
+"os"
+"path/filepath"
+"strings"
 
-	"gopkg.in/yaml.v3"
+"gopkg.in/yaml.v3"
 )
 
 // Criterion defines a single evaluation criterion.
 type Criterion struct {
-	Name        string `yaml:"name" json:"name"`
-	Description string `yaml:"description" json:"description"`
-}
-
-// MatchCondition defines when a criteria set should apply.
-// All non-empty fields must match the prompt's metadata.
-type MatchCondition struct {
-	Language string `yaml:"language,omitempty"`
-	Service  string `yaml:"service,omitempty"`
-	Plane    string `yaml:"plane,omitempty"`
-	Category string `yaml:"category,omitempty"`
-	SDK      string `yaml:"sdk,omitempty"`
+Name        string `yaml:"name" json:"name"`
+Description string `yaml:"description" json:"description"`
 }
 
 // CriteriaSet is a collection of criteria with conditions for when they apply.
 type CriteriaSet struct {
-	Match    MatchCondition `yaml:"match"`
-	Criteria []Criterion    `yaml:"criteria"`
-	Source   string         `yaml:"-"` // source file path
+When     map[string]string `yaml:"when"`
+Criteria []Criterion       `yaml:"criteria"`
+Source   string            `yaml:"-"` // source file path
 }
 
-// PromptAttrs holds prompt metadata used for criteria matching.
-type PromptAttrs struct {
-	Language string
-	Service  string
-	Plane    string
-	Category string
-	SDK      string
+// Matches returns true if every entry in When matches the corresponding value
+// in properties (case-insensitive). An empty When matches all prompts.
+func (cs CriteriaSet) Matches(properties map[string]string) bool {
+for k, v := range cs.When {
+if !strings.EqualFold(properties[k], v) {
+return false
 }
-
-// Matches returns true if all non-empty fields in the condition match the prompt attrs.
-func (m MatchCondition) Matches(attrs PromptAttrs) bool {
-	if m.Language != "" && !strings.EqualFold(m.Language, attrs.Language) {
-		return false
-	}
-	if m.Service != "" && !strings.EqualFold(m.Service, attrs.Service) {
-		return false
-	}
-	if m.Plane != "" && !strings.EqualFold(m.Plane, attrs.Plane) {
-		return false
-	}
-	if m.Category != "" && !strings.EqualFold(m.Category, attrs.Category) {
-		return false
-	}
-	if m.SDK != "" && !strings.EqualFold(m.SDK, attrs.SDK) {
-		return false
-	}
-	return true
+}
+return true
 }
 
 // LoadDir loads all criteria YAML files from a directory tree.
 func LoadDir(dir string) ([]CriteriaSet, error) {
-	var sets []CriteriaSet
+var sets []CriteriaSet
 
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		ext := filepath.Ext(path)
-		if ext != ".yaml" && ext != ".yml" {
-			return nil
-		}
+err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+if err != nil {
+return err
+}
+if info.IsDir() {
+return nil
+}
+ext := filepath.Ext(path)
+if ext != ".yaml" && ext != ".yml" {
+return nil
+}
 
-		cs, err := loadFile(path)
-		if err != nil {
-			slog.Warn("Skipping invalid criteria file", "path", path, "error", err)
-			return nil
-		}
-		cs.Source = path
-		sets = append(sets, *cs)
-		slog.Debug("Loaded criteria set", "path", path, "criteria_count", len(cs.Criteria))
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("walking criteria directory %s: %w", dir, err)
-	}
-	return sets, nil
+cs, err := loadFile(path)
+if err != nil {
+slog.Warn("Skipping invalid criteria file", "path", path, "error", err)
+return nil
+}
+cs.Source = path
+sets = append(sets, *cs)
+slog.Debug("Loaded criteria set", "path", path, "criteria_count", len(cs.Criteria))
+return nil
+})
+if err != nil {
+return nil, fmt.Errorf("walking criteria directory %s: %w", dir, err)
+}
+return sets, nil
 }
 
 func loadFile(path string) (*CriteriaSet, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var cs CriteriaSet
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
-	if err := dec.Decode(&cs); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", path, err)
-	}
-	if len(cs.Criteria) == 0 {
-		return nil, fmt.Errorf("%s: no criteria defined", path)
-	}
-	return &cs, nil
+data, err := os.ReadFile(path)
+if err != nil {
+return nil, err
+}
+var cs CriteriaSet
+dec := yaml.NewDecoder(bytes.NewReader(data))
+dec.KnownFields(true)
+if err := dec.Decode(&cs); err != nil {
+return nil, fmt.Errorf("parsing %s: %w", path, err)
+}
+if len(cs.Criteria) == 0 {
+return nil, fmt.Errorf("%s: no criteria defined", path)
+}
+return &cs, nil
 }
 
-// MatchingCriteria returns all criteria from sets that match the given prompt attrs.
-func MatchingCriteria(sets []CriteriaSet, attrs PromptAttrs) []Criterion {
-	var matched []Criterion
-	for _, s := range sets {
-		if s.Match.Matches(attrs) {
-			matched = append(matched, s.Criteria...)
-		}
-	}
-	return matched
+// MatchingCriteria returns all criteria from sets whose When conditions match
+// the given prompt properties.
+func MatchingCriteria(sets []CriteriaSet, properties map[string]string) []Criterion {
+var matched []Criterion
+for _, s := range sets {
+if s.Matches(properties) {
+matched = append(matched, s.Criteria...)
 }
-
-// FormatCriteria formats a list of criteria as a text block suitable for
-// injection into a review prompt.
-func FormatCriteria(criteria []Criterion) string {
-	if len(criteria) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for i, c := range criteria {
-		fmt.Fprintf(&b, "%d. **%s**", i+1, c.Name)
-		if c.Description != "" {
-			fmt.Fprintf(&b, " — %s", strings.TrimSpace(c.Description))
-		}
-		b.WriteString("\n")
-	}
-	return b.String()
 }
-
-// MergeCriteria combines Tier 2 (attribute-matched) criteria text with Tier 3
-// (prompt-specific) criteria text. Returns the merged string suitable for
-// passing to the reviewer.
-func MergeCriteria(tier2 []Criterion, tier3Text string) string {
-	parts := make([]string, 0, 2)
-
-	formatted := FormatCriteria(tier2)
-	if formatted != "" {
-		parts = append(parts, "### Attribute-Matched Criteria\n\n"+formatted)
-	}
-
-	tier3Text = strings.TrimSpace(tier3Text)
-	if tier3Text != "" {
-		parts = append(parts, "### Prompt-Specific Criteria\n\n"+tier3Text)
-	}
-
-	return strings.Join(parts, "\n")
+return matched
 }

--- a/hyoka/internal/criteria/criteria_test.go
+++ b/hyoka/internal/criteria/criteria_test.go
@@ -1,81 +1,83 @@
 package criteria
 
 import (
-	"io"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
+"io"
+"log/slog"
+"os"
+"path/filepath"
+"testing"
 )
 
 func TestMain(m *testing.M) {
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
-	os.Exit(m.Run())
+slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
+os.Exit(m.Run())
 }
 
-func TestMatchConditionMatchesAll(t *testing.T) {
-	m := MatchCondition{Language: "java", Service: "keyvault"}
-	attrs := PromptAttrs{Language: "java", Service: "keyvault", Plane: "data-plane"}
-	if !m.Matches(attrs) {
-		t.Error("expected match")
-	}
+func TestMatchesAll(t *testing.T) {
+cs := CriteriaSet{When: map[string]string{"language": "java", "service": "keyvault"}}
+props := map[string]string{"language": "java", "service": "keyvault", "plane": "data-plane"}
+if !cs.Matches(props) {
+t.Error("expected match")
+}
 }
 
-func TestMatchConditionCaseInsensitive(t *testing.T) {
-	m := MatchCondition{Language: "Java"}
-	attrs := PromptAttrs{Language: "java"}
-	if !m.Matches(attrs) {
-		t.Error("expected case-insensitive match")
-	}
+func TestMatchesCaseInsensitive(t *testing.T) {
+cs := CriteriaSet{When: map[string]string{"language": "Java"}}
+props := map[string]string{"language": "java"}
+if !cs.Matches(props) {
+t.Error("expected case-insensitive match")
+}
 }
 
-func TestMatchConditionNoMatch(t *testing.T) {
-	m := MatchCondition{Language: "python"}
-	attrs := PromptAttrs{Language: "java"}
-	if m.Matches(attrs) {
-		t.Error("expected no match")
-	}
+func TestMatchesNoMatch(t *testing.T) {
+cs := CriteriaSet{When: map[string]string{"language": "python"}}
+props := map[string]string{"language": "java"}
+if cs.Matches(props) {
+t.Error("expected no match")
+}
 }
 
-func TestMatchConditionEmpty(t *testing.T) {
-	m := MatchCondition{}
-	attrs := PromptAttrs{Language: "java", Service: "storage"}
-	if !m.Matches(attrs) {
-		t.Error("empty match condition should match everything")
-	}
+func TestMatchesEmptyWhen(t *testing.T) {
+cs := CriteriaSet{}
+props := map[string]string{"language": "java", "service": "storage"}
+if !cs.Matches(props) {
+t.Error("empty when should match everything")
+}
 }
 
-func TestMatchConditionPartialFields(t *testing.T) {
-	tests := []struct {
-		name    string
-		cond    MatchCondition
-		attrs   PromptAttrs
-		matches bool
-	}{
-		{"service only match", MatchCondition{Service: "keyvault"}, PromptAttrs{Service: "keyvault", Language: "go"}, true},
-		{"service only no match", MatchCondition{Service: "keyvault"}, PromptAttrs{Service: "storage", Language: "go"}, false},
-		{"plane match", MatchCondition{Plane: "data-plane"}, PromptAttrs{Plane: "data-plane"}, true},
-		{"category match", MatchCondition{Category: "auth"}, PromptAttrs{Category: "auth"}, true},
-		{"sdk match", MatchCondition{SDK: "azure-identity"}, PromptAttrs{SDK: "azure-identity"}, true},
-		{"multi-field partial fail", MatchCondition{Language: "java", Service: "storage"}, PromptAttrs{Language: "java", Service: "keyvault"}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.cond.Matches(tt.attrs); got != tt.matches {
-				t.Errorf("expected %v, got %v", tt.matches, got)
-			}
-		})
-	}
+func TestMatchesPartialFields(t *testing.T) {
+tests := []struct {
+name    string
+when    map[string]string
+props   map[string]string
+matches bool
+}{
+{"service only match", map[string]string{"service": "keyvault"}, map[string]string{"service": "keyvault", "language": "go"}, true},
+{"service only no match", map[string]string{"service": "keyvault"}, map[string]string{"service": "storage", "language": "go"}, false},
+{"plane match", map[string]string{"plane": "data-plane"}, map[string]string{"plane": "data-plane"}, true},
+{"category match", map[string]string{"category": "auth"}, map[string]string{"category": "auth"}, true},
+{"sdk match", map[string]string{"sdk": "azure-identity"}, map[string]string{"sdk": "azure-identity"}, true},
+{"multi-field partial fail", map[string]string{"language": "java", "service": "storage"}, map[string]string{"language": "java", "service": "keyvault"}, false},
+{"custom property match", map[string]string{"framework": "spring"}, map[string]string{"framework": "spring", "language": "java"}, true},
+{"missing property no match", map[string]string{"framework": "spring"}, map[string]string{"language": "java"}, false},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+cs := CriteriaSet{When: tt.when}
+if got := cs.Matches(tt.props); got != tt.matches {
+t.Errorf("expected %v, got %v", tt.matches, got)
+}
+})
+}
 }
 
 func TestLoadDir(t *testing.T) {
-	dir := t.TempDir()
+dir := t.TempDir()
 
-	javaFile := filepath.Join(dir, "language", "java.yaml")
-	os.MkdirAll(filepath.Dir(javaFile), 0755)
-	os.WriteFile(javaFile, []byte(`
-match:
+javaFile := filepath.Join(dir, "language", "java.yaml")
+os.MkdirAll(filepath.Dir(javaFile), 0755)
+os.WriteFile(javaFile, []byte(`
+when:
   language: java
 criteria:
   - name: Builder Pattern
@@ -84,147 +86,97 @@ criteria:
     description: AutoCloseable clients use try-with-resources.
 `), 0644)
 
-	kvFile := filepath.Join(dir, "service", "keyvault.yaml")
-	os.MkdirAll(filepath.Dir(kvFile), 0755)
-	os.WriteFile(kvFile, []byte(`
-match:
+kvFile := filepath.Join(dir, "service", "keyvault.yaml")
+os.MkdirAll(filepath.Dir(kvFile), 0755)
+os.WriteFile(kvFile, []byte(`
+when:
   service: keyvault
 criteria:
   - name: Vault URI Format
     description: Uses parameterized vault URI.
 `), 0644)
 
-	sets, err := LoadDir(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(sets) != 2 {
-		t.Fatalf("expected 2 criteria sets, got %d", len(sets))
-	}
+sets, err := LoadDir(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(sets) != 2 {
+t.Fatalf("expected 2 criteria sets, got %d", len(sets))
+}
 }
 
 func TestLoadDirSkipsInvalid(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("not: valid: yaml: ["), 0644)
-	os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte("match:\n  language: go\ncriteria: []\n"), 0644)
-	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a yaml file"), 0644)
+dir := t.TempDir()
+os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("not: valid: yaml: ["), 0644)
+os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte("when:\n  language: go\ncriteria: []\n"), 0644)
+os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a yaml file"), 0644)
 
-	sets, err := LoadDir(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(sets) != 0 {
-		t.Errorf("expected 0 valid sets, got %d", len(sets))
-	}
+sets, err := LoadDir(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(sets) != 0 {
+t.Errorf("expected 0 valid sets, got %d", len(sets))
+}
 }
 
 func TestLoadDirNonexistent(t *testing.T) {
-	_, err := LoadDir("/nonexistent/path")
-	if err == nil {
-		t.Error("expected error for nonexistent directory")
-	}
+_, err := LoadDir("/nonexistent/path")
+if err == nil {
+t.Error("expected error for nonexistent directory")
+}
 }
 
 func TestMatchingCriteria(t *testing.T) {
-	sets := []CriteriaSet{
-		{
-			Match:    MatchCondition{Language: "java"},
-			Criteria: []Criterion{{Name: "Builder Pattern"}, {Name: "Try-With-Resources"}},
-		},
-		{
-			Match:    MatchCondition{Service: "keyvault"},
-			Criteria: []Criterion{{Name: "Vault URI"}},
-		},
-		{
-			Match:    MatchCondition{Language: "python"},
-			Criteria: []Criterion{{Name: "Async Usage"}},
-		},
-	}
-
-	got := MatchingCriteria(sets, PromptAttrs{Language: "java", Service: "keyvault"})
-	if len(got) != 3 {
-		t.Fatalf("expected 3 matching criteria, got %d", len(got))
-	}
-
-	got = MatchingCriteria(sets, PromptAttrs{Language: "python", Service: "storage"})
-	if len(got) != 1 {
-		t.Fatalf("expected 1 matching criterion, got %d", len(got))
-	}
-
-	got = MatchingCriteria(sets, PromptAttrs{Language: "go", Service: "storage"})
-	if len(got) != 0 {
-		t.Errorf("expected 0 matching criteria, got %d", len(got))
-	}
+sets := []CriteriaSet{
+{
+When:     map[string]string{"language": "java"},
+Criteria: []Criterion{{Name: "Builder Pattern"}, {Name: "Try-With-Resources"}},
+},
+{
+When:     map[string]string{"service": "keyvault"},
+Criteria: []Criterion{{Name: "Vault URI"}},
+},
+{
+When:     map[string]string{"language": "python"},
+Criteria: []Criterion{{Name: "Async Usage"}},
+},
 }
 
-func TestFormatCriteria(t *testing.T) {
-	criteria := []Criterion{
-		{Name: "Builder Pattern", Description: "Use builder pattern for clients."},
-		{Name: "Error Handling"},
-	}
-	result := FormatCriteria(criteria)
-	if !strings.Contains(result, "1. **Builder Pattern**") {
-		t.Errorf("expected formatted criterion name, got %q", result)
-	}
-	if !strings.Contains(result, "Use builder pattern") {
-		t.Errorf("expected description, got %q", result)
-	}
-	if !strings.Contains(result, "2. **Error Handling**") {
-		t.Errorf("expected second criterion, got %q", result)
-	}
+got := MatchingCriteria(sets, map[string]string{"language": "java", "service": "keyvault"})
+if len(got) != 3 {
+t.Fatalf("expected 3 matching criteria, got %d", len(got))
 }
 
-func TestFormatCriteriaEmpty(t *testing.T) {
-	if got := FormatCriteria(nil); got != "" {
-		t.Errorf("expected empty string for nil criteria, got %q", got)
-	}
+got = MatchingCriteria(sets, map[string]string{"language": "python", "service": "storage"})
+if len(got) != 1 {
+t.Fatalf("expected 1 matching criterion, got %d", len(got))
 }
 
-func TestMergeCriteria(t *testing.T) {
-	tier2 := []Criterion{
-		{Name: "Builder Pattern", Description: "Use builder."},
-	}
-	tier3 := "- Uses correct authentication method"
-
-	result := MergeCriteria(tier2, tier3)
-	if !strings.Contains(result, "Attribute-Matched") {
-		t.Error("expected Attribute-Matched header")
-	}
-	if !strings.Contains(result, "Prompt-Specific") {
-		t.Error("expected Prompt-Specific header")
-	}
-	if !strings.Contains(result, "Builder Pattern") {
-		t.Error("expected tier 2 criterion")
-	}
-	if !strings.Contains(result, "authentication method") {
-		t.Error("expected tier 3 text")
-	}
+got = MatchingCriteria(sets, map[string]string{"language": "go", "service": "storage"})
+if len(got) != 0 {
+t.Errorf("expected 0 matching criteria, got %d", len(got))
+}
 }
 
-func TestMergeCriteriaTier2Only(t *testing.T) {
-	tier2 := []Criterion{{Name: "Test"}}
-	result := MergeCriteria(tier2, "")
-	if !strings.Contains(result, "Attribute-Matched") {
-		t.Error("expected tier 2 content")
-	}
-	if strings.Contains(result, "Prompt-Specific") {
-		t.Error("should not contain prompt-specific header when tier3 is empty")
-	}
+func TestMatchingCriteriaEmptyWhen(t *testing.T) {
+sets := []CriteriaSet{
+{
+Criteria: []Criterion{{Name: "Universal Rule"}},
+},
+{
+When:     map[string]string{"language": "python"},
+Criteria: []Criterion{{Name: "Python Only"}},
+},
 }
 
-func TestMergeCriteriaTier3Only(t *testing.T) {
-	result := MergeCriteria(nil, "some criteria")
-	if strings.Contains(result, "Attribute-Matched") {
-		t.Error("should not contain attribute-matched header when tier2 is empty")
-	}
-	if !strings.Contains(result, "Prompt-Specific") {
-		t.Error("expected prompt-specific header")
-	}
+got := MatchingCriteria(sets, map[string]string{"language": "java"})
+if len(got) != 1 || got[0].Name != "Universal Rule" {
+t.Errorf("expected only universal rule, got %v", got)
 }
 
-func TestMergeCriteriaBothEmpty(t *testing.T) {
-	result := MergeCriteria(nil, "")
-	if result != "" {
-		t.Errorf("expected empty result, got %q", result)
-	}
+got = MatchingCriteria(sets, map[string]string{"language": "python"})
+if len(got) != 2 {
+t.Errorf("expected 2 criteria (universal + python), got %d", len(got))
+}
 }

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -192,22 +192,17 @@ func (e *Engine) loadCriteria() {
 	slog.Info("Loaded attribute-matched criteria", "sets", len(sets), "dir", e.opts.CriteriaDir)
 }
 
-// mergedCriteria returns the combined Tier 2 + Tier 3 evaluation criteria
-// text for the given prompt.
-func (e *Engine) mergedCriteria(p *prompt.Prompt) string {
-	attrs := criteria.PromptAttrs{
-		Language: p.Language(),
-		Service:  p.Service(),
-		Plane:    p.Plane(),
-		Category: p.Category(),
-		SDK:      p.SDKPackage(),
+// matchedCriteria returns all Tier 2 criteria whose "when" conditions match
+// the prompt's properties.
+func (e *Engine) matchedCriteria(p *prompt.Prompt) []criteria.Criterion {
+	props := map[string]string{
+		"language": p.Language(),
+		"service":  p.Service(),
+		"plane":    p.Plane(),
+		"category": p.Category(),
+		"sdk":      p.SDKPackage(),
 	}
-	matched := criteria.MatchingCriteria(e.criteriaSets, attrs)
-	merged := criteria.MergeCriteria(matched, p.EvaluationCriteria)
-	if merged == "" {
-		return p.EvaluationCriteria
-	}
-	return merged
+	return criteria.MatchingCriteria(e.criteriaSets, props)
 }
 
 // SetPanelReviewer configures a multi-model review panel.
@@ -830,8 +825,24 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			referenceDir = task.Prompt.ReferenceAnswer
 		}
 
-		// Merge tiered evaluation criteria (#30)
-		evalCriteria := e.mergedCriteria(task.Prompt)
+		// Collect matching evaluation criteria (#30, #104)
+		matched := e.matchedCriteria(task.Prompt)
+		evalCriteria := task.Prompt.EvaluationCriteria
+		if len(matched) > 0 {
+			var b strings.Builder
+			for i, c := range matched {
+				fmt.Fprintf(&b, "%d. **%s**", i+1, c.Name)
+				if c.Description != "" {
+					fmt.Fprintf(&b, " — %s", strings.TrimSpace(c.Description))
+				}
+				b.WriteString("\n")
+			}
+			if evalCriteria != "" {
+				evalCriteria = b.String() + "\n" + evalCriteria
+			} else {
+				evalCriteria = b.String()
+			}
+		}
 
 		// Create reviewer for this specific config using the factory (#92)
 		var reviewer review.Reviewer

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -668,7 +668,7 @@ func TestCriteriaMergedIntoReview(t *testing.T) {
 	criteriaDir := t.TempDir()
 	os.MkdirAll(filepath.Join(criteriaDir, "language"), 0755)
 	os.WriteFile(filepath.Join(criteriaDir, "language", "go.yaml"), []byte(`
-match:
+when:
   language: go
 criteria:
   - name: Uses DefaultAzureCredential


### PR DESCRIPTION
## Summary

Replace the typed `MatchCondition` struct with a generic `When map[string]string` for criteria matching. This aligns the criteria system with the grader config property-based matching pattern.

## Changes

- **Removed**: `MatchCondition`, `PromptAttrs`, `FormatCriteria()`, `MergeCriteria()`
- **Added**: `CriteriaSet.When map[string]string` — each key/value pair is checked against prompt properties (case-insensitive); empty `when` matches all prompts
- **Updated**: `MatchingCriteria()` takes `map[string]string` instead of `PromptAttrs`
- **Updated**: Criteria YAML files from `match:` to `when:` format
- **Updated**: Engine caller formats matched criteria inline
- **Updated**: All tests for new API, added custom property and empty-when tests

## Why

The old typed `MatchCondition` was limited to 5 hardcoded fields. The new `when:` map supports arbitrary properties, enabling future extensibility (e.g., `framework: spring`, `sdk_version: 2.x`).

Closes #104