### PR TITLE
feat: define Grader interface and runtime types (#131)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -49,6 +49,14 @@ type ReviewerConfig struct {
 	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
+// SessionLimits holds configurable guardrails for a Copilot session.
+type SessionLimits struct {
+	MaxTurns          int    `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
+	MaxFiles          int    `yaml:"max_files,omitempty" json:"max_files,omitempty"`
+	MaxOutputSize     string `yaml:"max_output_size,omitempty" json:"max_output_size,omitempty"`
+	MaxSessionActions int    `yaml:"max_session_actions,omitempty" json:"max_session_actions,omitempty"`
+}
+
 // ToolConfig represents a single evaluation configuration.
 type ToolConfig struct {
 	Name        string           `yaml:"name" json:"name"`
@@ -56,6 +64,7 @@ type ToolConfig struct {
 	Generator   *GeneratorConfig `yaml:"generator,omitempty" json:"generator,omitempty"`
 	Reviewer    *ReviewerConfig  `yaml:"reviewer,omitempty" json:"reviewer,omitempty"`
 	Plugins     []string         `yaml:"plugins,omitempty" json:"plugins,omitempty"`
+	Limits      *SessionLimits   `yaml:"limits,omitempty" json:"limits,omitempty"`
 }
 
 // ConfigFile represents the top-level config file structure.

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -674,6 +674,90 @@ configs:
 	}
 }
 
+func TestParseSessionLimits(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: with-limits
+    description: "Config with session limits"
+    generator:
+      model: "claude-opus-4.6"
+    limits:
+      max_turns: 25
+      max_files: 50
+      max_output_size: "1MB"
+      max_session_actions: 100
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lim := cfg.Configs[0].Limits
+	if lim == nil {
+		t.Fatal("expected Limits to be non-nil")
+	}
+	if lim.MaxTurns != 25 {
+		t.Errorf("expected MaxTurns=25, got %d", lim.MaxTurns)
+	}
+	if lim.MaxFiles != 50 {
+		t.Errorf("expected MaxFiles=50, got %d", lim.MaxFiles)
+	}
+	if lim.MaxOutputSize != "1MB" {
+		t.Errorf("expected MaxOutputSize='1MB', got %q", lim.MaxOutputSize)
+	}
+	if lim.MaxSessionActions != 100 {
+		t.Errorf("expected MaxSessionActions=100, got %d", lim.MaxSessionActions)
+	}
+}
+
+func TestParseSessionLimitsOmitted(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: no-limits
+    description: "Config without limits"
+    generator:
+      model: "gpt-4"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Configs[0].Limits != nil {
+		t.Errorf("expected Limits to be nil when omitted, got %+v", cfg.Configs[0].Limits)
+	}
+}
+
+func TestParseSessionLimitsPartial(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: partial-limits
+    description: "Config with partial limits"
+    generator:
+      model: "gpt-4"
+    limits:
+      max_turns: 10
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lim := cfg.Configs[0].Limits
+	if lim == nil {
+		t.Fatal("expected Limits to be non-nil")
+	}
+	if lim.MaxTurns != 10 {
+		t.Errorf("expected MaxTurns=10, got %d", lim.MaxTurns)
+	}
+	if lim.MaxFiles != 0 {
+		t.Errorf("expected MaxFiles=0 (zero value), got %d", lim.MaxFiles)
+	}
+	if lim.MaxOutputSize != "" {
+		t.Errorf("expected MaxOutputSize='' (zero value), got %q", lim.MaxOutputSize)
+	}
+	if lim.MaxSessionActions != 0 {
+		t.Errorf("expected MaxSessionActions=0 (zero value), got %d", lim.MaxSessionActions)
+	}
+}
+
 func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
 	cf := &ConfigFile{
 		Configs: []ToolConfig{

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -7,8 +7,9 @@ import "fmt"
 // When the When map has entries, all key-value pairs must match the
 // prompt's properties for the tool to be included.
 type ToolEntry struct {
-Name string            `yaml:"name" json:"name"`
-When map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+Name     string            `yaml:"name" json:"name"`
+When     map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty"`
 }
 
 // ResolveTools evaluates tool entries against prompt properties and returns

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -211,3 +211,51 @@ t.Errorf("result[%d] = %q, want %q", i, result[i], name)
 }
 }
 }
