### PR TITLE
feat: create pairwise testing package (#120)

### DIFF
--- a/hyoka/internal/pairwise/pairwise.go
+++ b/hyoka/internal/pairwise/pairwise.go
@@ -1,0 +1,168 @@
+// Package pairwise generates config variants for pairwise tool-ablation testing.
+// Given a base config with N togglable tools, it produces N+1 variants:
+// one baseline with all tools enabled, and N variants each with one tool disabled.
+package pairwise
+
+import (
+	"fmt"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
+)
+
+// ExpandPairwise generates N+1 config variants from a base config.
+//   - Variant 0 (baseline): all tools enabled, named "{base}/baseline"
+//   - Variant 1..N: each disables one togglable tool, named "{base}/without-{tool}"
+//
+// Tools with AlwaysOn: true in Generator.Tools are never toggled.
+// Both Generator.Tools ([]ToolEntry) and Generator.AvailableTools ([]string)
+// are considered; duplicates across the two lists are unified.
+func ExpandPairwise(base config.ToolConfig) []config.ToolConfig {
+	togglable := collectTogglable(base)
+
+	variants := make([]config.ToolConfig, 0, len(togglable)+1)
+
+	// Baseline: deep copy with all tools intact.
+	baseline := cloneToolConfig(base)
+	baseline.Name = base.Name + "/baseline"
+	variants = append(variants, baseline)
+
+	// One variant per togglable tool, with that tool removed.
+	for _, tool := range togglable {
+		v := cloneToolConfig(base)
+		v.Name = fmt.Sprintf("%s/without-%s", base.Name, tool)
+		removeTool(&v, tool)
+		variants = append(variants, v)
+	}
+
+	return variants
+}
+
+// collectTogglable returns deduplicated tool names eligible for toggling.
+// Order: ToolEntry names first (preserving order), then AvailableTools.
+func collectTogglable(cfg config.ToolConfig) []string {
+	if cfg.Generator == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var tools []string
+
+	for _, te := range cfg.Generator.Tools {
+		if te.AlwaysOn || seen[te.Name] {
+			continue
+		}
+		seen[te.Name] = true
+		tools = append(tools, te.Name)
+	}
+
+	for _, name := range cfg.Generator.AvailableTools {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		tools = append(tools, name)
+	}
+
+	return tools
+}
+
+// removeTool removes a named tool from both Generator.Tools and
+// Generator.AvailableTools in the given config.
+func removeTool(cfg *config.ToolConfig, name string) {
+	if cfg.Generator == nil {
+		return
+	}
+
+	var tools []config.ToolEntry
+	for _, te := range cfg.Generator.Tools {
+		if te.Name != name {
+			tools = append(tools, te)
+		}
+	}
+	cfg.Generator.Tools = tools
+
+	var avail []string
+	for _, t := range cfg.Generator.AvailableTools {
+		if t != name {
+			avail = append(avail, t)
+		}
+	}
+	cfg.Generator.AvailableTools = avail
+}
+
+// cloneToolConfig returns a deep copy of a ToolConfig so mutations to the
+// clone never affect the original.
+func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
+	dst := src // copies value fields (Name, Description, Plugins header)
+
+	if src.Generator != nil {
+		gen := *src.Generator
+
+		if len(src.Generator.Skills) > 0 {
+			gen.Skills = make([]config.Skill, len(src.Generator.Skills))
+			copy(gen.Skills, src.Generator.Skills)
+		}
+
+		if len(src.Generator.Tools) > 0 {
+			gen.Tools = make([]config.ToolEntry, len(src.Generator.Tools))
+			copy(gen.Tools, src.Generator.Tools)
+			for i, te := range gen.Tools {
+				if te.When != nil {
+					m := make(map[string]string, len(te.When))
+					for k, v := range te.When {
+						m[k] = v
+					}
+					gen.Tools[i].When = m
+				}
+			}
+		}
+
+		if len(src.Generator.AvailableTools) > 0 {
+			gen.AvailableTools = make([]string, len(src.Generator.AvailableTools))
+			copy(gen.AvailableTools, src.Generator.AvailableTools)
+		}
+
+		if len(src.Generator.ExcludedTools) > 0 {
+			gen.ExcludedTools = make([]string, len(src.Generator.ExcludedTools))
+			copy(gen.ExcludedTools, src.Generator.ExcludedTools)
+		}
+
+		if len(src.Generator.MCPServers) > 0 {
+			gen.MCPServers = make(map[string]*config.MCPServer, len(src.Generator.MCPServers))
+			for k, v := range src.Generator.MCPServers {
+				srv := *v
+				if len(v.Args) > 0 {
+					srv.Args = make([]string, len(v.Args))
+					copy(srv.Args, v.Args)
+				}
+				if len(v.Tools) > 0 {
+					srv.Tools = make([]string, len(v.Tools))
+					copy(srv.Tools, v.Tools)
+				}
+				gen.MCPServers[k] = &srv
+			}
+		}
+
+		dst.Generator = &gen
+	}
+
+	if src.Reviewer != nil {
+		rev := *src.Reviewer
+		if len(src.Reviewer.Skills) > 0 {
+			rev.Skills = make([]config.Skill, len(src.Reviewer.Skills))
+			copy(rev.Skills, src.Reviewer.Skills)
+		}
+		if len(src.Reviewer.Models) > 0 {
+			rev.Models = make([]string, len(src.Reviewer.Models))
+			copy(rev.Models, src.Reviewer.Models)
+		}
+		dst.Reviewer = &rev
+	}
+
+	if len(src.Plugins) > 0 {
+		dst.Plugins = make([]string, len(src.Plugins))
+		copy(dst.Plugins, src.Plugins)
+	}
+
+	return dst
+}

