### PR TITLE
feat: wire configurable session limits into eval engine (#125)

### DIFF
--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -49,12 +49,13 @@ type ReviewerConfig struct {
 	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
-// SessionLimits holds configurable guardrails for a Copilot session.
+// SessionLimits configures per-config guardrail limits for evaluation sessions.
+// Zero values are ignored and fall back to engine-level defaults.
 type SessionLimits struct {
-	MaxTurns          int    `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
-	MaxFiles          int    `yaml:"max_files,omitempty" json:"max_files,omitempty"`
-	MaxOutputSize     string `yaml:"max_output_size,omitempty" json:"max_output_size,omitempty"`
-	MaxSessionActions int    `yaml:"max_session_actions,omitempty" json:"max_session_actions,omitempty"`
+	MaxTurns          int   `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
+	MaxFiles          int   `yaml:"max_files,omitempty" json:"max_files,omitempty"`
+	MaxOutputSize     int64 `yaml:"max_output_size,omitempty" json:"max_output_size,omitempty"`
+	MaxSessionActions int   `yaml:"max_session_actions,omitempty" json:"max_session_actions,omitempty"`
 }
 
 // ToolConfig represents a single evaluation configuration.

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -674,90 +674,6 @@ configs:
 	}
 }
 
-func TestParseSessionLimits(t *testing.T) {
-	data := []byte(`
-configs:
-  - name: with-limits
-    description: "Config with session limits"
-    generator:
-      model: "claude-opus-4.6"
-    limits:
-      max_turns: 25
-      max_files: 50
-      max_output_size: "1MB"
-      max_session_actions: 100
-`)
-	cfg, err := Parse(data)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	lim := cfg.Configs[0].Limits
-	if lim == nil {
-		t.Fatal("expected Limits to be non-nil")
-	}
-	if lim.MaxTurns != 25 {
-		t.Errorf("expected MaxTurns=25, got %d", lim.MaxTurns)
-	}
-	if lim.MaxFiles != 50 {
-		t.Errorf("expected MaxFiles=50, got %d", lim.MaxFiles)
-	}
-	if lim.MaxOutputSize != "1MB" {
-		t.Errorf("expected MaxOutputSize='1MB', got %q", lim.MaxOutputSize)
-	}
-	if lim.MaxSessionActions != 100 {
-		t.Errorf("expected MaxSessionActions=100, got %d", lim.MaxSessionActions)
-	}
-}
-
-func TestParseSessionLimitsOmitted(t *testing.T) {
-	data := []byte(`
-configs:
-  - name: no-limits
-    description: "Config without limits"
-    generator:
-      model: "gpt-4"
-`)
-	cfg, err := Parse(data)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Configs[0].Limits != nil {
-		t.Errorf("expected Limits to be nil when omitted, got %+v", cfg.Configs[0].Limits)
-	}
-}
-
-func TestParseSessionLimitsPartial(t *testing.T) {
-	data := []byte(`
-configs:
-  - name: partial-limits
-    description: "Config with partial limits"
-    generator:
-      model: "gpt-4"
-    limits:
-      max_turns: 10
-`)
-	cfg, err := Parse(data)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	lim := cfg.Configs[0].Limits
-	if lim == nil {
-		t.Fatal("expected Limits to be non-nil")
-	}
-	if lim.MaxTurns != 10 {
-		t.Errorf("expected MaxTurns=10, got %d", lim.MaxTurns)
-	}
-	if lim.MaxFiles != 0 {
-		t.Errorf("expected MaxFiles=0 (zero value), got %d", lim.MaxFiles)
-	}
-	if lim.MaxOutputSize != "" {
-		t.Errorf("expected MaxOutputSize='' (zero value), got %q", lim.MaxOutputSize)
-	}
-	if lim.MaxSessionActions != 0 {
-		t.Errorf("expected MaxSessionActions=0 (zero value), got %d", lim.MaxSessionActions)
-	}
-}
-
 func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
 	cf := &ConfigFile{
 		Configs: []ToolConfig{
@@ -774,3 +690,55 @@ func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
 	}
 }
 
