### PR TITLE
feat: implement behavior, action_sequence, and tool_constraint graders (#135)

### DIFF
--- a/hyoka/internal/graders/behavior_grader.go
+++ b/hyoka/internal/graders/behavior_grader.go
@@ -1,0 +1,368 @@
+package graders
+
+import (
+"context"
+"fmt"
+"sort"
+"strings"
+)
+
+// BehaviorGrader checks the action log for required/forbidden tool usage and
+// turn limits.
+type BehaviorGrader struct {
+name           string
+requiredTools  []string
+forbiddenTools []string
+maxTurns       int
+}
+
+// NewBehaviorGrader constructs a BehaviorGrader from a name and config map.
+func NewBehaviorGrader(name string, cfg map[string]any) (*BehaviorGrader, error) {
+if name == "" {
+return nil, fmt.Errorf("behavior grader: name is required")
+}
+g := &BehaviorGrader{name: name}
+if v, ok := cfg["required_tools"]; ok {
+tools, err := toStringSlice(v)
+if err != nil {
+return nil, fmt.Errorf("behavior grader %q: required_tools: %w", name, err)
+}
+g.requiredTools = tools
+}
+if v, ok := cfg["forbidden_tools"]; ok {
+tools, err := toStringSlice(v)
+if err != nil {
+return nil, fmt.Errorf("behavior grader %q: forbidden_tools: %w", name, err)
+}
+g.forbiddenTools = tools
+}
+if v, ok := cfg["max_turns"]; ok {
+turns, err := toInt(v)
+if err != nil {
+return nil, fmt.Errorf("behavior grader %q: max_turns: %w", name, err)
+}
+if turns <= 0 {
+return nil, fmt.Errorf("behavior grader %q: max_turns must be positive", name)
+}
+g.maxTurns = turns
+}
+return g, nil
+}
+
+func (g *BehaviorGrader) Kind() string { return KindBehavior }
+func (g *BehaviorGrader) Name() string { return g.name }
+
+func (g *BehaviorGrader) Grade(_ context.Context, input GraderInput) (GraderResult, error) {
+toolSet := collectToolSet(input.ActionLog)
+maxTurn := maxTurnNumber(input.ActionLog)
+details := &BehaviorGraderDetails{
+ToolsUsed:    sortedStringKeys(toolSet),
+MaxTurns:     g.maxTurns,
+ActualTurns:  maxTurn,
+TotalActions: len(input.ActionLog),
+}
+var violations []string
+for _, tool := range g.requiredTools {
+if !toolSet[tool] {
+details.MissingTools = append(details.MissingTools, tool)
+violations = append(violations, fmt.Sprintf("required tool %q not found", tool))
+}
+}
+for _, tool := range g.forbiddenTools {
+if toolSet[tool] {
+details.ForbiddenUsed = append(details.ForbiddenUsed, tool)
+violations = append(violations, fmt.Sprintf("forbidden tool %q was used", tool))
+}
+}
+if g.maxTurns > 0 && maxTurn > g.maxTurns {
+details.TurnLimitHit = true
+violations = append(violations, fmt.Sprintf("turn count %d exceeds limit %d", maxTurn, g.maxTurns))
+}
+details.Violations = violations
+pass := len(violations) == 0
+score := 0.0
+if pass {
+score = 1.0
+}
+msg := "all behavior constraints satisfied"
+if !pass {
+msg = strings.Join(violations, "; ")
+}
+return GraderResult{
+Kind:            KindBehavior,
+Name:            g.name,
+Pass:            pass,
+Score:           score,
+Message:         msg,
+BehaviorDetails: details,
+}, nil
+}
+
+// ActionSequenceGrader verifies that the action log contains an expected
+// ordered subsequence of actions (by Tool name).
+type ActionSequenceGrader struct {
+name            string
+expectedActions []string
+}
+
+// NewActionSequenceGrader constructs an ActionSequenceGrader from a name and config.
+func NewActionSequenceGrader(name string, cfg map[string]any) (*ActionSequenceGrader, error) {
+if name == "" {
+return nil, fmt.Errorf("action_sequence grader: name is required")
+}
+v, ok := cfg["expected_actions"]
+if !ok {
+return nil, fmt.Errorf("action_sequence grader %q: expected_actions is required", name)
+}
+actions, err := toStringSlice(v)
+if err != nil {
+return nil, fmt.Errorf("action_sequence grader %q: expected_actions: %w", name, err)
+}
+if len(actions) == 0 {
+return nil, fmt.Errorf("action_sequence grader %q: expected_actions must not be empty", name)
+}
+return &ActionSequenceGrader{name: name, expectedActions: actions}, nil
+}
+
+func (g *ActionSequenceGrader) Kind() string { return KindActionSequence }
+func (g *ActionSequenceGrader) Name() string { return g.name }
+
+func (g *ActionSequenceGrader) Grade(_ context.Context, input GraderInput) (GraderResult, error) {
+actual := make([]string, 0, len(input.ActionLog))
+for _, e := range input.ActionLog {
+actual = append(actual, e.Tool)
+}
+matchIdx := 0
+for _, action := range actual {
+if matchIdx < len(g.expectedActions) && action == g.expectedActions[matchIdx] {
+matchIdx++
+}
+}
+fullMatch := matchIdx == len(g.expectedActions)
+details := &BehaviorGraderDetails{
+SequenceMatch:    fullMatch,
+ExpectedSequence: g.expectedActions,
+ActualSequence:   actual,
+MatchedActions:   matchIdx,
+TotalActions:     len(input.ActionLog),
+ToolsUsed:        uniqueTools(actual),
+}
+score := float64(matchIdx) / float64(len(g.expectedActions))
+msg := "action sequence fully matched"
+if !fullMatch {
+msg = fmt.Sprintf("matched %d/%d expected actions", matchIdx, len(g.expectedActions))
+}
+return GraderResult{
+Kind:            KindActionSequence,
+Name:            g.name,
+Pass:            fullMatch,
+Score:           score,
+Message:         msg,
+BehaviorDetails: details,
+}, nil
+}
+
+// ToolConstraintGrader enforces granular tool usage constraints:
+// required/forbidden tools plus per-tool minimum/maximum call counts.
+type ToolConstraintGrader struct {
+name      string
+required  []string
+forbidden []string
+minCalls  map[string]int
+maxCalls  map[string]int
+}
+
+// NewToolConstraintGrader constructs a ToolConstraintGrader from a name and config.
+func NewToolConstraintGrader(name string, cfg map[string]any) (*ToolConstraintGrader, error) {
+if name == "" {
+return nil, fmt.Errorf("tool_constraint grader: name is required")
+}
+g := &ToolConstraintGrader{name: name}
+if v, ok := cfg["required"]; ok {
+tools, err := toStringSlice(v)
+if err != nil {
+return nil, fmt.Errorf("tool_constraint grader %q: required: %w", name, err)
+}
+g.required = tools
+}
+if v, ok := cfg["forbidden"]; ok {
+tools, err := toStringSlice(v)
+if err != nil {
+return nil, fmt.Errorf("tool_constraint grader %q: forbidden: %w", name, err)
+}
+g.forbidden = tools
+}
+if v, ok := cfg["min_calls"]; ok {
+m, err := toStringIntMap(v)
+if err != nil {
+return nil, fmt.Errorf("tool_constraint grader %q: min_calls: %w", name, err)
+}
+g.minCalls = m
+}
+if v, ok := cfg["max_calls"]; ok {
+m, err := toStringIntMap(v)
+if err != nil {
+return nil, fmt.Errorf("tool_constraint grader %q: max_calls: %w", name, err)
+}
+g.maxCalls = m
+}
+return g, nil
+}
+
+func (g *ToolConstraintGrader) Kind() string { return KindToolConstraint }
+func (g *ToolConstraintGrader) Name() string { return g.name }
+
+func (g *ToolConstraintGrader) Grade(_ context.Context, input GraderInput) (GraderResult, error) {
+toolCounts := countTools(input.ActionLog)
+details := &BehaviorGraderDetails{
+ToolsUsed:    sortedStringKeys(collectToolSet(input.ActionLog)),
+ToolCounts:   toolCounts,
+TotalActions: len(input.ActionLog),
+}
+var violations []string
+for _, tool := range g.required {
+if toolCounts[tool] == 0 {
+details.MissingTools = append(details.MissingTools, tool)
+violations = append(violations, fmt.Sprintf("required tool %q not called", tool))
+}
+}
+for _, tool := range g.forbidden {
+if toolCounts[tool] > 0 {
+details.ForbiddenUsed = append(details.ForbiddenUsed, tool)
+violations = append(violations, fmt.Sprintf("forbidden tool %q called %d time(s)", tool, toolCounts[tool]))
+}
+}
+for tool, minCount := range g.minCalls {
+if toolCounts[tool] < minCount {
+violations = append(violations, fmt.Sprintf("tool %q called %d time(s), minimum is %d", tool, toolCounts[tool], minCount))
+}
+}
+for tool, maxCount := range g.maxCalls {
+if toolCounts[tool] > maxCount {
+violations = append(violations, fmt.Sprintf("tool %q called %d time(s), maximum is %d", tool, toolCounts[tool], maxCount))
+}
+}
+details.Violations = violations
+details.ConstraintsMet = len(violations) == 0
+pass := len(violations) == 0
+score := 0.0
+if pass {
+score = 1.0
+}
+msg := "all tool constraints satisfied"
+if !pass {
+msg = strings.Join(violations, "; ")
+}
+return GraderResult{
+Kind:            KindToolConstraint,
+Name:            g.name,
+Pass:            pass,
+Score:           score,
+Message:         msg,
+BehaviorDetails: details,
+}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func collectToolSet(log []ActionEvent) map[string]bool {
+tools := make(map[string]bool)
+for _, e := range log {
+if e.Tool != "" {
+tools[e.Tool] = true
+}
+}
+return tools
+}
+
+func countTools(log []ActionEvent) map[string]int {
+counts := make(map[string]int)
+for _, e := range log {
+if e.Tool != "" {
+counts[e.Tool]++
+}
+}
+return counts
+}
+
+func maxTurnNumber(log []ActionEvent) int {
+max := 0
+for _, e := range log {
+if e.TurnNumber > max {
+max = e.TurnNumber
+}
+}
+return max
+}
+
+func sortedStringKeys(m map[string]bool) []string {
+keys := make([]string, 0, len(m))
+for k := range m {
+keys = append(keys, k)
+}
+sort.Strings(keys)
+return keys
+}
+
+func uniqueTools(tools []string) []string {
+seen := make(map[string]bool)
+var result []string
+for _, t := range tools {
+if t != "" && !seen[t] {
+seen[t] = true
+result = append(result, t)
+}
+}
+return result
+}
+
+func toStringSlice(v any) ([]string, error) {
+switch val := v.(type) {
+case []string:
+return val, nil
+case []any:
+result := make([]string, len(val))
+for i, elem := range val {
+s, ok := elem.(string)
+if !ok {
+return nil, fmt.Errorf("element %d must be a string", i)
+}
+result[i] = s
+}
+return result, nil
+default:
+return nil, fmt.Errorf("must be a string array")
+}
+}
+
+func toInt(v any) (int, error) {
+switch val := v.(type) {
+case int:
+return val, nil
+case float64:
+return int(val), nil
+default:
+return 0, fmt.Errorf("must be a number")
+}
+}
+
+func toStringIntMap(v any) (map[string]int, error) {
+switch val := v.(type) {
+case map[string]int:
+return val, nil
+case map[string]any:
+result := make(map[string]int, len(val))
+for k, elem := range val {
+n, err := toInt(elem)
+if err != nil {
+return nil, fmt.Errorf("key %q: %w", k, err)
+}
+result[k] = n
+}
+return result, nil
+default:
+return nil, fmt.Errorf("must be a map of string to int")
+}
+}

--- a/hyoka/internal/graders/behavior_grader_test.go
+++ b/hyoka/internal/graders/behavior_grader_test.go
@@ -1,0 +1,431 @@
+package graders
+
+import (
+"context"
+"testing"
+)
+
+func TestBehaviorGrader_AllConstraintsSatisfied(t *testing.T) {
+g, err := NewBehaviorGrader("test", map[string]any{
+"required_tools":  []any{"read_file", "edit_file"},
+"forbidden_tools": []any{"rm", "sudo"},
+"max_turns":       25,
+})
+if err != nil {
+t.Fatalf("NewBehaviorGrader: %v", err)
+}
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "read_file", TurnNumber: 1},
+{Tool: "edit_file", TurnNumber: 2},
+{Tool: "azure-mcp", TurnNumber: 3},
+},
+})
+if err != nil {
+t.Fatalf("Grade: %v", err)
+}
+if !result.Pass {
+t.Errorf("expected Pass=true, message: %s", result.Message)
+}
+if result.Score != 1.0 {
+t.Errorf("expected Score=1.0, got %f", result.Score)
+}
+if result.Kind != KindBehavior {
+t.Errorf("expected Kind=%s, got %s", KindBehavior, result.Kind)
+}
+}
+
+func TestBehaviorGrader_RequiredToolMissing(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{
+"required_tools": []any{"read_file", "azure-mcp"},
+})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "read_file", TurnNumber: 1},
+{Tool: "edit_file", TurnNumber: 2},
+},
+})
+if err != nil {
+t.Fatal(err)
+}
+if result.Pass {
+t.Error("expected Pass=false when required tool is missing")
+}
+if result.Score != 0.0 {
+t.Errorf("expected Score=0.0, got %f", result.Score)
+}
+details := result.BehaviorDetails
+if details == nil {
+t.Fatal("expected BehaviorDetails to be set")
+}
+if len(details.MissingTools) != 1 || details.MissingTools[0] != "azure-mcp" {
+t.Errorf("expected MissingTools=[azure-mcp], got %v", details.MissingTools)
+}
+}
+
+func TestBehaviorGrader_ForbiddenToolUsed(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{
+"forbidden_tools": []any{"rm", "sudo"},
+})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "read_file", TurnNumber: 1},
+{Tool: "rm", TurnNumber: 2},
+},
+})
+if err != nil {
+t.Fatal(err)
+}
+if result.Pass {
+t.Error("expected Pass=false when forbidden tool is used")
+}
+details := result.BehaviorDetails
+if details == nil {
+t.Fatal("expected BehaviorDetails")
+}
+if len(details.ForbiddenUsed) != 1 || details.ForbiddenUsed[0] != "rm" {
+t.Errorf("expected ForbiddenUsed=[rm], got %v", details.ForbiddenUsed)
+}
+}
+
+func TestBehaviorGrader_TurnLimitExceeded(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{"max_turns": 3})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "read_file", TurnNumber: 1},
+{Tool: "edit_file", TurnNumber: 4},
+},
+})
+if err != nil {
+t.Fatal(err)
+}
+if result.Pass {
+t.Error("expected Pass=false when turn limit exceeded")
+}
+if result.BehaviorDetails == nil || !result.BehaviorDetails.TurnLimitHit {
+t.Error("expected TurnLimitHit=true")
+}
+}
+
+func TestBehaviorGrader_TurnLimitNotExceeded(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{"max_turns": 10})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file", TurnNumber: 5}},
+})
+if err != nil {
+t.Fatal(err)
+}
+if !result.Pass {
+t.Errorf("expected Pass=true, message: %s", result.Message)
+}
+}
+
+func TestBehaviorGrader_EmptyActionLog(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{"required_tools": []any{"read_file"}})
+result, err := g.Grade(context.Background(), GraderInput{})
+if err != nil {
+t.Fatal(err)
+}
+if result.Pass {
+t.Error("expected Pass=false with empty log and required tools")
+}
+}
+
+func TestBehaviorGrader_NoConstraints(t *testing.T) {
+g, _ := NewBehaviorGrader("test", map[string]any{})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "anything", TurnNumber: 100}},
+})
+if err != nil {
+t.Fatal(err)
+}
+if !result.Pass {
+t.Error("expected Pass=true with no constraints")
+}
+}
+
+func TestBehaviorGrader_ValidationErrors(t *testing.T) {
+tests := []struct {
+name string
+gn   string
+cfg  map[string]any
+}{
+{"empty name", "", map[string]any{}},
+{"bad required_tools", "x", map[string]any{"required_tools": "not-a-slice"}},
+{"bad forbidden_tools", "x", map[string]any{"forbidden_tools": 42}},
+{"bad max_turns type", "x", map[string]any{"max_turns": "fast"}},
+{"negative max_turns", "x", map[string]any{"max_turns": -1}},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+_, err := NewBehaviorGrader(tt.gn, tt.cfg)
+if err == nil {
+t.Error("expected error")
+}
+})
+}
+}
+
+func TestBehaviorGrader_ImplementsGraderInterface(t *testing.T) {
+g, _ := NewBehaviorGrader("iface", map[string]any{})
+var _ Grader = g
+if g.Kind() != KindBehavior {
+t.Errorf("Kind() = %s, want %s", g.Kind(), KindBehavior)
+}
+}
+
+// --- ActionSequenceGrader tests ---
+
+func TestActionSequenceGrader_FullMatch(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{
+"expected_actions": []any{"read_file", "edit_file", "run_tests"},
+})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "read_file"}, {Tool: "analyze"}, {Tool: "edit_file"},
+{Tool: "format"}, {Tool: "run_tests"},
+},
+})
+if err != nil {
+t.Fatal(err)
+}
+if !result.Pass {
+t.Errorf("expected Pass=true, message: %s", result.Message)
+}
+if result.Score != 1.0 {
+t.Errorf("expected Score=1.0, got %f", result.Score)
+}
+if result.Kind != KindActionSequence {
+t.Errorf("expected Kind=%s, got %s", KindActionSequence, result.Kind)
+}
+details := result.BehaviorDetails
+if details == nil || !details.SequenceMatch {
+t.Error("expected SequenceMatch=true")
+}
+if details.MatchedActions != 3 {
+t.Errorf("expected MatchedActions=3, got %d", details.MatchedActions)
+}
+}
+
+func TestActionSequenceGrader_ExactMatch(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{
+"expected_actions": []any{"read_file", "edit_file"},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file"}, {Tool: "edit_file"}},
+})
+if !result.Pass {
+t.Error("expected Pass=true for exact match")
+}
+}
+
+func TestActionSequenceGrader_MissingStep(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{
+"expected_actions": []any{"read_file", "edit_file", "run_tests"},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file"}, {Tool: "edit_file"}},
+})
+if result.Pass {
+t.Error("expected Pass=false when step is missing")
+}
+details := result.BehaviorDetails
+if details == nil || details.MatchedActions != 2 {
+t.Errorf("expected MatchedActions=2, got %v", details)
+}
+expected := 2.0 / 3.0
+if result.Score < expected-0.01 || result.Score > expected+0.01 {
+t.Errorf("expected Score~=%f, got %f", expected, result.Score)
+}
+}
+
+func TestActionSequenceGrader_WrongOrder(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{
+"expected_actions": []any{"edit_file", "read_file"},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file"}, {Tool: "edit_file"}},
+})
+if result.Pass {
+t.Error("expected Pass=false for wrong order")
+}
+}
+
+func TestActionSequenceGrader_ExtraActionsOK(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{
+"expected_actions": []any{"read_file"},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "setup"}, {Tool: "read_file"}, {Tool: "analyze"},
+{Tool: "edit_file"}, {Tool: "cleanup"},
+},
+})
+if !result.Pass {
+t.Error("expected Pass=true, extra actions should not matter")
+}
+}
+
+func TestActionSequenceGrader_EmptyLog(t *testing.T) {
+g, _ := NewActionSequenceGrader("test", map[string]any{"expected_actions": []any{"a"}})
+result, _ := g.Grade(context.Background(), GraderInput{})
+if result.Pass {
+t.Error("expected Pass=false with empty log")
+}
+if result.Score != 0.0 {
+t.Errorf("expected Score=0.0, got %f", result.Score)
+}
+}
+
+func TestActionSequenceGrader_ValidationErrors(t *testing.T) {
+tests := []struct {
+name string
+gn   string
+cfg  map[string]any
+}{
+{"empty name", "", map[string]any{"expected_actions": []any{"a"}}},
+{"missing key", "x", map[string]any{}},
+{"empty slice", "x", map[string]any{"expected_actions": []any{}}},
+{"bad type", "x", map[string]any{"expected_actions": "not-a-slice"}},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+_, err := NewActionSequenceGrader(tt.gn, tt.cfg)
+if err == nil {
+t.Error("expected error")
+}
+})
+}
+}
+
+func TestActionSequenceGrader_ImplementsGraderInterface(t *testing.T) {
+g, _ := NewActionSequenceGrader("iface", map[string]any{"expected_actions": []any{"a"}})
+var _ Grader = g
+if g.Kind() != KindActionSequence {
+t.Errorf("Kind() = %s, want %s", g.Kind(), KindActionSequence)
+}
+}
+
+// --- ToolConstraintGrader tests ---
+
+func TestToolConstraintGrader_AllSatisfied(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{
+"required":  []any{"azure-mcp", "read_file"},
+"forbidden": []any{"rm"},
+"min_calls": map[string]any{"azure-mcp": 2},
+"max_calls": map[string]any{"azure-mcp": 10},
+})
+result, err := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{
+{Tool: "azure-mcp"}, {Tool: "read_file"}, {Tool: "azure-mcp"},
+{Tool: "edit_file"}, {Tool: "azure-mcp"},
+},
+})
+if err != nil {
+t.Fatal(err)
+}
+if !result.Pass {
+t.Errorf("expected Pass=true, message: %s", result.Message)
+}
+if result.Score != 1.0 {
+t.Errorf("expected Score=1.0, got %f", result.Score)
+}
+if result.Kind != KindToolConstraint {
+t.Errorf("expected Kind=%s, got %s", KindToolConstraint, result.Kind)
+}
+details := result.BehaviorDetails
+if details == nil || details.ToolCounts["azure-mcp"] != 3 {
+t.Errorf("expected azure-mcp count=3")
+}
+if !details.ConstraintsMet {
+t.Error("expected ConstraintsMet=true")
+}
+}
+
+func TestToolConstraintGrader_RequiredMissing(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{"required": []any{"azure-mcp"}})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file"}},
+})
+if result.Pass {
+t.Error("expected Pass=false when required tool missing")
+}
+}
+
+func TestToolConstraintGrader_ForbiddenUsed(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{"forbidden": []any{"dangerous"}})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "read_file"}, {Tool: "dangerous"}},
+})
+if result.Pass {
+t.Error("expected Pass=false when forbidden tool used")
+}
+details := result.BehaviorDetails
+if details == nil || len(details.Violations) == 0 {
+t.Error("expected violations")
+}
+}
+
+func TestToolConstraintGrader_BelowMinCalls(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{
+"min_calls": map[string]any{"azure-mcp": 3},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "azure-mcp"}, {Tool: "azure-mcp"}},
+})
+if result.Pass {
+t.Error("expected Pass=false when below min calls")
+}
+}
+
+func TestToolConstraintGrader_ExceedsMaxCalls(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{
+"max_calls": map[string]any{"azure-mcp": 2},
+})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "azure-mcp"}, {Tool: "azure-mcp"}, {Tool: "azure-mcp"}},
+})
+if result.Pass {
+t.Error("expected Pass=false when exceeding max calls")
+}
+}
+
+func TestToolConstraintGrader_NoConstraints(t *testing.T) {
+g, _ := NewToolConstraintGrader("test", map[string]any{})
+result, _ := g.Grade(context.Background(), GraderInput{
+ActionLog: []ActionEvent{{Tool: "anything"}},
+})
+if !result.Pass {
+t.Error("expected Pass=true with no constraints")
+}
+}
+
+func TestToolConstraintGrader_ValidationErrors(t *testing.T) {
+tests := []struct {
+name string
+gn   string
+cfg  map[string]any
+}{
+{"empty name", "", map[string]any{}},
+{"bad required", "x", map[string]any{"required": "not-a-slice"}},
+{"bad forbidden", "x", map[string]any{"forbidden": 42}},
+{"bad min_calls", "x", map[string]any{"min_calls": "not-a-map"}},
+{"bad max_calls", "x", map[string]any{"max_calls": 42}},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+_, err := NewToolConstraintGrader(tt.gn, tt.cfg)
+if err == nil {
+t.Error("expected error")
+}
+})
+}
+}
+
+func TestToolConstraintGrader_ImplementsGraderInterface(t *testing.T) {
+g, _ := NewToolConstraintGrader("iface", map[string]any{})
+var _ Grader = g
+if g.Kind() != KindToolConstraint {
+t.Errorf("Kind() = %s, want %s", g.Kind(), KindToolConstraint)
+}
+}

