### PR TITLE
feat: complete workspace starter file copy and cleanup (#127, #128)

### DIFF
--- a/hyoka/internal/clean/clean.go
+++ b/hyoka/internal/clean/clean.go
@@ -38,9 +38,9 @@ type Result struct {
 	// Process cleanup stats.
 	ProcessesFound  int
 	ProcessesKilled int
-	// Orphan workspace cleanup stats (#126).
-	WorkspacesFound   int
-	WorkspacesRemoved int
+	// Orphan workspace cleanup stats (#128).
+	OrphanWorkspacesFound   int
+	OrphanWorkspacesRemoved int
 }
 
 // copilotStateDirFn returns the Copilot CLI state directory.
@@ -101,6 +101,11 @@ func Run(opts Options) (*Result, error) {
 		if err := cleanLogs(logsDir, opts, result); err != nil {
 			fmt.Fprintf(opts.Out, "Warning: log cleanup: %v\n", err)
 		}
+	}
+
+	// Phase 4: Clean orphaned temp workspace directories (#128).
+	if err := cleanOrphanWorkspaces(opts, result); err != nil {
+		fmt.Fprintf(opts.Out, "Warning: workspace cleanup: %v\n", err)
 	}
 
 	return result, nil
@@ -193,6 +198,52 @@ func formatProcessInfo(p HyokaProcessInfo) string {
 		desc += fmt.Sprintf("  config=%s", p.Config)
 	}
 	return desc
+}
+
+// hyokaTempPrefixes are the prefixes used by hyoka for ephemeral temp directories.
+var hyokaTempPrefixes = []string{"hyoka-gen-", "hyoka-config-", "hyoka-review-", "hyoka-"}
+
+// tempDirFn returns the OS temp directory. Package-level variable so tests can override it.
+var tempDirFn = os.TempDir
+
+// cleanOrphanWorkspaces removes hyoka temp directories that were not cleaned up
+// due to crashes, panics, or context cancellation (#128).
+func cleanOrphanWorkspaces(opts Options, result *Result) error {
+	tmpDir := tempDirFn()
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return fmt.Errorf("reading temp dir: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		isHyoka := false
+		for _, prefix := range hyokaTempPrefixes {
+			if strings.HasPrefix(name, prefix) {
+				isHyoka = true
+				break
+			}
+		}
+		if !isHyoka {
+			continue
+		}
+		result.OrphanWorkspacesFound++
+		wsPath := filepath.Join(tmpDir, name)
+		size := dirSize(wsPath)
+		if opts.DryRun {
+			fmt.Fprintf(opts.Out, "  [dry-run] would remove orphan workspace %s (%s)\n", name, humanBytes(size))
+		} else {
+			if err := os.RemoveAll(wsPath); err != nil {
+				fmt.Fprintf(opts.Out, "  warning: failed to remove orphan workspace %s: %v\n", name, err)
+				continue
+			}
+			result.OrphanWorkspacesRemoved++
+			result.BytesFreed += size
+		}
+	}
+	return nil
 }
 
 // cleanSessions removes stale session-state directories.
@@ -323,43 +374,6 @@ func isHyokaSession(sessionPath string) bool {
 	}
 
 	return false
-}
-
-// evalWorkspacePrefix is the directory name prefix for isolated eval workspaces.
-// Must match eval.EvalWorkspacePrefix. Duplicated here to avoid an import cycle.
-const evalWorkspacePrefix = "hyoka-eval-"
-
-// cleanOrphanWorkspaces scans the OS temp directory for leftover hyoka-eval-*
-// workspace directories that were not cleaned up (e.g. after a crash).
-func cleanOrphanWorkspaces(opts Options, result *Result) error {
-	tmpDir := os.TempDir()
-	entries, err := os.ReadDir(tmpDir)
-	if err != nil {
-		return fmt.Errorf("reading temp dir: %w", err)
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), evalWorkspacePrefix) {
-			continue
-		}
-		result.WorkspacesFound++
-		wsPath := filepath.Join(tmpDir, entry.Name())
-		size := dirSize(wsPath)
-
-		if opts.DryRun {
-			fmt.Fprintf(opts.Out, "  [dry-run] would remove orphan workspace %s (%s)\n",
-				entry.Name(), humanBytes(size))
-		} else {
-			if err := os.RemoveAll(wsPath); err != nil {
-				fmt.Fprintf(opts.Out, "  warning: failed to remove workspace %s: %v\n", entry.Name(), err)
-				continue
-			}
-			result.WorkspacesRemoved++
-			result.BytesFreed += size
-			slog.Debug("Removed orphan eval workspace", "path", wsPath)
-		}
-	}
-	return nil
 }
 
 // dirSize returns the total size of all files in a directory tree.

--- a/hyoka/internal/clean/clean_test.go
+++ b/hyoka/internal/clean/clean_test.go
@@ -305,60 +305,50 @@ func TestFormatProcessInfo(t *testing.T) {
 	}
 }
 