+func TestParseSessionLimits(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: with-limits
+    generator:
+      model: "gpt-4"
+    limits:
+      max_turns: 10
+      max_files: 20
+      max_output_size: 524288
+      max_session_actions: 30
+`)
+	cfg, err := Parse(data)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	lim := cfg.Configs[0].Limits
+	if lim == nil { t.Fatal("expected Limits to be set") }
+	if lim.MaxTurns != 10 { t.Errorf("MaxTurns: expected 10, got %d", lim.MaxTurns) }
+	if lim.MaxFiles != 20 { t.Errorf("MaxFiles: expected 20, got %d", lim.MaxFiles) }
+	if lim.MaxOutputSize != 524288 { t.Errorf("MaxOutputSize: expected 524288, got %d", lim.MaxOutputSize) }
+	if lim.MaxSessionActions != 30 { t.Errorf("MaxSessionActions: expected 30, got %d", lim.MaxSessionActions) }
+}
+
+func TestParseSessionLimitsOmitted(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: no-limits
+    generator:
+      model: "gpt-4"
+`)
+	cfg, err := Parse(data)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if cfg.Configs[0].Limits != nil { t.Error("expected Limits to be nil when omitted") }
+}
+
+func TestParseSessionLimitsPartial(t *testing.T) {
+	data := []byte(`
+configs:
+  - name: partial-limits
+    generator:
+      model: "gpt-4"
+    limits:
+      max_turns: 15
+`)
+	cfg, err := Parse(data)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	lim := cfg.Configs[0].Limits
+	if lim == nil { t.Fatal("expected Limits to be set") }
+	if lim.MaxTurns != 15 { t.Errorf("MaxTurns: expected 15, got %d", lim.MaxTurns) }
+	if lim.MaxFiles != 0 { t.Errorf("MaxFiles: expected 0, got %d", lim.MaxFiles) }
+	if lim.MaxOutputSize != 0 { t.Errorf("MaxOutputSize: expected 0, got %d", lim.MaxOutputSize) }
+	if lim.MaxSessionActions != 0 { t.Errorf("MaxSessionActions: expected 0, got %d", lim.MaxSessionActions) }
+}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -74,6 +74,7 @@ type EngineOptions struct {
 	ConfirmLargeRuns bool
 	AutoConfirm      bool
 	// Generator guardrails (#35)
+	MaxTurns          int
 	MaxSessionActions int
 	MaxFiles          int
 	MaxOutputSize     int64
@@ -136,6 +137,9 @@ func NewEngineWithReviewerFactory(evaluator CopilotEvaluator, factory ReviewerFa
 		opts.OutputDir = "./reports"
 	}
 	// Generator guardrail defaults (#35)
+	if opts.MaxTurns <= 0 {
+		opts.MaxTurns = 25
+	}
 	if opts.MaxSessionActions <= 0 {
 		opts.MaxSessionActions = 50
 	}
@@ -224,6 +228,42 @@ func (e *Engine) SetPanelReviewer(pr *review.PanelReviewer) {
 type EvalTask struct {
 	Prompt *prompt.Prompt
 	Config config.ToolConfig
+}
+
+// resolvedLimits holds the effective guardrail limits for a single eval,
+// resolved from config-level overrides and engine-level defaults.
+type resolvedLimits struct {
+	maxTurns          int
+	maxFiles          int
+	maxOutputSize     int64
+	maxSessionActions int
+}
+
+// resolveLimits merges per-config session limits with engine defaults.
+// Config values > 0 take precedence; zero values fall back to engine defaults.
+func (e *Engine) resolveLimits(cfg config.ToolConfig) resolvedLimits {
+	rl := resolvedLimits{
+		maxTurns:          e.opts.MaxTurns,
+		maxFiles:          e.opts.MaxFiles,
+		maxOutputSize:     e.opts.MaxOutputSize,
+		maxSessionActions: e.opts.MaxSessionActions,
+	}
+	if cfg.Limits == nil {
+		return rl
+	}
+	if cfg.Limits.MaxTurns > 0 {
+		rl.maxTurns = cfg.Limits.MaxTurns
+	}
+	if cfg.Limits.MaxFiles > 0 {
+		rl.maxFiles = cfg.Limits.MaxFiles
+	}
+	if cfg.Limits.MaxOutputSize > 0 {
+		rl.maxOutputSize = cfg.Limits.MaxOutputSize
+	}
+	if cfg.Limits.MaxSessionActions > 0 {
+		rl.maxSessionActions = cfg.Limits.MaxSessionActions
+	}
+	return rl
 }
 
 // Run executes evaluations for the given prompts crossed with configs.
@@ -552,11 +592,15 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			"name":  task.Config.Name,
 			"model": task.Config.Generator.Model,
 		},
-		// Guardrail limits recorded for report transparency (#35)
-		GuardrailMaxTurns:      e.opts.MaxSessionActions,
-		GuardrailMaxFiles:      e.opts.MaxFiles,
-		GuardrailMaxOutputSize: e.opts.MaxOutputSize,
 	}