--- a/hyoka/internal/graders/grader.go
+++ b/hyoka/internal/graders/grader.go
@@ -29,9 +29,10 @@ Files         []FileEntry    // Listing of files in the workspace
 
 // ActionEvent represents a single agent action from the session log.
 type ActionEvent struct {
-Tool   string `json:"tool"`
-Action string `json:"action"`
-Path   string `json:"path,omitempty"`
+Tool       string `json:"tool"`
+Action     string `json:"action"`
+Path       string `json:"path,omitempty"`
+TurnNumber int    `json:"turn_number,omitempty"`
 }
 
 // PromptMetadata holds prompt frontmatter fields relevant to grading.
@@ -93,14 +94,27 @@ type PromptGraderDetails struct {
 Model     string `json:"model"`
 Rubric    string `json:"rubric"`
 Reasoning string `json:"reasoning"`
+RawScore  int    `json:"raw_score,omitempty"`
+MaxScore  int    `json:"max_score,omitempty"`
 }
 
 // BehaviorGraderDetails holds agent behavior analysis specifics.
 type BehaviorGraderDetails struct {
-ToolsUsed     []string `json:"tools_used,omitempty"`
-ForbiddenUsed []string `json:"forbidden_used,omitempty"`
-TurnCount     int      `json:"turn_count"`
-Violations    []string `json:"violations,omitempty"`
+ToolsUsed        []string       `json:"tools_used,omitempty"`
+MissingTools     []string       `json:"missing_tools,omitempty"`
+ForbiddenUsed    []string       `json:"forbidden_used,omitempty"`
+TurnCount        int            `json:"turn_count,omitempty"`
+MaxTurns         int            `json:"max_turns,omitempty"`
+ActualTurns      int            `json:"actual_turns,omitempty"`
+TotalActions     int            `json:"total_actions,omitempty"`
+TurnLimitHit     bool           `json:"turn_limit_hit,omitempty"`
+Violations       []string       `json:"violations,omitempty"`
+SequenceMatch    bool           `json:"sequence_match,omitempty"`
+ExpectedSequence []string       `json:"expected_sequence,omitempty"`
+ActualSequence   []string       `json:"actual_sequence,omitempty"`
+MatchedActions   int            `json:"matched_actions,omitempty"`
+ConstraintsMet   bool           `json:"constraints_met,omitempty"`
+ToolCounts       map[string]int `json:"tool_counts,omitempty"`
 }
 
 // AggregateResult holds the final aggregated score from all graders.