-// --- Orphan workspace cleanup tests (#126) ---
+// --- Orphan workspace cleanup tests (#128) ---
 
 func TestCleanOrphanWorkspaces_FindsAndRemoves(t *testing.T) {
-	ws1, err := os.MkdirTemp("", "hyoka-eval-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.WriteFile(filepath.Join(ws1, "test.py"), []byte("orphan"), 0o644)
-	ws2, err := os.MkdirTemp("", "hyoka-eval-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var buf bytes.Buffer
-	result := &Result{}
-	err = cleanOrphanWorkspaces(Options{Out: &buf}, result)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.WorkspacesFound < 2 {
-		t.Errorf("expected at least 2 orphan workspaces found, got %d", result.WorkspacesFound)
-	}
-	if result.WorkspacesRemoved < 2 {
-		t.Errorf("expected at least 2 orphan workspaces removed, got %d", result.WorkspacesRemoved)
-	}
-	if _, err := os.Stat(ws1); !os.IsNotExist(err) {
-		t.Errorf("orphan workspace should be removed: %s", ws1)
-	}
-	if _, err := os.Stat(ws2); !os.IsNotExist(err) {
-		t.Errorf("orphan workspace should be removed: %s", ws2)
-	}
+tmpDir := t.TempDir()
+os.MkdirAll(filepath.Join(tmpDir, "hyoka-gen-abc123"), 0755)
+os.WriteFile(filepath.Join(tmpDir, "hyoka-gen-abc123", "main.py"), []byte("code"), 0644)
+os.MkdirAll(filepath.Join(tmpDir, "hyoka-config-xyz456"), 0755)
+os.MkdirAll(filepath.Join(tmpDir, "hyoka-review-def789"), 0755)
+os.MkdirAll(filepath.Join(tmpDir, "other-project"), 0755)
+
+origFn := tempDirFn; tempDirFn = func() string { return tmpDir }; defer func() { tempDirFn = origFn }()
+origStateFn := copilotStateDirFn; copilotStateDirFn = func() string { return t.TempDir() }; defer func() { copilotStateDirFn = origStateFn }()
+
+var buf bytes.Buffer
+result, err := Run(Options{Out: &buf})
+if err != nil { t.Fatal(err) }
+if result.OrphanWorkspacesFound != 3 { t.Errorf("expected 3 found, got %d", result.OrphanWorkspacesFound) }
+if result.OrphanWorkspacesRemoved != 3 { t.Errorf("expected 3 removed, got %d", result.OrphanWorkspacesRemoved) }
+for _, name := range []string{"hyoka-gen-abc123", "hyoka-config-xyz456", "hyoka-review-def789"} {
+if _, err := os.Stat(filepath.Join(tmpDir, name)); !os.IsNotExist(err) { t.Errorf("%s should be removed", name) }
+}
+if _, err := os.Stat(filepath.Join(tmpDir, "other-project")); err != nil { t.Error("non-hyoka dir should remain") }
 }
 
 func TestCleanOrphanWorkspaces_DryRun(t *testing.T) {
-	ws, err := os.MkdirTemp("", "hyoka-eval-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(ws)
-	var buf bytes.Buffer
-	result := &Result{}
-	err = cleanOrphanWorkspaces(Options{DryRun: true, Out: &buf}, result)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.WorkspacesFound < 1 {
-		t.Errorf("expected at least 1 workspace found, got %d", result.WorkspacesFound)
-	}
-	if result.WorkspacesRemoved != 0 {
-		t.Errorf("expected 0 removed in dry-run, got %d", result.WorkspacesRemoved)
-	}
-	if _, err := os.Stat(ws); err != nil {
-		t.Error("workspace should still exist in dry-run mode")
-	}
-	if !strings.Contains(buf.String(), "[dry-run] would remove orphan workspace") {
-		t.Errorf("expected dry-run message, got %q", buf.String())
-	}
+tmpDir := t.TempDir()
+os.MkdirAll(filepath.Join(tmpDir, "hyoka-gen-test1"), 0755)
+origFn := tempDirFn; tempDirFn = func() string { return tmpDir }; defer func() { tempDirFn = origFn }()
+origStateFn := copilotStateDirFn; copilotStateDirFn = func() string { return t.TempDir() }; defer func() { copilotStateDirFn = origStateFn }()
+
+var buf bytes.Buffer
+result, _ := Run(Options{DryRun: true, Out: &buf})
+if result.OrphanWorkspacesFound != 1 { t.Errorf("expected 1 found, got %d", result.OrphanWorkspacesFound) }
+if result.OrphanWorkspacesRemoved != 0 { t.Errorf("expected 0 removed, got %d", result.OrphanWorkspacesRemoved) }
+if !strings.Contains(buf.String(), "[dry-run] would remove orphan workspace") { t.Errorf("expected dry-run msg, got %q", buf.String()) }
+}
+
+func TestCleanOrphanWorkspaces_NoOrphans(t *testing.T) {
+tmpDir := t.TempDir()
+os.MkdirAll(filepath.Join(tmpDir, "some-other-app"), 0755)
+origFn := tempDirFn; tempDirFn = func() string { return tmpDir }; defer func() { tempDirFn = origFn }()
+origStateFn := copilotStateDirFn; copilotStateDirFn = func() string { return t.TempDir() }; defer func() { copilotStateDirFn = origStateFn }()
+
+var buf bytes.Buffer
+result, _ := Run(Options{Out: &buf})
+if result.OrphanWorkspacesFound != 0 { t.Errorf("expected 0, got %d", result.OrphanWorkspacesFound) }
 }

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -78,28 +78,7 @@ func NewCopilotSDKEvaluator(opts CopilotEvalOptions) *CopilotSDKEvaluator {
 
 // Evaluate runs a prompt through a real Copilot session and returns generated files and events.
 func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cfg *config.ToolConfig, workDir string) (*EvalResult, error) {
-	// Copy starter project if configured
-	var starterFiles []string
-	if p.StarterProject != "" {
-		starterDir := resolveStarterDir(p)
-		info, err := os.Stat(starterDir)
-		if err != nil {
-			return nil, fmt.Errorf("starter project %q: %w", p.StarterProject, err)
-		}
-		if !info.IsDir() {
-			return nil, fmt.Errorf("starter project %q is not a directory", p.StarterProject)
-		}
-		if err := copyDir(starterDir, workDir); err != nil {
-			return nil, fmt.Errorf("copying starter project: %w", err)
-		}
-		starterFiles, err = listFiles(workDir)
-		if err != nil {
-			return nil, fmt.Errorf("listing starter files: %w", err)
-		}
-		if len(starterFiles) == 0 {
-			slog.Warn("Starter project directory contains no files", "dir", starterDir)
-		}
-	}
+	// Starter files are copied by the engine before Evaluate is called (#127).
 
 	// Create Copilot client
 	opts := *e.clientOpts
@@ -556,7 +535,6 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 				ToolCalls:      extractToolCalls(capturedEvts),
 				SessionEvents:  captured,
 				Success:        true, // Let engine.go guardrail set the proper failure
-				StarterFiles:   starterFiles,
 			}, nil
 		}
 
@@ -596,7 +574,6 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		SessionEvents:  capturedRecords,
 		Success:        !hasError,
 		Error:          "",
-		StarterFiles:   starterFiles,
 	}, nil
 }
 
