### PR TITLE
feat: create isolated workspace per evaluation session (#126)

### DIFF
--- a/hyoka/internal/clean/clean.go
+++ b/hyoka/internal/clean/clean.go
@@ -38,6 +38,9 @@ type Result struct {
 	// Process cleanup stats.
 	ProcessesFound  int
 	ProcessesKilled int
+	// Orphan workspace cleanup stats (#126).
+	WorkspacesFound   int
+	WorkspacesRemoved int
 }
 
 // copilotStateDirFn returns the Copilot CLI state directory.
@@ -85,7 +88,13 @@ func Run(opts Options) (*Result, error) {
 		fmt.Fprintf(opts.Out, "Warning: session cleanup: %v\n", err)
 	}
 
-	// Phase 3: Clean old log files (only with --all since we can't
+	// Phase 3: Clean orphan eval workspaces left in the OS temp directory
+	// after a crash (#126).
+	if err := cleanOrphanWorkspaces(opts, result); err != nil {
+		fmt.Fprintf(opts.Out, "Warning: workspace cleanup: %v\n", err)
+	}
+
+	// Phase 4: Clean old log files (only with --all since we can't
 	// distinguish hyoka-spawned logs from Copilot CLI logs).
 	if opts.All {
 		logsDir := filepath.Join(stateDir, "logs")
@@ -293,6 +302,7 @@ func isHyokaSession(sessionPath string) bool {
 		if strings.Contains(content, "hyoka") ||
 			strings.Contains(content, "reports/") ||
 			strings.Contains(content, "hyoka-gen-") ||
+			strings.Contains(content, "hyoka-eval-") ||
 			strings.Contains(content, "hyoka-config-") {
 			return true
 		}
@@ -306,12 +316,50 @@ func isHyokaSession(sessionPath string) bool {
 		if strings.Contains(content, "hyoka") ||
 			strings.Contains(content, "reports/") ||
 			strings.Contains(content, "hyoka-gen-") ||
+			strings.Contains(content, "hyoka-eval-") ||
 			strings.Contains(content, "hyoka-config-") {
 			return true
 		}
 	}
 
 	return false
+}
+
+// evalWorkspacePrefix is the directory name prefix for isolated eval workspaces.
+// Must match eval.EvalWorkspacePrefix. Duplicated here to avoid an import cycle.
+const evalWorkspacePrefix = "hyoka-eval-"
+
+// cleanOrphanWorkspaces scans the OS temp directory for leftover hyoka-eval-*
+// workspace directories that were not cleaned up (e.g. after a crash).
+func cleanOrphanWorkspaces(opts Options, result *Result) error {
+	tmpDir := os.TempDir()
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return fmt.Errorf("reading temp dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), evalWorkspacePrefix) {
+			continue
+		}
+		result.WorkspacesFound++
+		wsPath := filepath.Join(tmpDir, entry.Name())
+		size := dirSize(wsPath)
+
+		if opts.DryRun {
+			fmt.Fprintf(opts.Out, "  [dry-run] would remove orphan workspace %s (%s)\n",
+				entry.Name(), humanBytes(size))
+		} else {
+			if err := os.RemoveAll(wsPath); err != nil {
+				fmt.Fprintf(opts.Out, "  warning: failed to remove workspace %s: %v\n", entry.Name(), err)
+				continue
+			}
+			result.WorkspacesRemoved++
+			result.BytesFreed += size
+			slog.Debug("Removed orphan eval workspace", "path", wsPath)
+		}
+	}
+	return nil
 }
 
 // dirSize returns the total size of all files in a directory tree.

--- a/hyoka/internal/clean/clean_test.go
+++ b/hyoka/internal/clean/clean_test.go
@@ -163,6 +163,7 @@ func TestIsHyokaSession(t *testing.T) {
 		expect  bool
 	}{
 		{"hyoka-gen workspace", "cwd: /tmp/hyoka-gen-abc123", true},
+		{"hyoka-eval workspace", "cwd: /tmp/hyoka-eval-abc123", true},
 		{"reports dir", "cwd: /home/user/projects/hyoka/reports/20240101", true},
 		{"hyoka-config", "configDir: /tmp/hyoka-config-xyz", true},
 		{"random project", "cwd: /home/user/myproject", false},
@@ -301,5 +302,63 @@ func TestFormatProcessInfo(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.expect)
 			}
 		})