+
+	// Resolve effective limits: per-config overrides → engine defaults (#125)
+	lim := e.resolveLimits(task.Config)
+	evalReport.GuardrailMaxTurns = lim.maxTurns
+	evalReport.GuardrailMaxFiles = lim.maxFiles
+	evalReport.GuardrailMaxOutputSize = lim.maxOutputSize
+	evalReport.GuardrailMaxSessionActions = lim.maxSessionActions
+
 	if len(task.Prompt.Tags) > 0 {
 		evalReport.PromptMeta["tags"] = strings.Join(task.Prompt.Tags, ", ")
 	}
@@ -780,8 +824,23 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	}
 	evalReport.Environment = env
 
-	// Generator guardrail checks (#35)
+	// Generator guardrail checks (#35, #125)
 	if !evalFailed {
+		// Check turn count (assistant.message events = conversation turns)
+		turnCount := 0
+		for _, ev := range evalReport.SessionEvents {
+			if ev.Type == "assistant.message" {
+				turnCount++
+			}
+		}
+		if turnCount > lim.maxTurns {
+			reason := fmt.Sprintf("guardrail: turn count %d exceeded limit of %d", turnCount, lim.maxTurns)
+			evalReport.GuardrailAbortReason = reason
+			evalReport.Error = reason
+			evalReport.Success = false
+			lg.Warn("Guardrail triggered", "reason", reason, "turns", turnCount, "max_turns", lim.maxTurns)
+		}
+
 		// Check action count (count reasoning, message, and tool_execution_start events as actions)
 		actionCount := 0
 		for _, ev := range evalReport.SessionEvents {
@@ -789,21 +848,21 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 				actionCount++
 			}
 		}
-		if actionCount > e.opts.MaxSessionActions {
-			reason := fmt.Sprintf("guardrail: action count %d exceeded limit of %d", actionCount, e.opts.MaxSessionActions)
+		if actionCount > lim.maxSessionActions {
+			reason := fmt.Sprintf("guardrail: action count %d exceeded limit of %d", actionCount, lim.maxSessionActions)
 			evalReport.GuardrailAbortReason = reason
 			evalReport.Error = reason
 			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "actions", actionCount, "max_session_actions", e.opts.MaxSessionActions)
+			lg.Warn("Guardrail triggered", "reason", reason, "actions", actionCount, "max_session_actions", lim.maxSessionActions)
 		}
 
 		// Check file count
-		if len(generatedFiles) > e.opts.MaxFiles {
-			reason := fmt.Sprintf("guardrail: file count %d exceeded limit of %d", len(generatedFiles), e.opts.MaxFiles)
+		if len(generatedFiles) > lim.maxFiles {
+			reason := fmt.Sprintf("guardrail: file count %d exceeded limit of %d", len(generatedFiles), lim.maxFiles)
 			evalReport.GuardrailAbortReason = reason
 			evalReport.Error = reason
 			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "files", len(generatedFiles), "max_files", e.opts.MaxFiles)
+			lg.Warn("Guardrail triggered", "reason", reason, "files", len(generatedFiles), "max_files", lim.maxFiles)
 		}
 
 		// Check total output size
@@ -817,12 +876,12 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 				totalSize += info.Size()
 			}
 		}