+
+func TestParseConfigWithAlwaysOn(t *testing.T) {
+data := []byte(`
+configs:
+  - name: always-on-test
+    description: "Config with always_on tools"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        - name: "bash"
+          always_on: true
+        - name: "azure-mcp"
+          when:
+            language: python
+        - name: "edit"
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+tools := cfg.Configs[0].Generator.Tools
+if len(tools) != 3 {
+t.Fatalf("expected 3 tools, got %d", len(tools))
+}
+if !tools[0].AlwaysOn {
+t.Error("expected bash to have always_on=true")
+}
+if tools[1].AlwaysOn {
+t.Error("expected azure-mcp to have always_on=false (default)")
+}
+if tools[2].AlwaysOn {
+t.Error("expected edit to have always_on=false (default)")
+}
+}
+
+func TestToolEntryAlwaysOnDefault(t *testing.T) {
+entry := ToolEntry{Name: "bash"}
+if entry.AlwaysOn {
+t.Error("expected AlwaysOn to default to false")
+}
+}
+
+func TestValidateToolEntry_WithAlwaysOn(t *testing.T) {
+entry := ToolEntry{Name: "bash", AlwaysOn: true}
+if err := validateToolEntry(entry, "test", 0); err != nil {
+t.Errorf("unexpected error for always_on tool: %v", err)
+}
+}

--- a/hyoka/internal/graders/grader.go
+++ b/hyoka/internal/graders/grader.go
@@ -1,0 +1,160 @@
+package graders
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Grader evaluates generated code and produces a structured result.
+// Each implementation handles a single concern (file check, build, LLM review, etc.).
+type Grader interface {
+	// Kind returns the grader kind (e.g., "file", "program", "prompt").
+	Kind() string
+
+	// Name returns the unique name of this grader instance.
+	Name() string
+
+	// Grade evaluates the generated code and returns a result.
+	Grade(ctx context.Context, input *GraderInput) (*GraderResult, error)
+}
+
+// ActionEvent represents a single action taken by the agent during code generation.
+type ActionEvent struct {
+	Tool      string `json:"tool"`
+	Arguments string `json:"arguments,omitempty"`
+	Result    string `json:"result,omitempty"`
+	Timestamp int64  `json:"timestamp,omitempty"`
+}
+
+// FileInfo describes a file produced by the agent.
+type FileInfo struct {
+	Path    string `json:"path"`
+	Size    int64  `json:"size"`
+	IsDir   bool   `json:"is_dir,omitempty"`
+	ModTime int64  `json:"mod_time,omitempty"`
+}
+
+// SessionSummary holds metadata about the generation session.
+type SessionSummary struct {
+	SessionID    string        `json:"session_id"`
+	Model        string        `json:"model"`
+	TotalActions int           `json:"total_actions"`
+	Duration     time.Duration `json:"duration"`
+}
+
+// GraderInput contains everything a grader needs to evaluate generated code.
+// DM5: concrete struct rather than interface to keep grader signatures simple.
+type GraderInput struct {
+	WorkspacePath  string            // Path to session workspace with generated files
+	ActionLog      []ActionEvent     // Agent action history
+	PromptMeta     map[string]string // Prompt frontmatter properties (language, service, etc.)
+	Config         map[string]any    // Grader-specific config values from YAML
+	Files          []FileInfo        // Generated files listing
+	SessionSummary *SessionSummary   // Optional session metadata
+}
+
+// GraderResult holds the outcome of a single grader execution.
+// DM4: typed optional detail fields instead of interface{} for type safety.
+type GraderResult struct {
+	Kind    string  `json:"kind"`
+	Name    string  `json:"name"`
+	Score   float64 `json:"score"`   // 0.0–1.0 normalized
+	Weight  float64 `json:"weight"`  // effective weight used in aggregation
+	Pass    bool    `json:"pass"`    // whether the grader considers this passing
+	Gate    bool    `json:"gate"`    // DM3: hard pass/fail overrides weighted scoring
+	Message string  `json:"message"` // human-readable summary
+
+	// Typed optional details per grader kind (DM4).
+	FileDetails     *FileGraderDetails     `json:"file_details,omitempty"`
+	ProgramDetails  *ProgramGraderDetails  `json:"program_details,omitempty"`
+	PromptDetails   *PromptGraderDetails   `json:"prompt_details,omitempty"`
+	BehaviorDetails *BehaviorGraderDetails `json:"behavior_details,omitempty"`
+}
+
+// FileGraderDetails contains results from file existence/content checks.
+type FileGraderDetails struct {
+	Path       string `json:"path"`
+	Exists     bool   `json:"exists"`
+	MatchFound bool   `json:"match_found,omitempty"` // true if pattern matched
+	Pattern    string `json:"pattern,omitempty"`      // regex/glob that was tested
+}
+
+// ProgramGraderDetails contains results from running an external command.
+type ProgramGraderDetails struct {
+	Command  string        `json:"command"`
+	ExitCode int           `json:"exit_code"`
+	Stdout   string        `json:"stdout"`
+	Stderr   string        `json:"stderr"`
+	Duration time.Duration `json:"duration"`
+}
+
+// PromptGraderDetails contains results from an LLM-as-judge evaluation.
+type PromptGraderDetails struct {
+	Model     string `json:"model"`
+	Rubric    string `json:"rubric"`
+	Reasoning string `json:"reasoning"`
+	RawScore  int    `json:"raw_score"`
+	MaxScore  int    `json:"max_score"`
+}
+
+// BehaviorGraderDetails contains results from agent action log analysis.
+type BehaviorGraderDetails struct {
+	ToolsUsed      []string `json:"tools_used"`
+	MissingTools   []string `json:"missing_tools,omitempty"`
+	ForbiddenUsed  []string `json:"forbidden_used,omitempty"`
+	TotalActions   int      `json:"total_actions"`
+	TurnLimitHit   bool     `json:"turn_limit_hit,omitempty"`
+	SequenceMatch  bool     `json:"sequence_match,omitempty"`   // for action_sequence
+	ConstraintsMet bool     `json:"constraints_met,omitempty"`  // for tool_constraint
+}
+
+// AggregateResult holds the final aggregated score from all graders.
+type AggregateResult struct {
+	Score      float64        `json:"score"`       // 0.0–1.0 weighted average
+	Pass       bool           `json:"pass"`        // true if score > 0 and no gate failures
+	GateFailed bool           `json:"gate_failed"` // true if any gate grader failed
+	Results    []GraderResult `json:"results"`
+}
+
+// AggregateResults computes a weighted score from a set of grader results.
+// Gate semantics (DM3): if any gate grader fails, the overall result fails
+// with a score of 0 regardless of other scores.
+func AggregateResults(results []GraderResult) (*AggregateResult, error) {
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no grader results to aggregate")
+	}
+
+	agg := &AggregateResult{
+		Results: results,
+		Pass:    true,
+	}
+
+	// Check gate failures first.
+	for _, r := range results {
+		if r.Gate && !r.Pass {
+			agg.GateFailed = true
+			agg.Pass = false
+			agg.Score = 0
+			return agg, nil
+		}
+	}
+
+	// Compute weighted average.
+	var totalWeight float64
+	var weightedSum float64
+	for _, r := range results {
+		w := r.Weight
+		if w == 0 {
+			w = 1.0
+		}
+		totalWeight += w
+		weightedSum += r.Score * w
+	}
+
+	if totalWeight > 0 {
+		agg.Score = weightedSum / totalWeight
+	}
+
+	return agg, nil
+}

--- a/hyoka/internal/graders/grader_test.go
+++ b/hyoka/internal/graders/grader_test.go
@@ -1,0 +1,164 @@
+package graders
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAggregateResultsWeightedAverage(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "file_check", Score: 1.0, Weight: 1.0, Pass: true},
+		{Kind: KindPrompt, Name: "review", Score: 0.8, Weight: 2.0, Pass: true},
+		{Kind: KindBehavior, Name: "behavior", Score: 0.6, Weight: 1.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expected: (1.0*1 + 0.8*2 + 0.6*1) / (1+2+1) = 3.2/4 = 0.8
+	want := 0.8
+	if math.Abs(agg.Score-want) > 1e-9 {
+		t.Errorf("score = %f, want %f", agg.Score, want)
+	}
+	if !agg.Pass {
+		t.Error("expected pass = true")
+	}
+	if agg.GateFailed {
+		t.Error("expected gate_failed = false")
+	}
+}
+
+func TestAggregateResultsGateFailureOverrides(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "file_check", Score: 1.0, Weight: 1.0, Pass: true, Gate: true},
+		{Kind: KindProgram, Name: "build", Score: 0.0, Weight: 1.0, Pass: false, Gate: true},
+		{Kind: KindPrompt, Name: "review", Score: 0.9, Weight: 2.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if agg.Score != 0 {
+		t.Errorf("score = %f, want 0 (gate failure)", agg.Score)
+	}
+	if agg.Pass {
+		t.Error("expected pass = false (gate failure)")
+	}
+	if !agg.GateFailed {
+		t.Error("expected gate_failed = true")
+	}
+}
+
+func TestAggregateResultsGatePassDoesNotOverride(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "file_check", Score: 1.0, Weight: 1.0, Pass: true, Gate: true},
+		{Kind: KindPrompt, Name: "review", Score: 0.5, Weight: 1.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Gate passed, so normal weighted average: (1.0*1 + 0.5*1) / 2 = 0.75
+	want := 0.75
+	if math.Abs(agg.Score-want) > 1e-9 {
+		t.Errorf("score = %f, want %f", agg.Score, want)
+	}
+	if !agg.Pass {
+		t.Error("expected pass = true")
+	}
+}
+
+func TestAggregateResultsEmptyReturnsError(t *testing.T) {
+	_, err := AggregateResults(nil)
+	if err == nil {
+		t.Fatal("expected error for empty results")
+	}
+
+	_, err = AggregateResults([]GraderResult{})
+	if err == nil {
+		t.Fatal("expected error for empty slice")
+	}
+}
+
+func TestAggregateResultsDefaultWeight(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "a", Score: 1.0, Weight: 0, Pass: true},
+		{Kind: KindFile, Name: "b", Score: 0.5, Weight: 0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Zero weight defaults to 1.0: (1.0*1 + 0.5*1) / 2 = 0.75
+	want := 0.75
+	if math.Abs(agg.Score-want) > 1e-9 {
+		t.Errorf("score = %f, want %f", agg.Score, want)
+	}
+}
+
+func TestAggregateResultsSingleResult(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindPrompt, Name: "solo", Score: 0.42, Weight: 1.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if math.Abs(agg.Score-0.42) > 1e-9 {
+		t.Errorf("score = %f, want 0.42", agg.Score)
+	}
+	if len(agg.Results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(agg.Results))
+	}
+}
+
+func TestAggregateResultsNonGateFailureDoesNotForceZero(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "check", Score: 0.0, Weight: 1.0, Pass: false, Gate: false},
+		{Kind: KindPrompt, Name: "review", Score: 0.8, Weight: 1.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Non-gate failure: (0.0*1 + 0.8*1) / 2 = 0.4
+	want := 0.4
+	if math.Abs(agg.Score-want) > 1e-9 {
+		t.Errorf("score = %f, want %f", agg.Score, want)
+	}
+	if agg.GateFailed {
+		t.Error("gate_failed should be false for non-gate failures")
+	}
+}
+
+func TestAggregateResultsMultipleGateFailures(t *testing.T) {
+	results := []GraderResult{
+		{Kind: KindFile, Name: "gate1", Score: 0.0, Weight: 1.0, Pass: false, Gate: true},
+		{Kind: KindProgram, Name: "gate2", Score: 0.0, Weight: 1.0, Pass: false, Gate: true},
+		{Kind: KindPrompt, Name: "review", Score: 1.0, Weight: 1.0, Pass: true},
+	}
+
+	agg, err := AggregateResults(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if agg.Score != 0 {
+		t.Errorf("score = %f, want 0", agg.Score)
+	}
+	if !agg.GateFailed {
+		t.Error("expected gate_failed = true")
+	}
+}


### PR DESCRIPTION
## Summary

Defines the **Grader interface** and all runtime types that grader implementations will use. This is the critical-path task (2.5a) — types must be frozen before any grader implementations begin (DM14).

### New types in `hyoka/internal/graders/grader.go`

- **`Grader` interface** — `Kind()`, `Name()`, `Grade(ctx, input) (*GraderResult, error)`
- **`GraderInput`** — concrete struct (DM5) with workspace path, action log, prompt metadata, config, files, and session summary
- **`GraderResult`** — typed optional detail fields per grader kind (DM4) instead of `interface{}`
- **Detail structs**: `FileGraderDetails`, `ProgramGraderDetails`, `PromptGraderDetails`, `BehaviorGraderDetails`
- **Supporting types**: `ActionEvent`, `FileInfo`, `SessionSummary`
- **`AggregateResults()`** — computes weighted score with gate semantics (DM3: gate failure → score 0)

### Tests

8 test cases for `AggregateResults`:
- Weighted average calculation
- Gate failure overrides (score forced to 0)
- Gate pass does not override
- Empty results → error
- Default weight (0 → 1.0)
- Single result
- Non-gate failure does not force zero
- Multiple gate failures

All existing + new tests pass: `go build`, `go vet`, `go test` ✅

Closes #131