+	}
+}
+
+// --- Orphan workspace cleanup tests (#126) ---
+
+func TestCleanOrphanWorkspaces_FindsAndRemoves(t *testing.T) {
+	ws1, err := os.MkdirTemp("", "hyoka-eval-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(ws1, "test.py"), []byte("orphan"), 0o644)
+	ws2, err := os.MkdirTemp("", "hyoka-eval-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	result := &Result{}
+	err = cleanOrphanWorkspaces(Options{Out: &buf}, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WorkspacesFound < 2 {
+		t.Errorf("expected at least 2 orphan workspaces found, got %d", result.WorkspacesFound)
+	}
+	if result.WorkspacesRemoved < 2 {
+		t.Errorf("expected at least 2 orphan workspaces removed, got %d", result.WorkspacesRemoved)
+	}
+	if _, err := os.Stat(ws1); !os.IsNotExist(err) {
+		t.Errorf("orphan workspace should be removed: %s", ws1)
+	}
+	if _, err := os.Stat(ws2); !os.IsNotExist(err) {
+		t.Errorf("orphan workspace should be removed: %s", ws2)
+	}
+}
+
+func TestCleanOrphanWorkspaces_DryRun(t *testing.T) {
+	ws, err := os.MkdirTemp("", "hyoka-eval-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(ws)
+	var buf bytes.Buffer
+	result := &Result{}
+	err = cleanOrphanWorkspaces(Options{DryRun: true, Out: &buf}, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WorkspacesFound < 1 {
+		t.Errorf("expected at least 1 workspace found, got %d", result.WorkspacesFound)
+	}
+	if result.WorkspacesRemoved != 0 {
+		t.Errorf("expected 0 removed in dry-run, got %d", result.WorkspacesRemoved)
+	}
+	if _, err := os.Stat(ws); err != nil {
+		t.Error("workspace should still exist in dry-run mode")
+	}
+	if !strings.Contains(buf.String(), "[dry-run] would remove orphan workspace") {
+		t.Errorf("expected dry-run message, got %q", buf.String())
 	}
 }

--- a/hyoka/internal/eval/workspace.go
+++ b/hyoka/internal/eval/workspace.go
@@ -7,9 +7,58 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ronniegeraghty/hyoka/internal/utils"
 )
+
+// EvalWorkspacePrefix is the directory name prefix used for isolated evaluation
+// workspaces. The clean command uses this to find orphan workspaces.
+const EvalWorkspacePrefix = "hyoka-eval-"
+
+// EvalWorkspace is an isolated per-session workspace directory. Each evaluation
+// session gets its own empty workspace so the Copilot agent cannot see or
+// modify files from the user's development environment. The workspace is
+// created before the session starts and removed after it completes.
+type EvalWorkspace struct {
+	// Dir is the absolute path to the isolated workspace directory.
+	Dir string
+	// CreatedAt records when the workspace was created, used by the clean
+	// command to identify stale orphan workspaces.
+	CreatedAt time.Time
+}
+
+// NewEvalWorkspace creates an empty isolated workspace in the OS temp
+// directory. The directory name begins with EvalWorkspacePrefix so the clean
+// command can discover orphan workspaces after a crash.
+func NewEvalWorkspace() (*EvalWorkspace, error) {
+	dir, err := os.MkdirTemp("", EvalWorkspacePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("creating isolated eval workspace: %w", err)
+	}
+	return &EvalWorkspace{
+		Dir:       dir,
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+// CopyStarterFiles copies a starter project into the workspace.
+func (w *EvalWorkspace) CopyStarterFiles(starterDir string) error {
+	return copyDir(starterDir, w.Dir)
+}
+
+// ListFiles returns all non-hidden files in the workspace, relative to its root.
+func (w *EvalWorkspace) ListFiles() ([]string, error) {
+	return listFiles(w.Dir)
+}
+
+// Cleanup removes the workspace directory. Safe to call multiple times.
+func (w *EvalWorkspace) Cleanup() error {
+	if w == nil || w.Dir == "" {
+		return nil
+	}
+	return os.RemoveAll(w.Dir)
+}
 
 // Workspace manages a directory for an evaluation run.
 type Workspace struct {

--- a/hyoka/internal/eval/workspace_test.go
+++ b/hyoka/internal/eval/workspace_test.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
@@ -328,5 +329,131 @@ func TestResolveStarterDir_NoFilePath(t *testing.T) {
 	got := resolveStarterDir(p)
 	if got != "starter/" {
 		t.Errorf("resolveStarterDir = %q, want starter/", got)
+	}
+}
+
+// --- EvalWorkspace tests (#126) ---
+
+func TestNewEvalWorkspace_CreatesIsolatedDir(t *testing.T) {
+	ws, err := NewEvalWorkspace()
+	if err != nil {
+		t.Fatalf("NewEvalWorkspace() error: %v", err)
+	}
+	defer ws.Cleanup()
+
+	info, err := os.Stat(ws.Dir)
+	if err != nil {
+		t.Fatalf("workspace dir does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("workspace path is not a directory")
+	}
+	if !strings.HasPrefix(filepath.Base(ws.Dir), EvalWorkspacePrefix) {
+		t.Errorf("workspace dir %q does not have prefix %q", ws.Dir, EvalWorkspacePrefix)
+	}
+	entries, err := os.ReadDir(ws.Dir)
+	if err != nil {
+		t.Fatalf("reading workspace dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("workspace should be empty, got %d entries", len(entries))
+	}
+	if ws.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+}
+
+func TestEvalWorkspace_Cleanup(t *testing.T) {
+	ws, err := NewEvalWorkspace()
+	if err != nil {
+		t.Fatalf("NewEvalWorkspace() error: %v", err)
+	}
+	dir := ws.Dir
+	os.WriteFile(filepath.Join(dir, "test.py"), []byte("code"), 0644)
+	if err := ws.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("workspace dir should be removed after Cleanup")
+	}
+	if err := ws.Cleanup(); err != nil {
+		t.Errorf("second Cleanup() should not error, got: %v", err)
+	}
+}
+
+func TestEvalWorkspace_CleanupNil(t *testing.T) {
+	var ws *EvalWorkspace
+	if err := ws.Cleanup(); err != nil {
+		t.Errorf("Cleanup on nil workspace should not error, got: %v", err)
+	}
+}
+
+func TestEvalWorkspace_CopyStarterFiles(t *testing.T) {
+	ws, err := NewEvalWorkspace()
+	if err != nil {
+		t.Fatalf("NewEvalWorkspace() error: %v", err)
+	}
+	defer ws.Cleanup()
+	starterDir := t.TempDir()
+	os.WriteFile(filepath.Join(starterDir, "main.py"), []byte("starter"), 0644)
+	os.MkdirAll(filepath.Join(starterDir, "lib"), 0755)
+	os.WriteFile(filepath.Join(starterDir, "lib", "utils.py"), []byte("utils"), 0644)
+	if err := ws.CopyStarterFiles(starterDir); err != nil {
+		t.Fatalf("CopyStarterFiles() error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(ws.Dir, "main.py"))
+	if err != nil {
+		t.Fatal("main.py not copied to workspace")
+	}
+	if string(data) != "starter" {
+		t.Errorf("unexpected content: %q", data)
+	}
+	data, err = os.ReadFile(filepath.Join(ws.Dir, "lib", "utils.py"))
+	if err != nil {
+		t.Fatal("lib/utils.py not copied to workspace")
+	}
+	if string(data) != "utils" {
+		t.Errorf("unexpected content: %q", data)
+	}
+}
+
+func TestEvalWorkspace_ListFiles(t *testing.T) {
+	ws, err := NewEvalWorkspace()
+	if err != nil {
+		t.Fatalf("NewEvalWorkspace() error: %v", err)
+	}
+	defer ws.Cleanup()
+	files, err := ws.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(files))
+	}
+	os.WriteFile(filepath.Join(ws.Dir, "app.py"), []byte("app"), 0644)
+	os.MkdirAll(filepath.Join(ws.Dir, "pkg"), 0755)
+	os.WriteFile(filepath.Join(ws.Dir, "pkg", "mod.py"), []byte("mod"), 0644)
+	files, err = ws.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d: %v", len(files), files)
+	}
+}
+
+func TestEvalWorkspace_IsIsolated(t *testing.T) {
+	ws, err := NewEvalWorkspace()
+	if err != nil {
+		t.Fatalf("NewEvalWorkspace() error: %v", err)
+	}
+	defer ws.Cleanup()
+	cwdFiles, _ := os.ReadDir(".")
+	wsFiles, _ := os.ReadDir(ws.Dir)
+	if len(cwdFiles) == 0 {
+		t.Skip("CWD has no files")
+	}
+	if len(wsFiles) != 0 {
+		t.Errorf("workspace should be empty (isolated from CWD), got %d entries", len(wsFiles))
 	}
 }


### PR DESCRIPTION
## Summary

Each evaluation session now runs in a clean, isolated workspace directory created via `EvalWorkspace`. This prevents leakage from the user's development environment into the Copilot agent's working directory.

## Changes

### New: `EvalWorkspace` type (`workspace.go`)
- `NewEvalWorkspace()` — creates an empty temp dir with `hyoka-eval-` prefix
- `CopyStarterFiles()` — copies starter project into workspace
- `ListFiles()` — lists generated files
- `Cleanup()` — removes workspace (safe for double-call and nil receiver)
- `EvalWorkspacePrefix` constant for consistent prefix detection

### Updated: `engine.go`
- Replaced raw `os.MkdirTemp("hyoka-gen-")` with `NewEvalWorkspace()`
- Cleanup via `defer evalWs.Cleanup()` instead of `defer os.RemoveAll()`

### Updated: `clean.go` — orphan workspace cleanup
- New Phase 3: scans OS temp dir for orphan `hyoka-eval-*` directories
- `isHyokaSession()` now detects `hyoka-eval-` prefix in workspace.yaml
- New `WorkspacesFound` / `WorkspacesRemoved` fields in `Result`

### Tests
- Workspace creation, isolation, cleanup, nil-safety
- Starter file copying, file listing
- Orphan workspace detection and dry-run mode

Closes #126