### PR TITLE
fix: ensure goroutine lifecycle respects context cancellation (#129)

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -360,10 +360,20 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 			defer wg.Done()
 
 			// Acquire session semaphore first to limit total Copilot sessions.
-			sessionSem <- struct{}{}
+			// Use select so context cancellation unblocks waiting goroutines
+			// instead of leaking them (#129).
+			select {
+			case sessionSem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sessionSem }()
 
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 
 			taskName := t.Prompt.ID + "/" + t.Config.Name
@@ -567,19 +577,21 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		return evalReport
 	}
 
-	// Create an isolated temporary workspace for the generator (#26).
+	// Create an isolated temporary workspace for the generator (#26, #126).
 	// The agent writes files here — not directly to the report tree.
 	// After generation, files are copied to the persistent report directory.
-	genDir, err := os.MkdirTemp("", "hyoka-gen-*")
+	// The workspace is empty to prevent leakage from the user's dev environment.
+	evalWs, err := NewEvalWorkspace()
 	if err != nil {
 		evalReport.Error = fmt.Sprintf("generator workspace setup failed: %v", err)
 		evalReport.ErrorDetails = err.Error()
 		evalReport.ErrorCategory = "generation_failure"
-		evalReport.FailureReason = fmt.Sprintf("Could not create isolated generator workspace: %v", err)
+		evalReport.FailureReason = fmt.Sprintf("Could not create isolated eval workspace: %v", err)
 		evalReport.Duration = time.Since(start).Seconds()
 		return evalReport
 	}
-	defer os.RemoveAll(genDir)
+	defer evalWs.Cleanup()
+	genDir := evalWs.Dir
 
 	lg.Debug("Workspace created", "workspace", ws.Dir, "gen_dir", genDir)
 

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -751,6 +752,57 @@ func TestCriteriaDirEmpty(t *testing.T) {
 	// Should fall back to prompt-only criteria
 	if !strings.Contains(reviewer.capturedCriteria, "Prompt specific criterion") {
 		t.Errorf("expected prompt criteria as fallback, got: %s", reviewer.capturedCriteria)
+	}
+}
+
+// TestCancelledContextNoGoroutineLeak verifies that goroutines spawned by
+// Engine.Run terminate promptly when the parent context is already cancelled.
+// This catches semaphore-acquisition leaks (#129).
+func TestCancelledContextNoGoroutineLeak(t *testing.T) {
+	outputDir := t.TempDir()
+	// Use 1 worker but many tasks — excess goroutines would block on
+	// semaphore acquisition if context cancellation is not respected.
+	engine := NewEngine(&slowEvaluator{}, quietOpts(EngineOptions{
+		Workers:    1,
+		OutputDir:  outputDir,
+		SkipReview: true,
+	}))
+
+	prompts := []*prompt.Prompt{
+		{ID: "leak-1", Properties: map[string]string{"service": "s", "plane": "data-plane", "language": "go", "category": "c"}},
+		{ID: "leak-2", Properties: map[string]string{"service": "s", "plane": "data-plane", "language": "go", "category": "c"}},
+		{ID: "leak-3", Properties: map[string]string{"service": "s", "plane": "data-plane", "language": "go", "category": "c"}},
+		{ID: "leak-4", Properties: map[string]string{"service": "s", "plane": "data-plane", "language": "go", "category": "c"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "cfg", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	before := runtime.NumGoroutine()
+
+	// Context is already cancelled — all goroutines should bail immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := engine.Run(ctx, prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Allow goroutines a brief window to wind down.
+	deadline := time.After(2 * time.Second)
+	for {
+		after := runtime.NumGoroutine()
+		// Tolerate a small delta for unrelated runtime goroutines.
+		if after <= before+2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("goroutine leak: before=%d, after=%d (delta %d)", before, after, after-before)
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
 	}
 }
 

--- a/hyoka/internal/review/reviewer.go
+++ b/hyoka/internal/review/reviewer.go
@@ -364,6 +364,10 @@ func (p *PanelReviewer) ReviewPanel(ctx context.Context, originalPrompt string, 
 
 	// Run reviewers sequentially — one Copilot session at a time
 	for i, model := range p.models {
+		// Bail early if the parent context was cancelled (#129).
+		if ctx.Err() != nil {
+			break
+		}
 		slog.Debug("Panel reviewer starting", "model", model, "index", i)
 		modelWorkDir, copyErr := copyDirToTemp(workDir, fmt.Sprintf("hyoka-review-%s-*", model))
 		if copyErr != nil {
@@ -439,6 +443,7 @@ func (p *PanelReviewer) runSingleReview(ctx context.Context, model string, revie
 		select {
 		case <-done:
 		case <-time.After(10 * time.Second):
+			client.ForceStop()
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Audit and fix goroutine lifecycle across the eval/review pipeline so all goroutines terminate on context cancellation with no leaks.

### Changes

- **engine.go**: Semaphore acquisition (`sessionSem`, `sem`) now uses `select` with `ctx.Done()` so worker goroutines bail immediately on context cancellation instead of blocking forever on a full channel.
- **reviewer.go**: `ReviewPanel` loop checks `ctx.Err()` between iterations to skip remaining reviewers when the parent context is cancelled.
- **reviewer.go**: Add `client.ForceStop()` fallback after 10s timeout in `runSingleReview` cleanup, matching the existing pattern in `copilot.go`.
- **engine_test.go**: Add `TestCancelledContextNoGoroutineLeak` — runs 4 tasks through a 1-worker engine with a pre-cancelled context and verifies goroutine count stabilises (no leak).

### Audit summary

| Location | Goroutine | Status |
|---|---|---|
| `resourcemonitor.go:Start()` | Periodic ticker | ✅ Already uses `stopCh` + `wg.Done` |
| `proctracker_unix.go:TerminateOrphans` | Signal-based timeout | ✅ Hard 5s deadline |
| `engine.go` signal handler | Signal range loop | ✅ Exits when `sigCh` closed |
| `engine.go` eval workers | Semaphore-gated pool | **Fixed** — context-aware semaphore acquisition |
| `copilot.go` cleanup | Timeout goroutine | ✅ Already has `ForceStop` fallback |
| `reviewer.go` session cleanup | Timeout goroutine | ✅ Bounded by 15s timeout |
| `reviewer.go` client cleanup | Timeout goroutine | **Fixed** — added `ForceStop` after timeout |
| `reviewer.go` `ReviewPanel` loop | Sequential iterations | **Fixed** — early exit on cancelled context |
| `progress/display.go` redraw | Ticker loop | ✅ Already uses `stopCh` + `wg.Done` |

Closes #129