### PR TITLE
refactor: migrate criteria to grader config format, remove tier system (#105)

### DIFF
--- a/criteria/language/dotnet.yaml
+++ b/criteria/language/dotnet.yaml
@@ -1,23 +1,28 @@
 when:
   language: dotnet
-criteria:
+graders:
   - name: NuGet Package References
-    description: >
+    weight: 1.0
+    prompt: >
       Generated code includes correct NuGet package references for all
       Azure SDK packages used.
   - name: DefaultAzureCredential Usage
-    description: >
+    weight: 1.0
+    prompt: >
       Authentication uses DefaultAzureCredential from Azure.Identity,
       not connection strings or hardcoded keys.
   - name: IDisposable/IAsyncDisposable Pattern
-    description: >
+    weight: 1.0
+    prompt: >
       Azure SDK clients that implement IDisposable or IAsyncDisposable
       are used within using statements or explicitly disposed.
   - name: Correct Azure.* Namespace
-    description: >
+    weight: 1.0
+    prompt: >
       Imports use the latest Azure SDK namespace (Azure.*),
       not legacy Microsoft.Azure.* packages.
   - name: Async/Await Pattern
-    description: >
+    weight: 1.0
+    prompt: >
       If async operations are used, code follows proper async/await
       patterns with Async method suffixes.

--- a/criteria/language/go.yaml
+++ b/criteria/language/go.yaml
@@ -1,23 +1,28 @@
 when:
   language: go
-criteria:
+graders:
   - name: Module Dependencies
-    description: >
+    weight: 1.0
+    prompt: >
       Generated code includes correct Go module dependencies
       (go.mod) for all Azure SDK packages used.
   - name: DefaultAzureCredential Usage
-    description: >
+    weight: 1.0
+    prompt: >
       Authentication uses azidentity.NewDefaultAzureCredential,
       not connection strings or hardcoded keys.
   - name: Error Handling
-    description: >
+    weight: 1.0
+    prompt: >
       All Azure SDK method calls check returned errors and handle
       them appropriately (no ignored errors).
   - name: Client Close/Cleanup
-    description: >
+    weight: 1.0
+    prompt: >
       HTTP clients and response bodies are properly closed to
       prevent resource leaks.
   - name: Correct azcore/azidentity Imports
-    description: >
+    weight: 1.0
+    prompt: >
       Imports use the latest azure-sdk-for-go v2 packages
       (github.com/Azure/azure-sdk-for-go/sdk/*).

--- a/criteria/language/java.yaml
+++ b/criteria/language/java.yaml
@@ -1,34 +1,41 @@
 when:
   language: java
-criteria:
+graders:
   - name: Maven/Gradle Dependency Declaration
-    description: >
+    weight: 1.0
+    prompt: >
       Generated code includes correct dependency declarations
       (groupId, artifactId, version) for all Azure SDK packages used.
   - name: Try-With-Resources for Clients
-    description: >
+    weight: 1.0
+    prompt: >
       All Azure SDK client instances that implement AutoCloseable
       are used within try-with-resources blocks or explicitly closed
       in a finally block.
   - name: Correct Import Packages
-    description: >
+    weight: 1.0
+    prompt: >
       Imports use the latest azure-sdk-for-java package structure
       (com.azure.*), not legacy packages (com.microsoft.azure.*).
   - name: TokenCredential Authentication
-    description: >
+    weight: 1.0
+    prompt: >
       Authentication uses DefaultAzureCredential or another
       TokenCredential implementation, not connection strings or
       hardcoded keys.
   - name: Builder Pattern for Clients
-    description: >
+    weight: 1.0
+    prompt: >
       SDK clients are constructed using the builder pattern
       (e.g., new SecretClientBuilder().credential(...).buildClient()).
   - name: Proper Exception Handling
-    description: >
+    weight: 1.0
+    prompt: >
       Azure SDK exceptions (HttpResponseException and subclasses) are
       caught and handled with status code inspection where appropriate.
   - name: Pagination Handling
-    description: >
+    weight: 1.0
+    prompt: >
       List operations use PagedIterable/PagedFlux correctly, iterating
       with .stream() or .forEach() rather than calling .getValue() on
       the paged response directly.

--- a/criteria/language/python.yaml
+++ b/criteria/language/python.yaml
@@ -1,23 +1,28 @@
 when:
   language: python
-criteria:
+graders:
   - name: Correct Package Imports
-    description: >
+    weight: 1.0
+    prompt: >
       Imports use the latest azure-sdk-for-python package structure
       (azure.*), not deprecated packages.
   - name: DefaultAzureCredential Usage
-    description: >
+    weight: 1.0
+    prompt: >
       Authentication uses DefaultAzureCredential from azure-identity,
       not connection strings or hardcoded keys.
   - name: Context Manager for Clients
-    description: >
+    weight: 1.0
+    prompt: >
       Azure SDK clients that support context managers are used with
       `with` statements or explicitly closed.
   - name: Async Client Usage
-    description: >
+    weight: 1.0
+    prompt: >
       If async operations are requested, code uses the async client
       variant with proper await patterns.
   - name: Proper Exception Handling
-    description: >
+    weight: 1.0
+    prompt: >
       Azure SDK exceptions (HttpResponseError and subclasses) are
       caught and handled appropriately.

--- a/criteria/service/key-vault.yaml
+++ b/criteria/service/key-vault.yaml
@@ -1,15 +1,18 @@
 when:
   service: key-vault
-criteria:
+graders:
   - name: Secret/Key/Certificate Client Separation
-    description: >
+    weight: 1.0
+    prompt: >
       Uses the correct sub-client for the operation (SecretClient for
       secrets, KeyClient for keys, CertificateClient for certificates).
   - name: Key Vault URI Format
-    description: >
+    weight: 1.0
+    prompt: >
       Vault URI follows the https://{vault-name}.vault.azure.net
       pattern and is parameterized, not hardcoded.
   - name: Purge Protection Awareness
-    description: >
+    weight: 1.0
+    prompt: >
       Delete operations account for soft-delete and purge protection —
       code includes comments or handling for the recovery period.

--- a/criteria/service/storage.yaml
+++ b/criteria/service/storage.yaml
@@ -1,15 +1,18 @@
 when:
   service: storage
-criteria:
+graders:
   - name: Storage Account URL Format
-    description: >
+    weight: 1.0
+    prompt: >
       Storage account URL follows the correct pattern
       (https://{account}.blob.core.windows.net) and is parameterized.
   - name: Container/Blob Path Handling
-    description: >
+    weight: 1.0
+    prompt: >
       Container and blob names are properly parameterized
       and validated, not hardcoded.
   - name: SAS Token vs RBAC
-    description: >
+    weight: 1.0
+    prompt: >
       Prefers RBAC-based authentication (DefaultAzureCredential)
       over SAS tokens or account keys where possible.

--- a/hyoka/internal/criteria/criteria.go
+++ b/hyoka/internal/criteria/criteria.go
@@ -1,102 +1,144 @@
-// Package criteria implements a tiered evaluation criteria system.
+// Package criteria implements a grader-config-based evaluation criteria system.
 //
-// Criteria YAML files use a "when" map to declare which prompts they apply to.
-// All entries in "when" must match the corresponding prompt property
-// (case-insensitive). An empty or absent "when" block matches every prompt.
+// Criteria YAML files define grader configs with:
+//   - when: map[string]string conditions (all must match for the config to apply)
+//   - graders: weighted evaluation rubrics with prompts
+//
+// At eval time, matching grader configs are collected and merged with any
+// prompt-specific criteria to form the final evaluation rubric.
 package criteria
 
 import (
-"bytes"
-"fmt"
-"log/slog"
-"os"
-"path/filepath"
-"strings"
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 
-"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
-// Criterion defines a single evaluation criterion.
-type Criterion struct {
-Name        string `yaml:"name" json:"name"`
-Description string `yaml:"description" json:"description"`
+// GraderEntry defines a single grader with its evaluation prompt and weight.
+type GraderEntry struct {
+	Name   string  `yaml:"name" json:"name"`
+	Weight float64 `yaml:"weight" json:"weight"`
+	Prompt string  `yaml:"prompt" json:"prompt"`
 }
 
-// CriteriaSet is a collection of criteria with conditions for when they apply.
-type CriteriaSet struct {
-When     map[string]string `yaml:"when"`
-Criteria []Criterion       `yaml:"criteria"`
-Source   string            `yaml:"-"` // source file path
+// GraderConfig is a collection of graders with conditions for when they apply.
+// When the When map is empty, the config is unconditionally included.
+// When the When map has entries, all key-value pairs must match the prompt's
+// properties for the graders to be included.
+type GraderConfig struct {
+	When    map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+	Graders []GraderEntry     `yaml:"graders" json:"graders"`
+	Source  string            `yaml:"-" json:"-"`
 }
 
-// Matches returns true if every entry in When matches the corresponding value
-// in properties (case-insensitive). An empty When matches all prompts.
-func (cs CriteriaSet) Matches(properties map[string]string) bool {
-for k, v := range cs.When {
-if !strings.EqualFold(properties[k], v) {
-return false
-}
-}
-return true
-}
-
-// LoadDir loads all criteria YAML files from a directory tree.
-func LoadDir(dir string) ([]CriteriaSet, error) {
-var sets []CriteriaSet
-
-err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-if err != nil {
-return err
-}
-if info.IsDir() {
-return nil
-}
-ext := filepath.Ext(path)
-if ext != ".yaml" && ext != ".yml" {
-return nil
+// matchesWhen returns true when every key-value pair in when matches the
+// properties map (case-insensitive values). An empty when map always matches.
+func matchesWhen(when map[string]string, props map[string]string) bool {
+	for k, v := range when {
+		if !strings.EqualFold(props[k], v) {
+			return false
+		}
+	}
+	return true
 }
 
-cs, err := loadFile(path)
-if err != nil {
-slog.Warn("Skipping invalid criteria file", "path", path, "error", err)
-return nil
-}
-cs.Source = path
-sets = append(sets, *cs)
-slog.Debug("Loaded criteria set", "path", path, "criteria_count", len(cs.Criteria))
-return nil
-})
-if err != nil {
-return nil, fmt.Errorf("walking criteria directory %s: %w", dir, err)
-}
-return sets, nil
+// LoadDir loads all grader config YAML files from a directory tree.
+func LoadDir(dir string) ([]GraderConfig, error) {
+	var configs []GraderConfig
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		gc, err := loadFile(path)
+		if err != nil {
+			slog.Warn("Skipping invalid grader config file", "path", path, "error", err)
+			return nil
+		}
+		gc.Source = path
+		configs = append(configs, *gc)
+		slog.Debug("Loaded grader config", "path", path, "grader_count", len(gc.Graders))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking criteria directory %s: %w", dir, err)
+	}
+	return configs, nil
 }
 
-func loadFile(path string) (*CriteriaSet, error) {
-data, err := os.ReadFile(path)
-if err != nil {
-return nil, err
-}
-var cs CriteriaSet
-dec := yaml.NewDecoder(bytes.NewReader(data))
-dec.KnownFields(true)
-if err := dec.Decode(&cs); err != nil {
-return nil, fmt.Errorf("parsing %s: %w", path, err)
-}
-if len(cs.Criteria) == 0 {
-return nil, fmt.Errorf("%s: no criteria defined", path)
-}
-return &cs, nil
+func loadFile(path string) (*GraderConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var gc GraderConfig
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&gc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if len(gc.Graders) == 0 {
+		return nil, fmt.Errorf("%s: no graders defined", path)
+	}
+	return &gc, nil
 }
 
-// MatchingCriteria returns all criteria from sets whose When conditions match
-// the given prompt properties.
-func MatchingCriteria(sets []CriteriaSet, properties map[string]string) []Criterion {
-var matched []Criterion
-for _, s := range sets {
-if s.Matches(properties) {
-matched = append(matched, s.Criteria...)
+// MatchingGraders returns all grader entries from configs whose when-conditions
+// match the given prompt properties.
+func MatchingGraders(configs []GraderConfig, props map[string]string) []GraderEntry {
+	var matched []GraderEntry
+	for _, gc := range configs {
+		if matchesWhen(gc.When, props) {
+			matched = append(matched, gc.Graders...)
+		}
+	}
+	return matched
 }
+
+// FormatGraders formats a list of grader entries as a text block suitable for
+// injection into a review prompt.
+func FormatGraders(graders []GraderEntry) string {
+	if len(graders) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, g := range graders {
+		fmt.Fprintf(&b, "%d. **%s**", i+1, g.Name)
+		if g.Prompt != "" {
+			fmt.Fprintf(&b, " — %s", strings.TrimSpace(g.Prompt))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }
-return matched
+
+// MergeCriteria combines attribute-matched grader entries with prompt-specific
+// criteria text. Returns the merged string suitable for passing to the reviewer.
+func MergeCriteria(graders []GraderEntry, promptCriteria string) string {
+	parts := make([]string, 0, 2)
+
+	formatted := FormatGraders(graders)
+	if formatted != "" {
+		parts = append(parts, "### Attribute-Matched Criteria\n\n"+formatted)
+	}
+
+	promptCriteria = strings.TrimSpace(promptCriteria)
+	if promptCriteria != "" {
+		parts = append(parts, "### Prompt-Specific Criteria\n\n"+promptCriteria)
+	}
+
+	return strings.Join(parts, "\n")
 }

--- a/hyoka/internal/criteria/criteria_test.go
+++ b/hyoka/internal/criteria/criteria_test.go
@@ -1,182 +1,263 @@
 package criteria
 
 import (
-"io"
-"log/slog"
-"os"
-"path/filepath"
-"testing"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func TestMain(m *testing.M) {
-slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
-os.Exit(m.Run())
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
+	os.Exit(m.Run())
 }
 
-func TestMatchesAll(t *testing.T) {
-cs := CriteriaSet{When: map[string]string{"language": "java", "service": "keyvault"}}
-props := map[string]string{"language": "java", "service": "keyvault", "plane": "data-plane"}
-if !cs.Matches(props) {
-t.Error("expected match")
-}
-}
-
-func TestMatchesCaseInsensitive(t *testing.T) {
-cs := CriteriaSet{When: map[string]string{"language": "Java"}}
-props := map[string]string{"language": "java"}
-if !cs.Matches(props) {
-t.Error("expected case-insensitive match")
-}
+func TestMatchesWhenAllFields(t *testing.T) {
+	when := map[string]string{"language": "java", "service": "keyvault"}
+	props := map[string]string{"language": "java", "service": "keyvault", "plane": "data-plane"}
+	if !matchesWhen(when, props) {
+		t.Error("expected match")
+	}
 }
 
-func TestMatchesNoMatch(t *testing.T) {
-cs := CriteriaSet{When: map[string]string{"language": "python"}}
-props := map[string]string{"language": "java"}
-if cs.Matches(props) {
-t.Error("expected no match")
-}
-}
-
-func TestMatchesEmptyWhen(t *testing.T) {
-cs := CriteriaSet{}
-props := map[string]string{"language": "java", "service": "storage"}
-if !cs.Matches(props) {
-t.Error("empty when should match everything")
-}
+func TestMatchesWhenCaseInsensitive(t *testing.T) {
+	when := map[string]string{"language": "Java"}
+	props := map[string]string{"language": "java"}
+	if !matchesWhen(when, props) {
+		t.Error("expected case-insensitive match")
+	}
 }
 
-func TestMatchesPartialFields(t *testing.T) {
-tests := []struct {
-name    string
-when    map[string]string
-props   map[string]string
-matches bool
-}{
-{"service only match", map[string]string{"service": "keyvault"}, map[string]string{"service": "keyvault", "language": "go"}, true},
-{"service only no match", map[string]string{"service": "keyvault"}, map[string]string{"service": "storage", "language": "go"}, false},
-{"plane match", map[string]string{"plane": "data-plane"}, map[string]string{"plane": "data-plane"}, true},
-{"category match", map[string]string{"category": "auth"}, map[string]string{"category": "auth"}, true},
-{"sdk match", map[string]string{"sdk": "azure-identity"}, map[string]string{"sdk": "azure-identity"}, true},
-{"multi-field partial fail", map[string]string{"language": "java", "service": "storage"}, map[string]string{"language": "java", "service": "keyvault"}, false},
-{"custom property match", map[string]string{"framework": "spring"}, map[string]string{"framework": "spring", "language": "java"}, true},
-{"missing property no match", map[string]string{"framework": "spring"}, map[string]string{"language": "java"}, false},
+func TestMatchesWhenNoMatch(t *testing.T) {
+	when := map[string]string{"language": "python"}
+	props := map[string]string{"language": "java"}
+	if matchesWhen(when, props) {
+		t.Error("expected no match")
+	}
 }
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-cs := CriteriaSet{When: tt.when}
-if got := cs.Matches(tt.props); got != tt.matches {
-t.Errorf("expected %v, got %v", tt.matches, got)
+
+func TestMatchesWhenEmpty(t *testing.T) {
+	when := map[string]string{}
+	props := map[string]string{"language": "java", "service": "storage"}
+	if !matchesWhen(when, props) {
+		t.Error("empty when map should match everything")
+	}
 }
-})
-}
+
+func TestMatchesWhenPartialFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		when    map[string]string
+		props   map[string]string
+		matches bool
+	}{
+		{"service only match", map[string]string{"service": "keyvault"}, map[string]string{"service": "keyvault", "language": "go"}, true},
+		{"service only no match", map[string]string{"service": "keyvault"}, map[string]string{"service": "storage", "language": "go"}, false},
+		{"plane match", map[string]string{"plane": "data-plane"}, map[string]string{"plane": "data-plane"}, true},
+		{"category match", map[string]string{"category": "auth"}, map[string]string{"category": "auth"}, true},
+		{"sdk match", map[string]string{"sdk": "azure-identity"}, map[string]string{"sdk": "azure-identity"}, true},
+		{"multi-field partial fail", map[string]string{"language": "java", "service": "storage"}, map[string]string{"language": "java", "service": "keyvault"}, false},
+		{"missing prop key", map[string]string{"language": "go"}, map[string]string{"service": "storage"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesWhen(tt.when, tt.props); got != tt.matches {
+				t.Errorf("expected %v, got %v", tt.matches, got)
+			}
+		})
+	}
 }
 
 func TestLoadDir(t *testing.T) {
-dir := t.TempDir()
+	dir := t.TempDir()
 
-javaFile := filepath.Join(dir, "language", "java.yaml")
-os.MkdirAll(filepath.Dir(javaFile), 0755)
-os.WriteFile(javaFile, []byte(`
+	javaFile := filepath.Join(dir, "language", "java.yaml")
+	os.MkdirAll(filepath.Dir(javaFile), 0755)
+	os.WriteFile(javaFile, []byte(`
 when:
   language: java
-criteria:
+graders:
   - name: Builder Pattern
-    description: SDK clients use builder pattern.
+    weight: 1.0
+    prompt: SDK clients use builder pattern.
   - name: Try-With-Resources
-    description: AutoCloseable clients use try-with-resources.
+    weight: 1.0
+    prompt: AutoCloseable clients use try-with-resources.
 `), 0644)
 
-kvFile := filepath.Join(dir, "service", "keyvault.yaml")
-os.MkdirAll(filepath.Dir(kvFile), 0755)
-os.WriteFile(kvFile, []byte(`
+	kvFile := filepath.Join(dir, "service", "keyvault.yaml")
+	os.MkdirAll(filepath.Dir(kvFile), 0755)
+	os.WriteFile(kvFile, []byte(`
 when:
   service: keyvault
-criteria:
+graders:
   - name: Vault URI Format
-    description: Uses parameterized vault URI.
+    weight: 1.0
+    prompt: Uses parameterized vault URI.
 `), 0644)
 
-sets, err := LoadDir(dir)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if len(sets) != 2 {
-t.Fatalf("expected 2 criteria sets, got %d", len(sets))
-}
+	configs, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 grader configs, got %d", len(configs))
+	}
 }
 
 func TestLoadDirSkipsInvalid(t *testing.T) {
-dir := t.TempDir()
-os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("not: valid: yaml: ["), 0644)
-os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte("when:\n  language: go\ncriteria: []\n"), 0644)
-os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a yaml file"), 0644)
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("not: valid: yaml: ["), 0644)
+	os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte("when:\n  language: go\ngraders: []\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a yaml file"), 0644)
 
-sets, err := LoadDir(dir)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if len(sets) != 0 {
-t.Errorf("expected 0 valid sets, got %d", len(sets))
-}
+	configs, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 0 {
+		t.Errorf("expected 0 valid configs, got %d", len(configs))
+	}
 }
 
 func TestLoadDirNonexistent(t *testing.T) {
-_, err := LoadDir("/nonexistent/path")
-if err == nil {
-t.Error("expected error for nonexistent directory")
-}
-}
-
-func TestMatchingCriteria(t *testing.T) {
-sets := []CriteriaSet{
-{
-When:     map[string]string{"language": "java"},
-Criteria: []Criterion{{Name: "Builder Pattern"}, {Name: "Try-With-Resources"}},
-},
-{
-When:     map[string]string{"service": "keyvault"},
-Criteria: []Criterion{{Name: "Vault URI"}},
-},
-{
-When:     map[string]string{"language": "python"},
-Criteria: []Criterion{{Name: "Async Usage"}},
-},
+	_, err := LoadDir("/nonexistent/path")
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
 }
 
-got := MatchingCriteria(sets, map[string]string{"language": "java", "service": "keyvault"})
-if len(got) != 3 {
-t.Fatalf("expected 3 matching criteria, got %d", len(got))
+func TestMatchingGraders(t *testing.T) {
+	configs := []GraderConfig{
+		{
+			When:    map[string]string{"language": "java"},
+			Graders: []GraderEntry{{Name: "Builder Pattern", Weight: 1.0}, {Name: "Try-With-Resources", Weight: 1.0}},
+		},
+		{
+			When:    map[string]string{"service": "keyvault"},
+			Graders: []GraderEntry{{Name: "Vault URI", Weight: 1.0}},
+		},
+		{
+			When:    map[string]string{"language": "python"},
+			Graders: []GraderEntry{{Name: "Async Usage", Weight: 1.0}},
+		},
+	}
+
+	got := MatchingGraders(configs, map[string]string{"language": "java", "service": "keyvault"})
+	if len(got) != 3 {
+		t.Fatalf("expected 3 matching graders, got %d", len(got))
+	}
+
+	got = MatchingGraders(configs, map[string]string{"language": "python", "service": "storage"})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 matching grader, got %d", len(got))
+	}
+
+	got = MatchingGraders(configs, map[string]string{"language": "go", "service": "storage"})
+	if len(got) != 0 {
+		t.Errorf("expected 0 matching graders, got %d", len(got))
+	}
 }
 
-got = MatchingCriteria(sets, map[string]string{"language": "python", "service": "storage"})
-if len(got) != 1 {
-t.Fatalf("expected 1 matching criterion, got %d", len(got))
+func TestFormatGraders(t *testing.T) {
+	graders := []GraderEntry{
+		{Name: "Builder Pattern", Weight: 1.0, Prompt: "Use builder pattern for clients."},
+		{Name: "Error Handling", Weight: 1.0},
+	}
+	result := FormatGraders(graders)
+	if !strings.Contains(result, "1. **Builder Pattern**") {
+		t.Errorf("expected formatted grader name, got %q", result)
+	}
+	if !strings.Contains(result, "Use builder pattern") {
+		t.Errorf("expected prompt text, got %q", result)
+	}
+	if !strings.Contains(result, "2. **Error Handling**") {
+		t.Errorf("expected second grader, got %q", result)
+	}
 }
 
-got = MatchingCriteria(sets, map[string]string{"language": "go", "service": "storage"})
-if len(got) != 0 {
-t.Errorf("expected 0 matching criteria, got %d", len(got))
-}
-}
-
-func TestMatchingCriteriaEmptyWhen(t *testing.T) {
-sets := []CriteriaSet{
-{
-Criteria: []Criterion{{Name: "Universal Rule"}},
-},
-{
-When:     map[string]string{"language": "python"},
-Criteria: []Criterion{{Name: "Python Only"}},
-},
+func TestFormatGradersEmpty(t *testing.T) {
+	if got := FormatGraders(nil); got != "" {
+		t.Errorf("expected empty string for nil graders, got %q", got)
+	}
 }
 
-got := MatchingCriteria(sets, map[string]string{"language": "java"})
-if len(got) != 1 || got[0].Name != "Universal Rule" {
-t.Errorf("expected only universal rule, got %v", got)
+func TestMergeCriteria(t *testing.T) {
+	graders := []GraderEntry{
+		{Name: "Builder Pattern", Weight: 1.0, Prompt: "Use builder."},
+	}
+	promptCriteria := "- Uses correct authentication method"
+
+	result := MergeCriteria(graders, promptCriteria)
+	if !strings.Contains(result, "Attribute-Matched") {
+		t.Error("expected Attribute-Matched header")
+	}
+	if !strings.Contains(result, "Prompt-Specific") {
+		t.Error("expected Prompt-Specific header")
+	}
+	if !strings.Contains(result, "Builder Pattern") {
+		t.Error("expected grader criterion")
+	}
+	if !strings.Contains(result, "authentication method") {
+		t.Error("expected prompt criteria text")
+	}
 }
 
-got = MatchingCriteria(sets, map[string]string{"language": "python"})
-if len(got) != 2 {
-t.Errorf("expected 2 criteria (universal + python), got %d", len(got))
+func TestMergeCriteriaGradersOnly(t *testing.T) {
+	graders := []GraderEntry{{Name: "Test", Weight: 1.0}}
+	result := MergeCriteria(graders, "")
+	if !strings.Contains(result, "Attribute-Matched") {
+		t.Error("expected grader content")
+	}
+	if strings.Contains(result, "Prompt-Specific") {
+		t.Error("should not contain prompt-specific header when prompt criteria is empty")
+	}
 }
+
+func TestMergeCriteriaPromptOnly(t *testing.T) {
+	result := MergeCriteria(nil, "some criteria")
+	if strings.Contains(result, "Attribute-Matched") {
+		t.Error("should not contain attribute-matched header when graders is empty")
+	}
+	if !strings.Contains(result, "Prompt-Specific") {
+		t.Error("expected prompt-specific header")
+	}
+}
+
+func TestMergeCriteriaBothEmpty(t *testing.T) {
+	result := MergeCriteria(nil, "")
+	if result != "" {
+		t.Errorf("expected empty result, got %q", result)
+	}
+}
+
+func TestGraderWeightPreserved(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "test.yaml"), []byte(`
+when:
+  language: go
+graders:
+  - name: Critical Check
+    weight: 2.0
+    prompt: Very important check.
+  - name: Minor Check
+    weight: 0.5
+    prompt: Less important.
+`), 0644)
+
+	configs, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(configs))
+	}
+	if configs[0].Graders[0].Weight != 2.0 {
+		t.Errorf("expected weight 2.0, got %f", configs[0].Graders[0].Weight)
+	}
+	if configs[0].Graders[1].Weight != 0.5 {
+		t.Errorf("expected weight 0.5, got %f", configs[0].Graders[1].Weight)
+	}
 }

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -102,7 +102,7 @@ type Engine struct {
 	reviewerFactory ReviewerFactory
 	opts            EngineOptions
 	tracker         *ProcessTracker
-	criteriaSets    []criteria.CriteriaSet // Tier 2 attribute-matched criteria (#30)
+	graderConfigs   []criteria.GraderConfig // attribute-matched grader configs (#30)
 }
 
 // NewEngine creates a new Engine with the given evaluator and options.
@@ -174,7 +174,7 @@ func (e *Engine) printf(format string, args ...any) {
 	fmt.Fprintf(e.opts.Stdout, format, args...)
 }
 
-// loadCriteria loads Tier 2 criteria sets if CriteriaDir is configured.
+// loadCriteria loads grader configs if CriteriaDir is configured.
 func (e *Engine) loadCriteria() {
 	if e.opts.CriteriaDir == "" {
 		return
@@ -183,18 +183,18 @@ func (e *Engine) loadCriteria() {
 		slog.Debug("Criteria directory does not exist, skipping", "dir", e.opts.CriteriaDir)
 		return
 	}
-	sets, err := criteria.LoadDir(e.opts.CriteriaDir)
+	configs, err := criteria.LoadDir(e.opts.CriteriaDir)
 	if err != nil {
-		slog.Warn("Failed to load criteria sets", "dir", e.opts.CriteriaDir, "error", err)
+		slog.Warn("Failed to load grader configs", "dir", e.opts.CriteriaDir, "error", err)
 		return
 	}
-	e.criteriaSets = sets
-	slog.Info("Loaded attribute-matched criteria", "sets", len(sets), "dir", e.opts.CriteriaDir)
+	e.graderConfigs = configs
+	slog.Info("Loaded grader configs", "configs", len(configs), "dir", e.opts.CriteriaDir)
 }
 
-// matchedCriteria returns all Tier 2 criteria whose "when" conditions match
-// the prompt's properties.
-func (e *Engine) matchedCriteria(p *prompt.Prompt) []criteria.Criterion {
+// mergedCriteria returns the combined attribute-matched + prompt-specific
+// evaluation criteria text for the given prompt.
+func (e *Engine) mergedCriteria(p *prompt.Prompt) string {
 	props := map[string]string{
 		"language": p.Language(),
 		"service":  p.Service(),
@@ -202,7 +202,12 @@ func (e *Engine) matchedCriteria(p *prompt.Prompt) []criteria.Criterion {
 		"category": p.Category(),
 		"sdk":      p.SDKPackage(),
 	}
-	return criteria.MatchingCriteria(e.criteriaSets, props)
+	matched := criteria.MatchingGraders(e.graderConfigs, props)
+	merged := criteria.MergeCriteria(matched, p.EvaluationCriteria)
+	if merged == "" {
+		return p.EvaluationCriteria
+	}
+	return merged
 }
 
 // SetPanelReviewer configures a multi-model review panel.
@@ -223,7 +228,7 @@ type EvalTask struct {
 
 // Run executes evaluations for the given prompts crossed with configs.
 func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []config.ToolConfig) (*report.RunSummary, error) {
-	// Load tiered criteria sets (#30) if configured.
+	// Load grader configs (#30) if configured.
 	e.loadCriteria()
 
 	// Build task list (cross product: prompts × configs)
@@ -832,24 +837,8 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			referenceDir = task.Prompt.ReferenceAnswer
 		}
 
-		// Collect matching evaluation criteria (#30, #104)
-		matched := e.matchedCriteria(task.Prompt)
-		evalCriteria := task.Prompt.EvaluationCriteria
-		if len(matched) > 0 {
-			var b strings.Builder
-			for i, c := range matched {
-				fmt.Fprintf(&b, "%d. **%s**", i+1, c.Name)
-				if c.Description != "" {
-					fmt.Fprintf(&b, " — %s", strings.TrimSpace(c.Description))
-				}
-				b.WriteString("\n")
-			}
-			if evalCriteria != "" {
-				evalCriteria = b.String() + "\n" + evalCriteria
-			} else {
-				evalCriteria = b.String()
-			}
-		}
+		// Merge evaluation criteria (#30)
+		evalCriteria := e.mergedCriteria(task.Prompt)
 
 		// Create reviewer for this specific config using the factory (#92)
 		var reviewer review.Reviewer

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -664,15 +664,16 @@ func (c *capturingReviewer) Review(_ context.Context, _ string, _ string, _ stri
 }
 
 func TestCriteriaMergedIntoReview(t *testing.T) {
-	// Create criteria directory with a language-matched file
+	// Create criteria directory with a language-matched grader config
 	criteriaDir := t.TempDir()
 	os.MkdirAll(filepath.Join(criteriaDir, "language"), 0755)
 	os.WriteFile(filepath.Join(criteriaDir, "language", "go.yaml"), []byte(`
 when:
   language: go
-criteria:
+graders:
   - name: Uses DefaultAzureCredential
-    description: Must use azidentity.DefaultAzureCredential
+    weight: 1.0
+    prompt: Must use azidentity.DefaultAzureCredential
 `), 0644)
 
 	reviewer := &capturingReviewer{}
@@ -697,10 +698,10 @@ criteria:
 	}
 
 	if !strings.Contains(reviewer.capturedCriteria, "DefaultAzureCredential") {
-		t.Errorf("expected tier 2 criteria in review, got: %s", reviewer.capturedCriteria)
+		t.Errorf("expected grader criteria in review, got: %s", reviewer.capturedCriteria)
 	}
 	if !strings.Contains(reviewer.capturedCriteria, "handle errors properly") {
-		t.Errorf("expected tier 3 criteria in review, got: %s", reviewer.capturedCriteria)
+		t.Errorf("expected prompt criteria in review, got: %s", reviewer.capturedCriteria)
 	}
 }
 


### PR DESCRIPTION
## Summary

Migrates the criteria system from the old tier-based MatchCondition/Criterion format to the new grader config format using `when: map[string]string` matching and weighted GraderEntry prompts.

## Changes

### Criteria package (`hyoka/internal/criteria/`)
- **`MatchCondition` → `when: map[string]string`**: Replaced fixed-field struct with flexible key-value matching (consistent with `config.ToolEntry.When` pattern from PR #189)
- **`Criterion` → `GraderEntry`**: Added `weight` field and renamed `description` → `prompt` to clarify its role as a grader rubric
- **`CriteriaSet` → `GraderConfig`**: Updated container type with new field names
- **Removed `PromptAttrs` struct**: Replaced with `map[string]string` for property matching
- **Renamed functions**: `MatchingCriteria` → `MatchingGraders`, `FormatCriteria` → `FormatGraders`
- **Removed tier 1/2/3 terminology** from all code and comments

### Criteria YAML files (`criteria/`)
All 6 files migrated from old format:
```yaml
match:
  language: python
criteria:
  - name: X
    description: ...
```
To new grader config format:
```yaml
when:
  language: python
graders:
  - name: X
    weight: 1.0
    prompt: ...
```

### Engine (`hyoka/internal/eval/engine.go`)
- Updated to use `GraderConfig`/`GraderEntry` types
- Builds `map[string]string` props from prompt metadata
- Calls `MatchingGraders` instead of `MatchingCriteria`

### Tests
- All criteria unit tests rewritten for new types
- Added `TestGraderWeightPreserved` for weight serialization
- Engine integration tests updated with new YAML format

Closes #105