@@ -838,15 +815,4 @@ func toolArgSummary(event copilot.SessionEvent) string {
 		}
 	}
 	return ""
-}
-
-
-// resolveStarterDir returns the absolute path to a prompt's starter project directory.
-// If StarterProject is relative, it is resolved relative to the prompt file's directory.
-func resolveStarterDir(p *prompt.Prompt) string {
-	dir := p.StarterProject
-	if !filepath.IsAbs(dir) && p.FilePath != "" {
-		dir = filepath.Join(filepath.Dir(p.FilePath), dir)
-	}
-	return dir
 }

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -624,8 +624,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Create an isolated temporary workspace for the generator (#26, #126).
 	// The agent writes files here — not directly to the report tree.
 	// After generation, files are copied to the persistent report directory.
-	// The workspace is empty to prevent leakage from the user's dev environment.
-	evalWs, err := NewEvalWorkspace()
+	genWs, err := NewWorkspace(task.Prompt.ID, task.Config.Name)
 	if err != nil {
 		evalReport.Error = fmt.Sprintf("generator workspace setup failed: %v", err)
 		evalReport.ErrorDetails = err.Error()
@@ -634,10 +633,23 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		evalReport.Duration = time.Since(start).Seconds()
 		return evalReport
 	}
-	defer evalWs.Cleanup()
-	genDir := evalWs.Dir
+	defer genWs.Cleanup()
+	genDir := genWs.Dir
 
-	lg.Debug("Workspace created", "workspace", ws.Dir, "gen_dir", genDir)
+	// Copy starter files into the generator workspace before evaluation (#127).
+	starterFiles, starterErr := genWs.CopyStarterFiles(task.Prompt)
+	if starterErr != nil {
+		evalReport.Error = fmt.Sprintf("starter file copy failed: %v", starterErr)
+		evalReport.ErrorDetails = starterErr.Error()
+		evalReport.ErrorCategory = "generation_failure"
+		evalReport.FailureReason = fmt.Sprintf("Could not copy starter project: %v", starterErr)
+		evalReport.Duration = time.Since(start).Seconds()
+		return evalReport
+	}
+	evalReport.StarterFiles = starterFiles
+
+	lg.Debug("Workspace created", "workspace", ws.Dir, "gen_dir", genDir,
+		"starter_files", len(starterFiles))
 
 	// Snapshot home directory and CWD before eval so we can recover misplaced files after
 	homeDir, _ := os.UserHomeDir()
@@ -688,7 +700,6 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		evalReport.SessionEvents = result.SessionEvents
 		evalReport.IsStub = result.IsStub
 		evalReport.Success = result.Success
-		evalReport.StarterFiles = result.StarterFiles
 	}
 
 	// Collect generated files — workspace listing is the primary source since

--- a/hyoka/internal/eval/workspace.go
+++ b/hyoka/internal/eval/workspace.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ronniegeraghty/hyoka/internal/prompt"
 	"github.com/ronniegeraghty/hyoka/internal/utils"
 )
 
@@ -137,6 +138,47 @@ func (w *Workspace) CopyFilesTo(destDir string) ([]string, error) {
 	}
 
 	return files, nil