--- a/hyoka/internal/pairwise/pairwise_test.go
+++ b/hyoka/internal/pairwise/pairwise_test.go
@@ -1,0 +1,278 @@
+package pairwise
+
+import (
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
+)
+
+func TestExpandPairwise_ThreeTools(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "test-cfg",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			Tools: []config.ToolEntry{
+				{Name: "tool-a"},
+				{Name: "tool-b"},
+				{Name: "tool-c"},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 4 {
+		t.Fatalf("expected 4 variants, got %d", got)
+	}
+
+	// Variant 0: baseline with all tools.
+	assertName(t, variants[0], "test-cfg/baseline")
+	assertToolNames(t, variants[0], []string{"tool-a", "tool-b", "tool-c"})
+
+	// Variant 1: without tool-a.
+	assertName(t, variants[1], "test-cfg/without-tool-a")
+	assertToolNames(t, variants[1], []string{"tool-b", "tool-c"})
+
+	// Variant 2: without tool-b.
+	assertName(t, variants[2], "test-cfg/without-tool-b")
+	assertToolNames(t, variants[2], []string{"tool-a", "tool-c"})
+
+	// Variant 3: without tool-c.
+	assertName(t, variants[3], "test-cfg/without-tool-c")
+	assertToolNames(t, variants[3], []string{"tool-a", "tool-b"})
+}
+
+func TestExpandPairwise_AlwaysOnExemption(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "with-always-on",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			Tools: []config.ToolEntry{
+				{Name: "core-tool", AlwaysOn: true},
+				{Name: "optional-a"},
+				{Name: "optional-b"},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	// 2 togglable tools → 3 variants (baseline + 2).
+	if got := len(variants); got != 3 {
+		t.Fatalf("expected 3 variants, got %d", got)
+	}
+
+	// Baseline keeps all three.
+	assertToolNames(t, variants[0], []string{"core-tool", "optional-a", "optional-b"})
+
+	// Variant 1: without optional-a; core-tool still present.
+	assertName(t, variants[1], "with-always-on/without-optional-a")
+	assertToolNames(t, variants[1], []string{"core-tool", "optional-b"})
+
+	// Variant 2: without optional-b; core-tool still present.
+	assertName(t, variants[2], "with-always-on/without-optional-b")
+	assertToolNames(t, variants[2], []string{"core-tool", "optional-a"})
+}
+
+func TestExpandPairwise_ZeroTools(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "no-tools",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 1 {
+		t.Fatalf("expected 1 variant (baseline only), got %d", got)
+	}
+	assertName(t, variants[0], "no-tools/baseline")
+}
+
+func TestExpandPairwise_SingleTool(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "single",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			Tools: []config.ToolEntry{
+				{Name: "only-tool"},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 2 {
+		t.Fatalf("expected 2 variants, got %d", got)
+	}
+	assertName(t, variants[0], "single/baseline")
+	assertToolNames(t, variants[0], []string{"only-tool"})
+
+	assertName(t, variants[1], "single/without-only-tool")
+	assertToolNames(t, variants[1], nil)
+}
+
+func TestExpandPairwise_AvailableTools(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "avail",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			AvailableTools: []string{"fetch", "search", "run"},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 4 {
+		t.Fatalf("expected 4 variants, got %d", got)
+	}
+
+	assertName(t, variants[0], "avail/baseline")
+	assertAvailableTools(t, variants[0], []string{"fetch", "search", "run"})
+
+	assertName(t, variants[1], "avail/without-fetch")
+	assertAvailableTools(t, variants[1], []string{"search", "run"})
+
+	assertName(t, variants[2], "avail/without-search")
+	assertAvailableTools(t, variants[2], []string{"fetch", "run"})
+
+	assertName(t, variants[3], "avail/without-run")
+	assertAvailableTools(t, variants[3], []string{"fetch", "search"})
+}
+
+func TestExpandPairwise_MixedToolSources(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "mixed",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			Tools: []config.ToolEntry{
+				{Name: "structured-tool"},
+			},
+			AvailableTools: []string{"flat-tool"},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 3 {
+		t.Fatalf("expected 3 variants, got %d", got)
+	}
+
+	// Baseline has both.
+	assertName(t, variants[0], "mixed/baseline")
+	assertToolNames(t, variants[0], []string{"structured-tool"})
+	assertAvailableTools(t, variants[0], []string{"flat-tool"})
+
+	// Without structured-tool.
+	assertName(t, variants[1], "mixed/without-structured-tool")
+	assertToolNames(t, variants[1], nil)
+	assertAvailableTools(t, variants[1], []string{"flat-tool"})
+
+	// Without flat-tool.
+	assertName(t, variants[2], "mixed/without-flat-tool")
+	assertToolNames(t, variants[2], []string{"structured-tool"})
+	assertAvailableTools(t, variants[2], nil)
+}
+
+func TestExpandPairwise_DeduplicatesAcrossSources(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "dedup",
+		Generator: &config.GeneratorConfig{
+			Model:          "model-a",
+			Tools:          []config.ToolEntry{{Name: "shared"}},
+			AvailableTools: []string{"shared", "unique"},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	// "shared" appears in both sources but should produce one toggle, not two.
+	// Togglable: shared, unique → 3 variants.
+	if got := len(variants); got != 3 {
+		t.Fatalf("expected 3 variants, got %d", got)
+	}
+	assertName(t, variants[1], "dedup/without-shared")
+	assertName(t, variants[2], "dedup/without-unique")
+}
+
+func TestExpandPairwise_NilGenerator(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "nil-gen",
+	}
+
+	variants := ExpandPairwise(base)
+
+	if got := len(variants); got != 1 {
+		t.Fatalf("expected 1 variant, got %d", got)
+	}
+	assertName(t, variants[0], "nil-gen/baseline")
+}
+
+func TestExpandPairwise_CloneIsolation(t *testing.T) {
+	base := config.ToolConfig{
+		Name: "isolation",
+		Generator: &config.GeneratorConfig{
+			Model: "model-a",
+			Tools: []config.ToolEntry{
+				{Name: "alpha"},
+				{Name: "beta"},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(base)
+
+	// Mutate a variant's tools and verify the original is untouched.
+	variants[1].Generator.Tools = append(variants[1].Generator.Tools, config.ToolEntry{Name: "injected"})
+
+	if len(base.Generator.Tools) != 2 {
+		t.Fatalf("original base was mutated: got %d tools, want 2", len(base.Generator.Tools))
+	}
+	// Also verify other variants are unaffected.
+	if len(variants[0].Generator.Tools) != 2 {
+		t.Fatalf("baseline variant was mutated: got %d tools, want 2", len(variants[0].Generator.Tools))
+	}
+}
+
+// --- helpers ---
+
+func assertName(t *testing.T, v config.ToolConfig, want string) {
+	t.Helper()
+	if v.Name != want {
+		t.Errorf("name = %q, want %q", v.Name, want)
+	}
+}
+
+func assertToolNames(t *testing.T, v config.ToolConfig, want []string) {
+	t.Helper()
+	var got []string
+	if v.Generator != nil {
+		for _, te := range v.Generator.Tools {
+			got = append(got, te.Name)
+		}
+	}
+	assertStringSlice(t, "Tools", got, want)
+}
+
+func assertAvailableTools(t *testing.T, v config.ToolConfig, want []string) {
+	t.Helper()
+	var got []string
+	if v.Generator != nil {
+		got = v.Generator.AvailableTools
+	}
+	assertStringSlice(t, "AvailableTools", got, want)
+}
+
+func assertStringSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s length = %d, want %d; got %v, want %v", label, len(got), len(want), got, want)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s[%d] = %q, want %q", label, i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Create `hyoka/internal/pairwise/` package that generates N+1 config variants from a base config for tool-ablation testing.

### What it does

`ExpandPairwise(base config.ToolConfig) []config.ToolConfig` produces:
- **Variant 0 (baseline):** all tools enabled → `{name}/baseline`
- **Variants 1..N:** one tool disabled each → `{name}/without-{tool}`

### Key behaviors
- Works with both `Generator.Tools` (`[]ToolEntry`) and `Generator.AvailableTools` (`[]string`)
- Tools with `AlwaysOn: true` are exempt from toggling
- Cross-source deduplication (tool in both lists = one toggle)
- Full deep-copy isolation — mutations to variants never affect the original

### Tests (9 cases)
- 3 tools → 4 variants
- AlwaysOn exemption
- Zero tools → baseline only
- Single tool → 2 variants
- AvailableTools (flat list)
- Mixed tool sources
- Deduplication across sources
- Nil generator
- Clone isolation (mutation safety)

Closes #120