-		if totalSize > e.opts.MaxOutputSize {
-			reason := fmt.Sprintf("guardrail: total output size %d bytes exceeded limit of %d bytes", totalSize, e.opts.MaxOutputSize)
+		if totalSize > lim.maxOutputSize {
+			reason := fmt.Sprintf("guardrail: total output size %d bytes exceeded limit of %d bytes", totalSize, lim.maxOutputSize)
 			evalReport.GuardrailAbortReason = reason
 			evalReport.Error = reason
 			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "total_size", totalSize, "max_size", e.opts.MaxOutputSize)
+			lg.Warn("Guardrail triggered", "reason", reason, "total_size", totalSize, "max_size", lim.maxOutputSize)
 		}
 	}
 

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -391,6 +391,9 @@ func TestGuardrailMaxOutputSize(t *testing.T) {
 
 func TestGuardrailDefaultValues(t *testing.T) {
 	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	if engine.opts.MaxTurns != 25 {
+		t.Errorf("default MaxTurns: expected 25, got %d", engine.opts.MaxTurns)
+	}
 	if engine.opts.MaxSessionActions != 50 {
 		t.Errorf("default MaxSessionActions: expected 50, got %d", engine.opts.MaxSessionActions)
 	}
@@ -400,6 +403,72 @@ func TestGuardrailDefaultValues(t *testing.T) {
 	if engine.opts.MaxOutputSize != 1048576 {
 		t.Errorf("default MaxOutputSize: expected 1048576, got %d", engine.opts.MaxOutputSize)
 	}
+}
+
+func TestResolveLimitsNilFallsBackToDefaults(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "no-limits", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+	lim := engine.resolveLimits(cfg)
+	if lim.maxTurns != 25 { t.Errorf("expected maxTurns 25, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 50 { t.Errorf("expected maxSessionActions 50, got %d", lim.maxSessionActions) }
+	if lim.maxFiles != 50 { t.Errorf("expected maxFiles 50, got %d", lim.maxFiles) }
+	if lim.maxOutputSize != 1048576 { t.Errorf("expected maxOutputSize 1048576, got %d", lim.maxOutputSize) }
+}
+
+func TestResolveLimitsZeroFieldsFallBackToDefaults(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "zero", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{}}
+	lim := engine.resolveLimits(cfg)
+	if lim.maxTurns != 25 { t.Errorf("expected 25, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 50 { t.Errorf("expected 50, got %d", lim.maxSessionActions) }
+	if lim.maxFiles != 50 { t.Errorf("expected 50, got %d", lim.maxFiles) }
+	if lim.maxOutputSize != 1048576 { t.Errorf("expected 1048576, got %d", lim.maxOutputSize) }
+}
+
+func TestResolveLimitsConfigOverridesDefaults(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "custom", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10, MaxFiles: 20, MaxOutputSize: 524288, MaxSessionActions: 30}}
+	lim := engine.resolveLimits(cfg)
+	if lim.maxTurns != 10 { t.Errorf("expected 10, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 30 { t.Errorf("expected 30, got %d", lim.maxSessionActions) }
+	if lim.maxFiles != 20 { t.Errorf("expected 20, got %d", lim.maxFiles) }
+	if lim.maxOutputSize != 524288 { t.Errorf("expected 524288, got %d", lim.maxOutputSize) }
+}
+
+func TestResolveLimitsPartialOverride(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "partial", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10}}
+	lim := engine.resolveLimits(cfg)
+	if lim.maxTurns != 10 { t.Errorf("expected 10, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 50 { t.Errorf("expected 50, got %d", lim.maxSessionActions) }
+	if lim.maxFiles != 50 { t.Errorf("expected 50, got %d", lim.maxFiles) }
+	if lim.maxOutputSize != 1048576 { t.Errorf("expected 1048576, got %d", lim.maxOutputSize) }
+}
+
+func TestConfigLimitsRespectedByGuardrail(t *testing.T) {
+	outputDir := t.TempDir()
+	engine := NewEngine(&manyTurnsEvaluator{turnCount: 15}, quietOpts(EngineOptions{Workers: 1, OutputDir: outputDir, SkipReview: true}))
+	prompts := []*prompt.Prompt{{ID: "config-limit-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}}}
+	configs := []config.ToolConfig{{Name: "strict", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 5, MaxSessionActions: 99}}}
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	r := summary.Results[0]
+	if r.Success { t.Error("expected guardrail to fail") }
+	if !strings.Contains(r.GuardrailAbortReason, "turn count") { t.Errorf("expected turn count guardrail, got %q", r.GuardrailAbortReason) }
+	if r.GuardrailMaxTurns != 5 { t.Errorf("expected GuardrailMaxTurns 5, got %d", r.GuardrailMaxTurns) }
+	if r.GuardrailMaxSessionActions != 99 { t.Errorf("expected GuardrailMaxSessionActions 99, got %d", r.GuardrailMaxSessionActions) }
+}
+
+func TestConfigLimitsOverrideEngineDefaults(t *testing.T) {
+	outputDir := t.TempDir()
+	engine := NewEngine(&manyFilesEvaluator{fileCount: 10}, quietOpts(EngineOptions{Workers: 1, OutputDir: outputDir, SkipReview: true, MaxFiles: 100}))
+	prompts := []*prompt.Prompt{{ID: "override-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}}}
+	configs := []config.ToolConfig{{Name: "restrictive", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxFiles: 3}}}
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	r := summary.Results[0]
+	if r.Success { t.Error("expected config-level MaxFiles=3 to fail") }
+	if !strings.Contains(r.GuardrailAbortReason, "file count") { t.Errorf("expected file count guardrail, got %q", r.GuardrailAbortReason) }
 }
 
 // Integration-style: full stub eval lifecycle — verifies reports are generated and result is consistent.
@@ -459,11 +528,14 @@ func TestStubEvalLifecycle(t *testing.T) {
 	}
 
 	// Verify guardrail limits are recorded
-	if r.GuardrailMaxTurns != 50 {
-		t.Errorf("expected GuardrailMaxTurns 50, got %d", r.GuardrailMaxTurns)
+	if r.GuardrailMaxTurns != 25 {
+		t.Errorf("expected GuardrailMaxTurns 25, got %d", r.GuardrailMaxTurns)
 	}
 	if r.GuardrailMaxFiles != 50 {
 		t.Errorf("expected GuardrailMaxFiles 50, got %d", r.GuardrailMaxFiles)
+	}
+	if r.GuardrailMaxSessionActions != 50 {
+		t.Errorf("expected GuardrailMaxSessionActions 50, got %d", r.GuardrailMaxSessionActions)
 	}
 
 	// Verify report files exist on disk

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -101,11 +101,12 @@ type EvalReport struct {
 	FailureReason  string                `json:"failure_reason,omitempty"` // human-readable explanation of failure
 	IsStub         bool                  `json:"is_stub,omitempty"`
 	RerunCommand   string                `json:"rerunCommand,omitempty"`
-	// Generator guardrails (#35)
-	GuardrailMaxTurns      int    `json:"guardrail_max_turns,omitempty"`
-	GuardrailMaxFiles      int    `json:"guardrail_max_files,omitempty"`
-	GuardrailMaxOutputSize int64  `json:"guardrail_max_output_size,omitempty"`
-	GuardrailAbortReason   string `json:"guardrail_abort_reason,omitempty"`
+	// Generator guardrails (#35, #125)
+	GuardrailMaxTurns          int    `json:"guardrail_max_turns,omitempty"`
+	GuardrailMaxFiles          int    `json:"guardrail_max_files,omitempty"`
+	GuardrailMaxOutputSize     int64  `json:"guardrail_max_output_size,omitempty"`
+	GuardrailMaxSessionActions int    `json:"guardrail_max_session_actions,omitempty"`
+	GuardrailAbortReason       string `json:"guardrail_abort_reason,omitempty"`
 }
 
 // RunResourceStats holds aggregate resource utilization across all evals (#45).


### PR DESCRIPTION
## Summary

Wire per-config `SessionLimits` into the eval engine guardrail checks, replacing the current hardcoded defaults.

### Changes

- **`config.SessionLimits`** — New struct with `max_turns`, `max_files`, `max_output_size`, `max_session_actions` fields
- **`config.ToolConfig.Limits`** — Optional `*SessionLimits` field on each config
- **`eval.resolvedLimits`** — Merges config-level overrides with engine-level defaults
- **New turn count guardrail** — Counts `assistant.message` events as conversation turns (separate from action count)
- **Report field** — Added `guardrail_max_session_actions` to `EvalReport` for transparency

### Defaults (when config omits limits)

| Limit | Default |
|-------|---------|
| `max_turns` | 25 |
| `max_files` | 50 |
| `max_output_size` | 1048576 (1MB) |
| `max_session_actions` | 50 |

### Example config YAML

```yaml
configs:
  - name: strict-config
    generator:
      model: claude-opus-4.6
    limits:
      max_turns: 10
      max_files: 20
      max_output_size: 524288
      max_session_actions: 30
```

### Tests

- Config parsing: full, omitted, partial limits
- `resolveLimits`: nil fallback, zero fallback, full override, partial override
- Integration: config limits trigger guardrails, config overrides engine defaults

Closes #125