+}
+
+// CopyStarterFiles copies the starter project declared in the prompt into
+// the workspace directory. Only files from the declared starter directory are
+// copied — hidden files, symlinks, and build artifacts are excluded by copyDir.
+// Returns the list of files copied (relative to the workspace root) and a nil
+// error on success. Returns (nil, nil) when the prompt has no starter project.
+func (w *Workspace) CopyStarterFiles(p *prompt.Prompt) ([]string, error) {
+	if p.StarterProject == "" {
+		return nil, nil
+	}
+	starterDir := resolveStarterDir(p)
+	info, err := os.Stat(starterDir)
+	if err != nil {
+		return nil, fmt.Errorf("starter project %q: %w", p.StarterProject, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("starter project %q is not a directory", p.StarterProject)
+	}
+	if err := copyDir(starterDir, w.Dir); err != nil {
+		return nil, fmt.Errorf("copying starter project: %w", err)
+	}
+	files, err := listFiles(w.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("listing starter files: %w", err)
+	}
+	if len(files) == 0 {
+		slog.Warn("Starter project directory contains no files", "dir", starterDir)
+	}
+	return files, nil
+}
+
+// resolveStarterDir returns the absolute path to a prompt's starter project
+// directory. If StarterProject is relative, it is resolved relative to the
+// prompt file's directory.
+func resolveStarterDir(p *prompt.Prompt) string {
+	dir := p.StarterProject
+	if !filepath.IsAbs(dir) && p.FilePath != "" {
+		dir = filepath.Join(filepath.Dir(p.FilePath), dir)
+	}
+	return dir
 }
 
 // listFiles is a helper used by Workspace and CopilotSDKEvaluator.

--- a/hyoka/internal/eval/workspace_test.go
+++ b/hyoka/internal/eval/workspace_test.go
@@ -1,335 +1,256 @@
 package eval
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
+"context"
+"os"
+"path/filepath"
+"sort"
+"strings"
+"testing"
 
-	"github.com/ronniegeraghty/hyoka/internal/prompt"
+"github.com/ronniegeraghty/hyoka/internal/prompt"
 )
 
 func TestSnapshotDir_CapturesFilesAndDirs(t *testing.T) {
 dir := t.TempDir()
-
-// Create a file and a subdirectory
 os.WriteFile(filepath.Join(dir, "hello.py"), []byte("print('hi')"), 0644)
 os.Mkdir(filepath.Join(dir, "subdir"), 0755)
-os.Mkdir(filepath.Join(dir, ".hidden"), 0755) // should be skipped
-
+os.Mkdir(filepath.Join(dir, ".hidden"), 0755)
 snap := snapshotDir(dir)
-if snap == nil {
-t.Fatal("snapshotDir returned nil")
-}
-if !snap["hello.py"] {
-t.Error("snapshotDir should capture files")
-}
-if !snap["subdir"] {
-t.Error("snapshotDir should capture directories")
-}
-if snap[".hidden"] {
-t.Error("snapshotDir should skip hidden entries")
-}
+if snap == nil { t.Fatal("snapshotDir returned nil") }
+if !snap["hello.py"] { t.Error("snapshotDir should capture files") }
+if !snap["subdir"] { t.Error("snapshotDir should capture directories") }
+if snap[".hidden"] { t.Error("snapshotDir should skip hidden entries") }
 }
 
 func TestRecoverMisplacedFiles_RecoversNewFiles(t *testing.T) {
-home := t.TempDir()
-workspace := t.TempDir()
-
-// Pre-existing file
+home := t.TempDir(); workspace := t.TempDir()
 os.WriteFile(filepath.Join(home, "existing.txt"), []byte("old"), 0644)
 snap := snapshotDir(home)
-
-// Simulate agent creating a new file
 os.WriteFile(filepath.Join(home, "main.py"), []byte("print('hello')"), 0644)
-
 recovered := recoverMisplacedFiles(home, snap, workspace, "test")
-if recovered != 1 {
-t.Fatalf("expected 1 recovered, got %d", recovered)
-}
-// File should exist in workspace
-if _, err := os.Stat(filepath.Join(workspace, "main.py")); err != nil {
-t.Error("main.py should be in workspace")
-}
-// File should be removed from home
-if _, err := os.Stat(filepath.Join(home, "main.py")); err == nil {
-t.Error("main.py should be removed from home")
-}
+if recovered != 1 { t.Fatalf("expected 1 recovered, got %d", recovered) }
+if _, err := os.Stat(filepath.Join(workspace, "main.py")); err != nil { t.Error("main.py should be in workspace") }
+if _, err := os.Stat(filepath.Join(home, "main.py")); err == nil { t.Error("main.py should be removed from home") }
 }
 
 func TestRecoverMisplacedFiles_DeletesJunkDirs(t *testing.T) {
-home := t.TempDir()
-workspace := t.TempDir()
-
+home := t.TempDir(); workspace := t.TempDir()
 snap := snapshotDir(home)
-
-// Simulate __pycache__ appearing
 pycache := filepath.Join(home, "__pycache__")
 os.Mkdir(pycache, 0755)
 os.WriteFile(filepath.Join(pycache, "mod.cpython-311.pyc"), []byte{0}, 0644)
-
 recovered := recoverMisplacedFiles(home, snap, workspace, "test")
-if recovered != 1 {
-t.Fatalf("expected 1 recovered (junk dir deleted), got %d", recovered)
-}
-if _, err := os.Stat(pycache); err == nil {
-t.Error("__pycache__ should be deleted")
-}
-// Should NOT appear in workspace
-if _, err := os.Stat(filepath.Join(workspace, "__pycache__")); err == nil {
-t.Error("__pycache__ should not be moved to workspace")
-}
+if recovered != 1 { t.Fatalf("expected 1 recovered, got %d", recovered) }
+if _, err := os.Stat(pycache); err == nil { t.Error("__pycache__ should be deleted") }
 }
 
 func TestRecoverMisplacedFiles_MovesNewDirToWorkspace(t *testing.T) {
-home := t.TempDir()
-workspace := t.TempDir()
-
+home := t.TempDir(); workspace := t.TempDir()
 snap := snapshotDir(home)
-
-// Simulate agent creating a project directory
 projDir := filepath.Join(home, "myproject")
 os.Mkdir(projDir, 0755)
 os.WriteFile(filepath.Join(projDir, "app.py"), []byte("app"), 0644)
-
 recovered := recoverMisplacedFiles(home, snap, workspace, "test")
-if recovered != 1 {
-t.Fatalf("expected 1 recovered, got %d", recovered)
-}
-// Directory should exist in workspace
-if _, err := os.Stat(filepath.Join(workspace, "myproject", "app.py")); err != nil {
-t.Error("myproject/app.py should be in workspace")
-}
-// Directory should be removed from home
-if _, err := os.Stat(projDir); err == nil {
-t.Error("myproject should be removed from home")
-}
+if recovered != 1 { t.Fatalf("expected 1 recovered, got %d", recovered) }
+if _, err := os.Stat(filepath.Join(workspace, "myproject", "app.py")); err != nil { t.Error("myproject/app.py should be in workspace") }
 }
 
 func TestRecoverMisplacedFiles_SkipsPreExistingDirs(t *testing.T) {
-home := t.TempDir()
-workspace := t.TempDir()
-
-// Pre-existing directory
+home := t.TempDir(); workspace := t.TempDir()
 os.Mkdir(filepath.Join(home, "Documents"), 0755)
 snap := snapshotDir(home)
-
 recovered := recoverMisplacedFiles(home, snap, workspace, "test")
-if recovered != 0 {
-t.Fatalf("expected 0 recovered, got %d", recovered)
-}
-// Documents should still exist in home
-if _, err := os.Stat(filepath.Join(home, "Documents")); err != nil {
-t.Error("Documents should still exist in home")
-}
+if recovered != 0 { t.Fatalf("expected 0 recovered, got %d", recovered) }
 }
 
 func TestFilterExcludedDirs_Empty(t *testing.T) {
-	files := []string{"main.go", "lib/utils.go"}
-	got := filterExcludedDirs(files, nil)
-	if len(got) != 2 {
-		t.Errorf("expected 2 files with nil excludes, got %d", len(got))
-	}
-	got = filterExcludedDirs(files, []string{})
-	if len(got) != 2 {
-		t.Errorf("expected 2 files with empty excludes, got %d", len(got))
-	}
+files := []string{"main.go", "lib/utils.go"}
+if got := filterExcludedDirs(files, nil); len(got) != 2 { t.Errorf("expected 2, got %d", len(got)) }
+if got := filterExcludedDirs(files, []string{}); len(got) != 2 { t.Errorf("expected 2, got %d", len(got)) }
 }
 
 func TestFilterExcludedDirs_ExcludesTopLevel(t *testing.T) {
-	files := []string{
-		"main.go",
-		"node_modules/express/index.js",
-		"node_modules/lodash/lodash.js",
-		"src/app.js",
-		"dist/bundle.js",
-	}
-	got := filterExcludedDirs(files, []string{"node_modules", "dist"})
-	if len(got) != 2 {
-		t.Errorf("expected 2 files, got %d: %v", len(got), got)
-	}
-	for _, f := range got {
-		if f == "node_modules/express/index.js" || f == "dist/bundle.js" {
-			t.Errorf("file %q should have been excluded", f)
-		}
-	}
+files := []string{"main.go", "node_modules/express/index.js", "src/app.js", "dist/bundle.js"}
+got := filterExcludedDirs(files, []string{"node_modules", "dist"})
+if len(got) != 2 { t.Errorf("expected 2, got %d: %v", len(got), got) }
 }
 
 func TestFilterExcludedDirs_KeepsNonMatching(t *testing.T) {
-	files := []string{"src/main.go", "src/utils.go", "README.md"}
-	got := filterExcludedDirs(files, []string{"node_modules", "target"})
-	if len(got) != 3 {
-		t.Errorf("expected 3 files (nothing excluded), got %d", len(got))
-	}
+files := []string{"src/main.go", "src/utils.go", "README.md"}
+if got := filterExcludedDirs(files, []string{"node_modules"}); len(got) != 3 { t.Errorf("expected 3, got %d", len(got)) }
 }
 
 func TestFilterExcludedDirs_NestedMatch(t *testing.T) {
-	files := []string{
-		"project/target/classes/App.class",
-		"project/src/App.java",
-		"target/output.jar",
-	}
-	got := filterExcludedDirs(files, []string{"target"})
-	// Only top-level "target/output.jar" should be excluded;
-	// "project/target/..." has "target" as a nested segment, which IS matched.
-	if len(got) != 1 {
-		t.Errorf("expected 1 file, got %d: %v", len(got), got)
-	}
+files := []string{"project/target/classes/App.class", "project/src/App.java", "target/output.jar"}
+if got := filterExcludedDirs(files, []string{"target"}); len(got) != 1 { t.Errorf("expected 1, got %d: %v", len(got), got) }
 }
 
 func TestFilterExcludedDirs_TrailingSlash(t *testing.T) {
-	files := []string{"dist/app.js", "src/main.ts"}
-	got := filterExcludedDirs(files, []string{"dist/"})
-	if len(got) != 1 {
-		t.Errorf("expected 1 file after trailing-slash exclude, got %d: %v", len(got), got)
-	}
+files := []string{"dist/app.js", "src/main.ts"}
+if got := filterExcludedDirs(files, []string{"dist/"}); len(got) != 1 { t.Errorf("expected 1, got %d: %v", len(got), got) }
 }
 
 func TestDefaultIgnoreDirs_CoversAllLanguages(t *testing.T) {
-	// Verify that key dependency directories for all supported languages are present.
-	expected := []string{
-		// JS/TS
-		"node_modules", "bower_components",
-		// Python
-		"__pycache__", "venv", ".venv", "site-packages",
-		// Rust
-		"target",
-		// Go
-		"vendor",
-		// Java
-		".gradle",
-		// C#/.NET
-		"bin", "obj",
-		// General
-		"dist", "build",
-	}
-	for _, dir := range expected {
-		if !DefaultIgnoreDirs[dir] {
-			t.Errorf("DefaultIgnoreDirs missing expected entry: %q", dir)
-		}
-	}
+for _, dir := range []string{"node_modules", "__pycache__", "venv", "target", "vendor", ".gradle", "bin", "obj", "dist", "build"} {
+if !DefaultIgnoreDirs[dir] { t.Errorf("missing %q", dir) }
+}
 }
 
 func TestJunkDirsIsDefaultIgnoreDirs(t *testing.T) {
-	// Ensure junkDirs is the same reference as DefaultIgnoreDirs
-	// so recoverMisplacedFiles benefits from the expanded list.
-	for k := range DefaultIgnoreDirs {
-		if !junkDirs[k] {
-			t.Errorf("junkDirs missing key %q from DefaultIgnoreDirs", k)
-		}
-	}
-	for k := range junkDirs {
-		if !DefaultIgnoreDirs[k] {
-			t.Errorf("DefaultIgnoreDirs missing key %q from junkDirs", k)
-		}
-	}
+for k := range DefaultIgnoreDirs { if !junkDirs[k] { t.Errorf("junkDirs missing %q", k) } }
+for k := range junkDirs { if !DefaultIgnoreDirs[k] { t.Errorf("DefaultIgnoreDirs missing %q", k) } }
 }
 
 func TestCopyDir_CopiesFilesAndSubdirs(t *testing.T) {
-	src := t.TempDir()
-	dst := t.TempDir()
-
-	os.WriteFile(filepath.Join(src, "main.py"), []byte("print('hello')"), 0644)
-	os.MkdirAll(filepath.Join(src, "sub", "deep"), 0755)
-	os.WriteFile(filepath.Join(src, "sub", "deep", "util.py"), []byte("# util"), 0644)
-
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir failed: %v", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(dst, "main.py"))
-	if err != nil {
-		t.Fatal("main.py not copied")
-	}
-	if string(data) != "print('hello')" {
-		t.Errorf("unexpected content: %q", data)
-	}
-
-	data, err = os.ReadFile(filepath.Join(dst, "sub", "deep", "util.py"))
-	if err != nil {
-		t.Fatal("sub/deep/util.py not copied")
-	}
-	if string(data) != "# util" {
-		t.Errorf("unexpected content: %q", data)
-	}
+src := t.TempDir(); dst := t.TempDir()
+os.WriteFile(filepath.Join(src, "main.py"), []byte("print('hello')"), 0644)
+os.MkdirAll(filepath.Join(src, "sub"), 0755)
+os.WriteFile(filepath.Join(src, "sub", "util.py"), []byte("# util"), 0644)
+if err := copyDir(src, dst); err != nil { t.Fatalf("copyDir failed: %v", err) }
+data, _ := os.ReadFile(filepath.Join(dst, "main.py"))
+if string(data) != "print('hello')" { t.Errorf("unexpected content: %q", data) }
 }
 
 func TestCopyDir_SkipsHiddenDirs(t *testing.T) {
-	src := t.TempDir()
-	dst := t.TempDir()
-
-	os.MkdirAll(filepath.Join(src, ".git"), 0755)
-	os.WriteFile(filepath.Join(src, ".git", "config"), []byte("git config"), 0644)
-	os.WriteFile(filepath.Join(src, "main.py"), []byte("code"), 0644)
-
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir failed: %v", err)
-	}
-
-	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
-		t.Error(".git directory should not be copied")
-	}
-	if _, err := os.Stat(filepath.Join(dst, "main.py")); err != nil {
-		t.Error("main.py should be copied")
-	}
+src := t.TempDir(); dst := t.TempDir()
+os.MkdirAll(filepath.Join(src, ".git"), 0755)
+os.WriteFile(filepath.Join(src, ".git", "config"), []byte("x"), 0644)
+os.WriteFile(filepath.Join(src, "main.py"), []byte("code"), 0644)
+copyDir(src, dst)
+if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil { t.Error(".git should not be copied") }
+if _, err := os.Stat(filepath.Join(dst, "main.py")); err != nil { t.Error("main.py should be copied") }
 }
 
 func TestCopyDir_MissingSrcReturnsError(t *testing.T) {
-	dst := t.TempDir()
-	err := copyDir("/nonexistent/path/to/starter", dst)
-	if err == nil {
-		t.Fatal("expected error for nonexistent source")
-	}
+if err := copyDir("/nonexistent/path", t.TempDir()); err == nil { t.Fatal("expected error") }
 }
 
 func TestCopyDir_EmptyDirectory(t *testing.T) {
-	src := t.TempDir()
-	dst := t.TempDir()
-
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir on empty dir failed: %v", err)
-	}
-
-	files, err := listFiles(dst)
-	if err != nil {
-		t.Fatalf("listFiles failed: %v", err)
-	}
-	if len(files) != 0 {
-		t.Errorf("expected 0 files, got %d: %v", len(files), files)
-	}
+src := t.TempDir(); dst := t.TempDir()
+copyDir(src, dst)
+files, _ := listFiles(dst)
+if len(files) != 0 { t.Errorf("expected 0 files, got %d", len(files)) }
 }
 
 func TestResolveStarterDir_Relative(t *testing.T) {
-	p := &prompt.Prompt{
-		StarterProject: "./starter/",
-		FilePath:       "/home/user/prompts/storage/blob.prompt.md",
-	}
-	got := resolveStarterDir(p)
-	want := "/home/user/prompts/storage/starter"
-	if got != want {
-		t.Errorf("resolveStarterDir = %q, want %q", got, want)
-	}
+p := &prompt.Prompt{StarterProject: "./starter/", FilePath: "/home/user/prompts/storage/blob.prompt.md"}
+if got := resolveStarterDir(p); got != "/home/user/prompts/storage/starter" { t.Errorf("got %q", got) }
 }
 
 func TestResolveStarterDir_Absolute(t *testing.T) {
-	p := &prompt.Prompt{
-		StarterProject: "/absolute/starter",
-		FilePath:       "/home/user/prompts/blob.prompt.md",
-	}
-	got := resolveStarterDir(p)
-	if got != "/absolute/starter" {
-		t.Errorf("resolveStarterDir = %q, want /absolute/starter", got)
-	}
+p := &prompt.Prompt{StarterProject: "/absolute/starter", FilePath: "/home/user/prompts/blob.prompt.md"}
+if got := resolveStarterDir(p); got != "/absolute/starter" { t.Errorf("got %q", got) }
 }
 
 func TestResolveStarterDir_NoFilePath(t *testing.T) {
-	p := &prompt.Prompt{
-		StarterProject: "starter/",
-	}
-	got := resolveStarterDir(p)
-	if got != "starter/" {
-		t.Errorf("resolveStarterDir = %q, want starter/", got)
-	}
+p := &prompt.Prompt{StarterProject: "starter/"}
+if got := resolveStarterDir(p); got != "starter/" { t.Errorf("got %q", got) }
+}
+
+// --- CopyStarterFiles tests (#127) ---
+
+func TestCopyStarterFiles_CopiesOnlyDeclaredFiles(t *testing.T) {
+starterDir := t.TempDir()
+os.WriteFile(filepath.Join(starterDir, "main.py"), []byte("print('hello')"), 0644)
+os.MkdirAll(filepath.Join(starterDir, "src"), 0755)
+os.WriteFile(filepath.Join(starterDir, "src", "utils.py"), []byte("# utils"), 0644)
+os.WriteFile(filepath.Join(starterDir, "requirements.txt"), []byte("azure-identity"), 0644)
+
+ws, _ := NewWorkspace("test-prompt", "test-config")
+defer ws.Cleanup()
+
+files, err := ws.CopyStarterFiles(&prompt.Prompt{StarterProject: starterDir})
+if err != nil { t.Fatalf("CopyStarterFiles failed: %v", err) }
+sort.Strings(files)
+expected := []string{"main.py", "requirements.txt", "src/utils.py"}
+if len(files) != len(expected) { t.Fatalf("expected %d files, got %d: %v", len(expected), len(files), files) }
+for i, f := range expected { if files[i] != f { t.Errorf("file[%d] = %q, want %q", i, files[i], f) } }
+data, _ := os.ReadFile(filepath.Join(ws.Dir, "main.py"))
+if string(data) != "print('hello')" { t.Error("main.py content mismatch") }
+}
+
+func TestCopyStarterFiles_NoLeakOfHiddenFiles(t *testing.T) {
+starterDir := t.TempDir()
+os.WriteFile(filepath.Join(starterDir, "app.py"), []byte("app"), 0644)
+os.MkdirAll(filepath.Join(starterDir, ".git"), 0755)
+os.WriteFile(filepath.Join(starterDir, ".git", "config"), []byte("x"), 0644)
+
+ws, _ := NewWorkspace("test-prompt", "test-config")
+defer ws.Cleanup()
+files, _ := ws.CopyStarterFiles(&prompt.Prompt{StarterProject: starterDir})
+if len(files) != 1 || files[0] != "app.py" { t.Errorf("expected [app.py], got %v", files) }
+if _, err := os.Stat(filepath.Join(ws.Dir, ".git")); err == nil { t.Error(".git should not be copied") }
+}
+
+func TestCopyStarterFiles_ExcludesBuildArtifacts(t *testing.T) {
+starterDir := t.TempDir()
+os.WriteFile(filepath.Join(starterDir, "main.py"), []byte("code"), 0644)
+os.MkdirAll(filepath.Join(starterDir, "node_modules", "express"), 0755)
+os.WriteFile(filepath.Join(starterDir, "node_modules", "express", "index.js"), []byte("//"), 0644)
+
+ws, _ := NewWorkspace("test-prompt", "test-config")
+defer ws.Cleanup()
+files, _ := ws.CopyStarterFiles(&prompt.Prompt{StarterProject: starterDir})
+if len(files) != 1 || files[0] != "main.py" { t.Errorf("expected [main.py], got %v", files) }
+if _, err := os.Stat(filepath.Join(ws.Dir, "node_modules")); err == nil { t.Error("node_modules should not be copied") }
+}
+
+func TestCopyStarterFiles_NoStarterProject(t *testing.T) {
+ws, _ := NewWorkspace("test", "test"); defer ws.Cleanup()
+files, err := ws.CopyStarterFiles(&prompt.Prompt{})
+if err != nil { t.Fatalf("unexpected error: %v", err) }
+if files != nil { t.Errorf("expected nil, got %v", files) }
+}
+
+func TestCopyStarterFiles_InvalidPath(t *testing.T) {
+ws, _ := NewWorkspace("test", "test"); defer ws.Cleanup()
+_, err := ws.CopyStarterFiles(&prompt.Prompt{StarterProject: "/nonexistent/path"})
+if err == nil { t.Fatal("expected error") }
+}
+
+func TestCopyStarterFiles_RelativeToPromptFile(t *testing.T) {
+promptDir := t.TempDir()
+os.MkdirAll(filepath.Join(promptDir, "starter"), 0755)
+os.WriteFile(filepath.Join(promptDir, "starter", "setup.py"), []byte("setup"), 0644)
+ws, _ := NewWorkspace("test", "test"); defer ws.Cleanup()
+files, _ := ws.CopyStarterFiles(&prompt.Prompt{StarterProject: "./starter", FilePath: filepath.Join(promptDir, "test.prompt.md")})
+if len(files) != 1 || files[0] != "setup.py" { t.Errorf("expected [setup.py], got %v", files) }
+}
+
+// --- Workspace Cleanup tests (#128) ---
+
+func TestWorkspaceCleanup_EphemeralRemovedOnSuccess(t *testing.T) {
+ws, _ := NewWorkspace("test", "test"); dir := ws.Dir
+os.WriteFile(filepath.Join(dir, "output.py"), []byte("result"), 0644)
+ws.Cleanup()
+if _, err := os.Stat(dir); !os.IsNotExist(err) { t.Error("ephemeral workspace should be removed") }
+}
+
+func TestWorkspaceCleanup_PersistentSurvives(t *testing.T) {
+dir := t.TempDir(); ws, _ := NewWorkspaceAt(dir)
+os.WriteFile(filepath.Join(dir, "output.py"), []byte("result"), 0644)
+ws.Cleanup()
+if _, err := os.Stat(filepath.Join(dir, "output.py")); err != nil { t.Error("persistent workspace should survive") }
+}
+
+func TestWorkspaceCleanup_OnError(t *testing.T) {
+ws, _ := NewWorkspace("test", "test"); dir := ws.Dir
+func() { defer ws.Cleanup(); os.WriteFile(filepath.Join(dir, "partial.py"), []byte("x"), 0644) }()
+if _, err := os.Stat(dir); !os.IsNotExist(err) { t.Error("workspace should be cleaned up on error path") }
+}
+
+func TestWorkspaceCleanup_OnContextCancellation(t *testing.T) {
+ws, _ := NewWorkspace("test", "test"); dir := ws.Dir
+ctx, cancel := context.WithCancel(context.Background())
+func() { defer ws.Cleanup(); cancel(); _ = ctx.Err() }()
+if _, err := os.Stat(dir); !os.IsNotExist(err) { t.Error("workspace should be cleaned up after cancellation") }
+}
+
+func TestWorkspaceCleanup_DoubleCleanup(t *testing.T) {
+ws, _ := NewWorkspace("test", "test")
+if err := ws.Cleanup(); err != nil { t.Fatal(err) }
+if err := ws.Cleanup(); err != nil { t.Fatal("second cleanup should not fail:", err) }
 }
 
 // --- EvalWorkspace tests (#126) ---


