### PR TITLE
feat: add always_on tool field and session limit config (#122, #124)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -49,6 +49,14 @@ type ReviewerConfig struct {
 	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
+// SessionLimits holds configurable guardrails for a Copilot session.
+type SessionLimits struct {
+	MaxTurns          int    `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
+	MaxFiles          int    `yaml:"max_files,omitempty" json:"max_files,omitempty"`
+	MaxOutputSize     string `yaml:"max_output_size,omitempty" json:"max_output_size,omitempty"`
+	MaxSessionActions int    `yaml:"max_session_actions,omitempty" json:"max_session_actions,omitempty"`
+}
+
 // ToolConfig represents a single evaluation configuration.
 type ToolConfig struct {
 	Name        string           `yaml:"name" json:"name"`
@@ -56,6 +64,7 @@ type ToolConfig struct {
 	Generator   *GeneratorConfig `yaml:"generator,omitempty" json:"generator,omitempty"`
 	Reviewer    *ReviewerConfig  `yaml:"reviewer,omitempty" json:"reviewer,omitempty"`
 	Plugins     []string         `yaml:"plugins,omitempty" json:"plugins,omitempty"`
+	Limits      *SessionLimits   `yaml:"limits,omitempty" json:"limits,omitempty"`
 }
 
 // ConfigFile represents the top-level config file structure.

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -689,3 +689,87 @@ func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
 		t.Errorf("got %q, want %q", err.Error(), want)
 	}
 }
+
+func TestParseSessionLimits(t *testing.T) {
+data := []byte(`
+configs:
+  - name: with-limits
+    description: "Config with session limits"
+    generator:
+      model: "claude-opus-4.6"
+    limits:
+      max_turns: 25
+      max_files: 50
+      max_output_size: "1MB"
+      max_session_actions: 100
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+lim := cfg.Configs[0].Limits
+if lim == nil {
+t.Fatal("expected Limits to be non-nil")
+}
+if lim.MaxTurns != 25 {
+t.Errorf("expected MaxTurns=25, got %d", lim.MaxTurns)
+}
+if lim.MaxFiles != 50 {
+t.Errorf("expected MaxFiles=50, got %d", lim.MaxFiles)
+}
+if lim.MaxOutputSize != "1MB" {
+t.Errorf("expected MaxOutputSize='1MB', got %q", lim.MaxOutputSize)
+}
+if lim.MaxSessionActions != 100 {
+t.Errorf("expected MaxSessionActions=100, got %d", lim.MaxSessionActions)
+}
+}
+
+func TestParseSessionLimitsOmitted(t *testing.T) {
+data := []byte(`
+configs:
+  - name: no-limits
+    description: "Config without limits"
+    generator:
+      model: "gpt-4"
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if cfg.Configs[0].Limits != nil {
+t.Errorf("expected Limits to be nil when omitted, got %+v", cfg.Configs[0].Limits)
+}
+}
+
+func TestParseSessionLimitsPartial(t *testing.T) {
+data := []byte(`
+configs:
+  - name: partial-limits
+    description: "Config with partial limits"
+    generator:
+      model: "gpt-4"
+    limits:
+      max_turns: 10
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+lim := cfg.Configs[0].Limits
+if lim == nil {
+t.Fatal("expected Limits to be non-nil")
+}
+if lim.MaxTurns != 10 {
+t.Errorf("expected MaxTurns=10, got %d", lim.MaxTurns)
+}
+if lim.MaxFiles != 0 {
+t.Errorf("expected MaxFiles=0 (zero value), got %d", lim.MaxFiles)
+}
+if lim.MaxOutputSize != "" {
+t.Errorf("expected MaxOutputSize='' (zero value), got %q", lim.MaxOutputSize)
+}
+if lim.MaxSessionActions != 0 {
+t.Errorf("expected MaxSessionActions=0 (zero value), got %d", lim.MaxSessionActions)
+}
+}

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -7,8 +7,9 @@ import "fmt"
 // When the When map has entries, all key-value pairs must match the
 // prompt's properties for the tool to be included.
 type ToolEntry struct {
-Name string            `yaml:"name" json:"name"`
-When map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+Name     string            `yaml:"name" json:"name"`
+When     map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty"`
 }
 
 // ResolveTools evaluates tool entries against prompt properties and returns

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -211,3 +211,51 @@ t.Errorf("result[%d] = %q, want %q", i, result[i], name)
 }
 }
 }
+
+func TestParseConfigWithAlwaysOn(t *testing.T) {
+data := []byte(`
+configs:
+  - name: always-on-test
+    description: "Config with always_on tools"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        - name: "bash"
+          always_on: true
+        - name: "azure-mcp"
+          when:
+            language: python
+        - name: "edit"
+`)
+cfg, err := Parse(data)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+tools := cfg.Configs[0].Generator.Tools
+if len(tools) != 3 {
+t.Fatalf("expected 3 tools, got %d", len(tools))
+}
+if !tools[0].AlwaysOn {
+t.Error("expected bash to have always_on=true")
+}
+if tools[1].AlwaysOn {
+t.Error("expected azure-mcp to have always_on=false (default)")
+}
+if tools[2].AlwaysOn {
+t.Error("expected edit to have always_on=false (default)")
+}
+}
+
+func TestToolEntryAlwaysOnDefault(t *testing.T) {
+entry := ToolEntry{Name: "bash"}
+if entry.AlwaysOn {
+t.Error("expected AlwaysOn to default to false")
+}
+}
+
+func TestValidateToolEntry_WithAlwaysOn(t *testing.T) {
+entry := ToolEntry{Name: "bash", AlwaysOn: true}
+if err := validateToolEntry(entry, "test", 0); err != nil {
+t.Errorf("unexpected error for always_on tool: %v", err)
+}
+}


### PR DESCRIPTION
## Summary

Adds two config schema fields for the pairwise testing and session control features:

### Task 2.1c: `always_on` field (#122)
- Added `AlwaysOn bool` field to `ToolEntry` struct in `tool_filter.go`
- Tools marked `always_on: true` are exempt from pairwise toggling
- Defaults to `false` (no behavior change for existing configs)

### Task 2.2a: Session limit fields (#124)
- Added `SessionLimits` struct with `max_turns`, `max_files`, `max_output_size`, `max_session_actions`
- Added `Limits *SessionLimits` field to `ToolConfig`
- All fields optional (omitempty); nil Limits when not specified

### Tests
- YAML parsing tests for `always_on: true/false` and default behavior
- Validation test confirming `always_on` tools pass validation
- Full/partial/omitted session limits parsing tests

Closes #122
Closes #124