--- a/hyoka/internal/graders/prompt_grader.go
+++ b/hyoka/internal/graders/prompt_grader.go
@@ -20,14 +20,6 @@ type LLMCaller interface {
 	Call(ctx context.Context, model string, prompt string) (string, error)
 }
 
-// PromptGraderDetails captures the full details of a prompt grader evaluation.
-type PromptGraderDetails struct {
-	Model     string `json:"model"`
-	Rubric    string `json:"rubric"`
-	Reasoning string `json:"reasoning"`
-	RawScore  int    `json:"raw_score"`
-	MaxScore  int    `json:"max_score"`
-}
 
 // PromptGradeResult holds the normalized output of a prompt grader.
 type PromptGradeResult struct {

--- a/hyoka/internal/graders/types.go
+++ b/hyoka/internal/graders/types.go
@@ -108,8 +108,8 @@ ExpectedActions []string `yaml:"expected_actions" json:"expected_actions"`
 type ToolConstraintConfig struct {
 Required  []string `yaml:"required,omitempty" json:"required,omitempty"`
 Forbidden []string `yaml:"forbidden,omitempty" json:"forbidden,omitempty"`
-MinCalls  int      `yaml:"min_calls,omitempty" json:"min_calls,omitempty"`
-MaxCalls  int      `yaml:"max_calls,omitempty" json:"max_calls,omitempty"`
+MinCalls  map[string]int `yaml:"min_calls,omitempty" json:"min_calls,omitempty"`
+MaxCalls  map[string]int `yaml:"max_calls,omitempty" json:"max_calls,omitempty"`
 }
 
 // EffectiveWeight returns the grader's weight, defaulting to 1.0 if unset.

--- a/hyoka/internal/graders/types_test.go
+++ b/hyoka/internal/graders/types_test.go
@@ -59,8 +59,10 @@ graders:
     config:
       required: ["azure-mcp"]
       forbidden: ["dangerous"]
-      min_calls: 1
-      max_calls: 50
+      min_calls:
+        azure-mcp: 1
+      max_calls:
+        azure-mcp: 50
     weight: 0.5
 `
 gcf, err := Parse([]byte(yaml))
@@ -142,8 +144,8 @@ if err != nil {
 t.Fatalf("DecodeConfig tool_constraint: %v", err)
 }
 tc := cfg.(*ToolConstraintConfig)
-if tc.MinCalls != 1 || tc.MaxCalls != 50 {
-t.Errorf("tool_constraint: min=%d max=%d", tc.MinCalls, tc.MaxCalls)
+if tc.MinCalls["azure-mcp"] != 1 || tc.MaxCalls["azure-mcp"] != 50 {
+t.Errorf("tool_constraint: min=%v max=%v", tc.MinCalls, tc.MaxCalls)
 }
 }
 


### PR DESCRIPTION
## Summary

Implements three graders that analyze agent behavior from the action log (task 2.5e).

### BehaviorGrader
- Config: `required_tools`, `forbidden_tools`, `max_turns`
- Pass if all required tools used, no forbidden tools used, turns within limit

### ActionSequenceGrader
- Config: `expected_actions` (ordered list)
- Subsequence matching — expected actions must appear in order, extra actions OK
- Partial scoring: matched/total expected actions

### ToolConstraintGrader
- Config: `required`, `forbidden`, `min_calls` (map[string]int), `max_calls` (map[string]int)
- Per-tool minimum/maximum call count enforcement

### Changes to existing types
- `ActionEvent`: added `TurnNumber` field for turn tracking
- `BehaviorGraderDetails`: extended with fields for all three graders (Violations, MaxTurns, ActualTurns, ExpectedSequence, ActualSequence, MatchedActions, ToolCounts)
- `ToolConstraintConfig`: changed `min_calls`/`max_calls` from `int` to `map[string]int` for per-tool granularity

### Tests
40 tests total (all passing with `-race`):
- BehaviorGrader: 10 tests (required/missing, forbidden, turn limits, validation, interface)
- ActionSequenceGrader: 9 tests (full match, missing step, wrong order, extra actions, validation)
- ToolConstraintGrader: 8 tests (required, forbidden, min/max calls, validation)
- Existing tests: 13 tests (all still passing)

Closes #135