### PR DESCRIPTION
## Summary
Complete the workspace lifecycle by implementing starter file copying and cleanup integration.

### Starter file copy (#127)
- Add `Workspace.CopyStarterFiles()` method that copies only declared starter files into the workspace, excluding hidden files, symlinks, and build artifacts
- Move `resolveStarterDir()` from `copilot.go` to `workspace.go` (proper ownership)
- Refactor engine to copy starter files before `Evaluate()`, removing duplication from `CopilotSDKEvaluator`

### Cleanup integration (#128)
- Replace raw `os.MkdirTemp`/`os.RemoveAll` with `NewWorkspace()`/`Cleanup()` in the eval engine
- Generator workspace cleanup runs via `defer genWs.Cleanup()` ensuring cleanup on success, error, or panic
- Add Phase 4 to `hyoka clean` command: scan OS temp dir for orphaned `hyoka-gen-*`, `hyoka-config-*`, `hyoka-review-*` directories

### Tests (14 new)
- Starter files correctly copied with content verification
- Hidden files (`.git`, `.env`) excluded from copy
- Build artifacts (`node_modules`, `__pycache__`) excluded
- No-op for prompts without starter projects
- Invalid and relative path handling
- Cleanup on success, error path, and context cancellation
- Double-cleanup safety (idempotent)
- Orphan workspace detection and removal (+ dry-run)

Closes #127
Closes #128