### PR TITLE
feat: wire grader execution into eval engine (#136)

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ronniegeraghty/hyoka/internal/config"
 	"github.com/ronniegeraghty/hyoka/internal/criteria"
+	"github.com/ronniegeraghty/hyoka/internal/graders"
 	"github.com/ronniegeraghty/hyoka/internal/logging"
 	"github.com/ronniegeraghty/hyoka/internal/progress"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
@@ -88,6 +89,8 @@ type EngineOptions struct {
 	MonitorResources bool
 	// Tiered criteria (#30)
 	CriteriaDir string // Directory containing attribute-matched criteria YAML files.
+	// Pluggable graders (#136)
+	GradersDir string // Directory containing grader config YAML files.
 	// Directory exclusion (#63)
 	ExcludeDirs []string // Directories to exclude from generated_files output.
 	// Output writer for user-facing messages (defaults to os.Stdout).
@@ -104,6 +107,7 @@ type Engine struct {
 	opts            EngineOptions
 	tracker         *ProcessTracker
 	graderConfigs   []criteria.GraderConfig // attribute-matched grader configs (#30)
+	pluginGraders   []graders.GraderConfig  // pluggable grader configs (#136)
 }
 
 // NewEngine creates a new Engine with the given evaluator and options.
@@ -196,6 +200,24 @@ func (e *Engine) loadCriteria() {
 	slog.Info("Loaded grader configs", "configs", len(configs), "dir", e.opts.CriteriaDir)
 }
 
+// loadGraders loads pluggable grader configs if GradersDir is configured (#136).
+func (e *Engine) loadGraders() {
+	if e.opts.GradersDir == "" {
+		return
+	}
+	if _, err := os.Stat(e.opts.GradersDir); os.IsNotExist(err) {
+		slog.Debug("Graders directory does not exist, skipping", "dir", e.opts.GradersDir)
+		return
+	}
+	gcf, err := graders.LoadDir(e.opts.GradersDir)
+	if err != nil {
+		slog.Warn("Failed to load grader configs", "dir", e.opts.GradersDir, "error", err)
+		return
+	}
+	e.pluginGraders = gcf.Graders
+	slog.Info("Loaded pluggable grader configs", "graders", len(gcf.Graders), "dir", e.opts.GradersDir)
+}
+
 // mergedCriteria returns the combined attribute-matched + prompt-specific
 // evaluation criteria text for the given prompt.
 func (e *Engine) mergedCriteria(p *prompt.Prompt) string {
@@ -270,6 +292,9 @@ func (e *Engine) resolveLimits(cfg config.ToolConfig) resolvedLimits {
 func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []config.ToolConfig) (*report.RunSummary, error) {
 	// Load grader configs (#30) if configured.
 	e.loadCriteria()
+
+	// Load pluggable grader configs (#136) if configured.
+	e.loadGraders()
 
 	// Build task list (cross product: prompts × configs)
 	var tasks []EvalTask
@@ -896,6 +921,72 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		}
 	}
 
+	// Pluggable grader execution (#136) — runs after generation, before review.
+	if len(e.pluginGraders) > 0 && len(generatedFiles) > 0 {
+		glg := logging.WithPhase(lg, "grading")
+
+		props := map[string]string{
+			"language": task.Prompt.Language(),
+			"service":  task.Prompt.Service(),
+			"plane":    task.Prompt.Plane(),
+			"category": task.Prompt.Category(),
+			"sdk":      task.Prompt.SDKPackage(),
+		}
+
+		applicable := graders.ApplicableGraders(e.pluginGraders, props)
+		glg.Debug("Applicable graders", "total", len(e.pluginGraders), "applicable", len(applicable))
+
+		if len(applicable) > 0 {
+			instances, err := graders.InstantiateGraders(applicable)
+			if err != nil {
+				glg.Error("Failed to instantiate graders", "error", err)
+			} else {
+				input := graders.GraderInput{
+					WorkspacePath: genWs.Dir,
+				}
+
+				results := graders.RunGraders(ctx, instances, applicable, input)
+				agg, aggErr := graders.AggregateResults(results)
+				if aggErr != nil {
+					glg.Error("Failed to aggregate grader results", "error", aggErr)
+				} else {
+					reportResults := make([]report.GraderResultEntry, len(agg.Results))
+					for i, r := range agg.Results {
+						reportResults[i] = report.GraderResultEntry{
+							Name:    r.Name,
+							Kind:    r.Kind,
+							Passed:  r.Pass,
+							Score:   r.Score,
+							Message: r.Message,
+							Weight:  r.Weight,
+							Gate:    r.Gate,
+						}
+					}
+					evalReport.GraderResults = &report.GraderAggregateEntry{
+						Results: reportResults,
+						Score:   agg.Score,
+						Passed:  agg.Pass,
+					}
+
+					if !agg.Pass && !evalFailed {
+						evalReport.Success = false
+						if agg.GateFailed {
+							evalReport.FailureReason = "gate grader(s) failed"
+						}
+					}
+
+					glg.Info("Grader execution complete",
+						"graders", len(results),
+						"score", fmt.Sprintf("%.2f", agg.Score),
+						"passed", agg.Pass,
+						"gate_failed", agg.GateFailed)
+					sendEvent(progress.EventToolComplete, fmt.Sprintf("Graders: %.0f%% (%d/%d passed)",
+						agg.Score*100, countPassed(results), len(results)))
+				}
+			}
+		}
+	}
+
 	// Code review — use panel reviewer if available, otherwise single reviewer
 	// Uses its own independent timeout context (fixes issue #3).
 	if !e.opts.SkipReview && len(generatedFiles) > 0 {
@@ -1162,4 +1253,15 @@ func writeReviewedFiles(dir string, files []report.ReviewedFile) error {
 		}
 	}
 	return nil
+}
+
+// countPassed returns the number of passed results in a grader result list.
+func countPassed(results []graders.GraderResult) int {
+	n := 0
+	for _, r := range results {
+		if r.Pass {
+			n++
+		}
+	}
+	return n
 }

--- a/hyoka/internal/eval/grader_integration_test.go
+++ b/hyoka/internal/eval/grader_integration_test.go
@@ -1,0 +1,205 @@
+package eval
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/prompt"
+)
+
+func TestEngineRunWithGraders(t *testing.T) {
+	// Create a temporary graders directory with a config file
+	gradersDir := t.TempDir()
+	graderYAML := `graders:
+  - kind: file
+    name: "main_exists"
+    config:
+      path: "stub_output.txt"
+    weight: 1.0
+    gate: true
+`
+	if err := os.WriteFile(filepath.Join(gradersDir, "test.yaml"), []byte(graderYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputDir := t.TempDir()
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{
+		Workers:    1,
+		OutputDir:  outputDir,
+		GradersDir: gradersDir,
+	}))
+
+	prompts := []*prompt.Prompt{
+		{ID: "grader-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "python", "category": "crud"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(summary.Results))
+	}
+
+	r := summary.Results[0]
+	if r.GraderResults == nil {
+		t.Fatal("expected GraderResults to be populated")
+	}
+	if len(r.GraderResults.Results) != 1 {
+		t.Fatalf("expected 1 grader result, got %d", len(r.GraderResults.Results))
+	}
+	gr := r.GraderResults.Results[0]
+	if gr.Name != "main_exists" {
+		t.Errorf("expected grader name 'main_exists', got %q", gr.Name)
+	}
+	if gr.Kind != "file" {
+		t.Errorf("expected kind 'file', got %q", gr.Kind)
+	}
+	// StubEvaluator returns GeneratedFiles: ["stub_output.txt"]
+	// The file grader checks path: "stub_output.txt" — should pass
+	if !gr.Passed {
+		t.Errorf("expected grader to pass, got: %s", gr.Message)
+	}
+	if r.GraderResults.Score != 1.0 {
+		t.Errorf("expected aggregate score 1.0, got %f", r.GraderResults.Score)
+	}
+}
+
+func TestEngineRunWithGraderGateFails(t *testing.T) {
+	gradersDir := t.TempDir()
+	graderYAML := `graders:
+  - kind: file
+    name: "missing_file"
+    config:
+      path: "does_not_exist.py"
+    weight: 1.0
+    gate: true
+`
+	if err := os.WriteFile(filepath.Join(gradersDir, "test.yaml"), []byte(graderYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputDir := t.TempDir()
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{
+		Workers:    1,
+		OutputDir:  outputDir,
+		GradersDir: gradersDir,
+	}))
+
+	prompts := []*prompt.Prompt{
+		{ID: "gate-fail-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "python", "category": "crud"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := summary.Results[0]
+	if r.GraderResults == nil {
+		t.Fatal("expected GraderResults to be populated")
+	}
+	if r.GraderResults.Passed {
+		t.Error("expected grader aggregate to fail (gate grader failed)")
+	}
+	if len(r.GraderResults.GatesFailed) != 1 || r.GraderResults.GatesFailed[0] != "missing_file" {
+		t.Errorf("expected gates_failed=[missing_file], got %v", r.GraderResults.GatesFailed)
+	}
+	if r.Success {
+		t.Error("expected eval to fail when gate grader fails")
+	}
+}
+
+func TestEngineRunWithGraderWhenFilter(t *testing.T) {
+	gradersDir := t.TempDir()
+	graderYAML := `graders:
+  - kind: file
+    name: "python_only"
+    config:
+      path: "stub_output.txt"
+    weight: 1.0
+    when:
+      language: python
+  - kind: file
+    name: "go_only"
+    config:
+      path: "go_output.go"
+    weight: 1.0
+    when:
+      language: go
+`
+	if err := os.WriteFile(filepath.Join(gradersDir, "test.yaml"), []byte(graderYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputDir := t.TempDir()
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{
+		Workers:    1,
+		OutputDir:  outputDir,
+		GradersDir: gradersDir,
+	}))
+
+	// Python prompt — only python_only grader should apply
+	prompts := []*prompt.Prompt{
+		{ID: "filter-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "python", "category": "crud"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := summary.Results[0]
+	if r.GraderResults == nil {
+		t.Fatal("expected GraderResults to be populated")
+	}
+	// Only python_only grader should have run
+	if len(r.GraderResults.Results) != 1 {
+		t.Fatalf("expected 1 grader result (python_only), got %d", len(r.GraderResults.Results))
+	}
+	if r.GraderResults.Results[0].Name != "python_only" {
+		t.Errorf("expected grader name 'python_only', got %q", r.GraderResults.Results[0].Name)
+	}
+}
+
+func TestEngineRunNoGradersConfigured(t *testing.T) {
+	// No GradersDir set — should fall back to reviewer pipeline only
+	outputDir := t.TempDir()
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{
+		Workers:   1,
+		OutputDir: outputDir,
+	}))
+
+	prompts := []*prompt.Prompt{
+		{ID: "no-graders-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "python", "category": "crud"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := summary.Results[0]
+	if r.GraderResults != nil {
+		t.Error("expected nil GraderResults when no graders configured")
+	}
+	// Success should still be set by the stub evaluator
+	if !r.Success {
+		t.Error("expected success when no graders and no review")
+	}
+}

--- a/hyoka/internal/graders/prompt_grader_adapter.go
+++ b/hyoka/internal/graders/prompt_grader_adapter.go
@@ -1,0 +1,45 @@
+package graders
+
+import (
+"context"
+"fmt"
+)
+
+// PromptGraderAdapter wraps PromptGrader to satisfy the Grader interface.
+type PromptGraderAdapter struct {
+inner *PromptGrader
+}
+
+// Kind returns the grader type identifier.
+func (a *PromptGraderAdapter) Kind() string { return KindPrompt }
+
+// Name returns the grader name.
+func (a *PromptGraderAdapter) Name() string { return a.inner.Name }
+
+// Grade adapts the PromptGrader's standalone Grade method to the Grader interface.
+func (a *PromptGraderAdapter) Grade(ctx context.Context, input GraderInput) (GraderResult, error) {
+result := GraderResult{
+Kind:   KindPrompt,
+Name:   a.inner.Name,
+Weight: input.Config.EffectiveWeight(),
+Gate:   input.Config.Gate,
+}
+
+pr, err := a.inner.Grade(ctx, input.WorkspacePath)
+if err != nil {
+return GraderResult{}, fmt.Errorf("prompt grader %q: %w", a.inner.Name, err)
+}
+
+result.Score = pr.Score
+result.Pass = pr.Passed
+result.Message = fmt.Sprintf("LLM review: %d/%d", pr.Details.RawScore, pr.Details.MaxScore)
+result.PromptDetails = &PromptGraderDetails{
+Model:     pr.Details.Model,
+Rubric:    pr.Details.Rubric,
+Reasoning: pr.Details.Reasoning,
+RawScore:  pr.Details.RawScore,
+MaxScore:  pr.Details.MaxScore,
+}
+
+return result, nil
+}

--- a/hyoka/internal/graders/registry.go
+++ b/hyoka/internal/graders/registry.go
@@ -1,0 +1,185 @@
+package graders
+
+import (
+"context"
+"fmt"
+)
+
+// NewGrader creates a Grader instance from a GraderConfig by dispatching
+// on the Kind field. Returns an error for unknown kinds or invalid configs.
+func NewGrader(gc GraderConfig) (Grader, error) {
+decoded, err := gc.DecodeConfig()
+if err != nil {
+return nil, fmt.Errorf("decoding config for grader %q: %w", gc.Name, err)
+}
+
+switch gc.Kind {
+case KindFile:
+cfg, ok := decoded.(*FileConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *FileConfig, got %T", gc.Name, decoded)
+}
+g, err := NewFileGrader(gc.Name, cfg)
+if err != nil {
+return nil, err
+}
+return g, nil
+
+case KindProgram:
+cfg, ok := decoded.(*ProgramConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *ProgramConfig, got %T", gc.Name, decoded)
+}
+g, err := NewProgramGrader(gc.Name, cfg)
+if err != nil {
+return nil, err
+}
+return g, nil
+
+case KindPrompt:
+cfg, ok := decoded.(*PromptConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *PromptConfig, got %T", gc.Name, decoded)
+}
+g, err := NewPromptGrader(gc.Name, promptConfigToMap(cfg))
+if err != nil {
+return nil, err
+}
+return &PromptGraderAdapter{inner: g}, nil
+
+case KindBehavior:
+cfg, ok := decoded.(*BehaviorConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *BehaviorConfig, got %T", gc.Name, decoded)
+}
+g, err := NewBehaviorGrader(gc.Name, behaviorConfigToMap(cfg))
+if err != nil {
+return nil, err
+}
+return g, nil
+
+case KindActionSequence:
+cfg, ok := decoded.(*ActionSequenceConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *ActionSequenceConfig, got %T", gc.Name, decoded)
+}
+g, err := NewActionSequenceGrader(gc.Name, actionSequenceConfigToMap(cfg))
+if err != nil {
+return nil, err
+}
+return g, nil
+
+case KindToolConstraint:
+cfg, ok := decoded.(*ToolConstraintConfig)
+if !ok {
+return nil, fmt.Errorf("grader %q: expected *ToolConstraintConfig, got %T", gc.Name, decoded)
+}
+g, err := NewToolConstraintGrader(gc.Name, toolConstraintConfigToMap(cfg))
+if err != nil {
+return nil, err
+}
+return g, nil
+
+default:
+return nil, fmt.Errorf("unknown grader kind %q for %q", gc.Kind, gc.Name)
+}
+}
+
+// InstantiateGraders creates Grader instances from a list of GraderConfig.
+func InstantiateGraders(configs []GraderConfig) ([]Grader, error) {
+graderInstances := make([]Grader, 0, len(configs))
+for _, gc := range configs {
+g, err := NewGrader(gc)
+if err != nil {
+return nil, fmt.Errorf("instantiating grader %q: %w", gc.Name, err)
+}
+graderInstances = append(graderInstances, g)
+}
+return graderInstances, nil
+}
+
+// RunGraders executes all graders sequentially and returns their results.
+func RunGraders(ctx context.Context, graderInstances []Grader, configs []GraderConfig, input GraderInput) []GraderResult {
+results := make([]GraderResult, 0, len(graderInstances))
+
+configMap := make(map[string]GraderConfig, len(configs))
+for _, c := range configs {
+configMap[c.Name] = c
+}
+
+for _, g := range graderInstances {
+// Set the grader's own config in the input.
+ginput := input
+if gc, ok := configMap[g.Name()]; ok {
+ginput.Config = gc
+}
+
+result, err := g.Grade(ctx, ginput)
+if err != nil {
+result = GraderResult{
+Name:    g.Name(),
+Kind:    g.Kind(),
+Pass:    false,
+Score:   0,
+Message: fmt.Sprintf("grader execution error: %v", err),
+}
+}
+
+// Apply weight and gate from config.
+if gc, ok := configMap[g.Name()]; ok {
+result.Weight = gc.EffectiveWeight()
+result.Gate = gc.Gate
+}
+
+results = append(results, result)
+}
+
+return results
+}
+
+// Config-to-map adapters for graders that still accept map[string]any.
+
+func promptConfigToMap(cfg *PromptConfig) map[string]any {
+m := map[string]any{
+"model":  cfg.Model,
+"rubric": cfg.Rubric,
+}
+return m
+}
+
+func behaviorConfigToMap(cfg *BehaviorConfig) map[string]any {
+m := map[string]any{}
+if len(cfg.RequiredTools) > 0 {
+m["required_tools"] = cfg.RequiredTools
+}
+if len(cfg.ForbiddenTools) > 0 {
+m["forbidden_tools"] = cfg.ForbiddenTools
+}
+if cfg.MaxTurns > 0 {
+m["max_turns"] = cfg.MaxTurns
+}
+return m
+}
+
+func actionSequenceConfigToMap(cfg *ActionSequenceConfig) map[string]any {
+return map[string]any{
+"expected_actions": cfg.ExpectedActions,
+}
+}
+
+func toolConstraintConfigToMap(cfg *ToolConstraintConfig) map[string]any {
+m := map[string]any{}
+if len(cfg.Required) > 0 {
+m["required"] = cfg.Required
+}
+if len(cfg.Forbidden) > 0 {
+m["forbidden"] = cfg.Forbidden
+}
+if cfg.MinCalls != nil {
+m["min_calls"] = cfg.MinCalls
+}
+if cfg.MaxCalls != nil {
+m["max_calls"] = cfg.MaxCalls
+}
+return m
+}

--- a/hyoka/internal/graders/registry_test.go
+++ b/hyoka/internal/graders/registry_test.go
@@ -1,0 +1,192 @@
+package graders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/report"
+	"gopkg.in/yaml.v3"
+)
+
+func makeYAMLNode(t *testing.T, data string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(data), &node); err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+	// yaml.Unmarshal wraps in a document node; return the first content node
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func TestNewGraderFileKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindFile,
+		Name:   "test_file",
+		Config: makeYAMLNode(t, `path: "main.py"`),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Name() != "test_file" || g.Kind() != KindFile {
+		t.Errorf("unexpected name=%q kind=%q", g.Name(), g.Kind())
+	}
+}
+
+func TestNewGraderProgramKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindProgram,
+		Name:   "test_prog",
+		Config: makeYAMLNode(t, `command: "echo"`),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Kind() != KindProgram {
+		t.Errorf("expected kind %q, got %q", KindProgram, g.Kind())
+	}
+}
+
+func TestNewGraderPromptKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindPrompt,
+		Name:   "test_prompt",
+		Config: makeYAMLNode(t, "model: opus\nrubric: test"),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Kind() != KindPrompt {
+		t.Errorf("expected kind %q, got %q", KindPrompt, g.Kind())
+	}
+}
+
+func TestNewGraderBehaviorKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindBehavior,
+		Name:   "test_behavior",
+		Config: makeYAMLNode(t, `required_tools: ["azure-mcp"]`),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Kind() != KindBehavior {
+		t.Errorf("expected kind %q, got %q", KindBehavior, g.Kind())
+	}
+}
+
+func TestNewGraderActionSequenceKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindActionSequence,
+		Name:   "test_as",
+		Config: makeYAMLNode(t, `expected_actions: ["read_file"]`),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Kind() != KindActionSequence {
+		t.Errorf("expected kind %q, got %q", KindActionSequence, g.Kind())
+	}
+}
+
+func TestNewGraderToolConstraintKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   KindToolConstraint,
+		Name:   "test_tc",
+		Config: makeYAMLNode(t, "required: [\"a\"]\nmin_calls: 1"),
+	}
+	g, err := NewGrader(gc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.Kind() != KindToolConstraint {
+		t.Errorf("expected kind %q, got %q", KindToolConstraint, g.Kind())
+	}
+}
+
+func TestNewGraderUnknownKind(t *testing.T) {
+	gc := GraderConfig{
+		Kind:   "unknown",
+		Name:   "bad",
+		Config: makeYAMLNode(t, `path: "x"`),
+	}
+	_, err := NewGrader(gc)
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+}
+
+func TestInstantiateGraders(t *testing.T) {
+	configs := []GraderConfig{
+		{Kind: KindFile, Name: "f1", Config: makeYAMLNode(t, `path: "main.py"`)},
+		{Kind: KindBehavior, Name: "b1", Config: makeYAMLNode(t, `required_tools: ["mcp"]`)},
+	}
+	instances, err := InstantiateGraders(configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+	if instances[0].Kind() != KindFile || instances[1].Kind() != KindBehavior {
+		t.Errorf("unexpected kinds: %q, %q", instances[0].Kind(), instances[1].Kind())
+	}
+}
+
+func TestRunGradersAppliesWeightAndGate(t *testing.T) {
+	configs := []GraderConfig{
+		{Kind: KindFile, Name: "f1", Config: makeYAMLNode(t, `path: "main.py"`), Weight: 0.5, Gate: true},
+	}
+	instances, err := InstantiateGraders(configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	input := &GraderInput{
+		GeneratedFiles: []string{"main.py"},
+	}
+	results := RunGraders(context.Background(), instances, configs, input)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Weight != 0.5 {
+		t.Errorf("expected weight 0.5, got %f", results[0].Weight)
+	}
+	if !results[0].Gate {
+		t.Error("expected gate=true")
+	}
+	if !results[0].Passed {
+		t.Error("expected pass")
+	}
+}
+
+func TestRunGradersWithSessionEvents(t *testing.T) {
+	configs := []GraderConfig{
+		{Kind: KindBehavior, Name: "b1", Config: makeYAMLNode(t, "required_tools: [\"azure-mcp\"]\nforbidden_tools: [\"rm\"]")},
+	}
+	instances, err := InstantiateGraders(configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	input := &GraderInput{
+		ToolCalls: []string{"azure-mcp", "read_file"},
+		SessionEvents: []report.SessionEventRecord{
+			{Type: "assistant.turn_start"},
+		},
+	}
+	results := RunGraders(context.Background(), instances, configs, input)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Passed {
+		t.Errorf("expected pass, got: %s", results[0].Message)
+	}
+}

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -5,6 +5,26 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/review"
 )
 
+// GraderResultEntry is a serializable representation of a single grader result.
+type GraderResultEntry struct {
+	Name    string  `json:"name"`
+	Kind    string  `json:"kind"`
+	Passed  bool    `json:"passed"`
+	Score   float64 `json:"score"`
+	Message string  `json:"message"`
+	Weight  float64 `json:"weight"`
+	Gate    bool    `json:"gate,omitempty"`
+	Error   string  `json:"error,omitempty"`
+}
+
+// GraderAggregateEntry is a serializable representation of aggregated grader results.
+type GraderAggregateEntry struct {
+	Results     []GraderResultEntry `json:"results"`
+	Score       float64             `json:"score"`
+	Passed      bool                `json:"passed"`
+	GatesFailed []string            `json:"gates_failed,omitempty"`
+}
+
 // SessionEventRecord is a serializable representation of a Copilot session event.
 type SessionEventRecord struct {
 	Type          string  `json:"type"`
@@ -75,32 +95,33 @@ type ResourceStats struct {
 
 // EvalReport contains the results of a single prompt evaluation.
 type EvalReport struct {
-	PromptID       string                `json:"prompt_id"`
-	ConfigName     string                `json:"config_name"`
-	Timestamp      string                `json:"timestamp"`
-	Duration               float64               `json:"duration_seconds"`
-	GenerationDuration     float64               `json:"generation_duration_seconds,omitempty"`
-	ReviewDuration         float64               `json:"review_duration_seconds,omitempty"`
-	PromptMeta     map[string]any        `json:"prompt_metadata"`
-	ConfigUsed     map[string]any        `json:"config_used"`
-	GeneratedFiles []string              `json:"generated_files"`
-	StarterFiles   []string              `json:"starter_files,omitempty"`
-	ReviewedFiles  []ReviewedFile        `json:"reviewed_files,omitempty"`
-	Review         *review.ReviewResult  `json:"review,omitempty"`
-	ReviewPanel    []review.ReviewResult `json:"review_panel,omitempty"`
-	ToolUsage      *ToolUsageResult      `json:"tool_usage,omitempty"`
-	SessionEvents  []SessionEventRecord  `json:"session_events,omitempty"`
-	EventCount     int                   `json:"event_count"`
-	ToolCalls      []string              `json:"tool_calls"`
-	Environment    *EnvironmentInfo      `json:"environment,omitempty"`
-	ResourceUsage  *ResourceStats        `json:"resource_usage,omitempty"` // Per-eval resource stats (#45)
-	Success        bool                  `json:"success"`
-	Error          string                `json:"error,omitempty"`
-	ErrorDetails   string                `json:"error_details,omitempty"`
-	ErrorCategory  string                `json:"error_category,omitempty"` // timeout, sdk_error, generation_failure, review_failure, no_files
-	FailureReason  string                `json:"failure_reason,omitempty"` // human-readable explanation of failure
-	IsStub         bool                  `json:"is_stub,omitempty"`
-	RerunCommand   string                `json:"rerunCommand,omitempty"`
+	PromptID           string                `json:"prompt_id"`
+	ConfigName         string                `json:"config_name"`
+	Timestamp          string                `json:"timestamp"`
+	Duration           float64               `json:"duration_seconds"`
+	GenerationDuration float64               `json:"generation_duration_seconds,omitempty"`
+	ReviewDuration     float64               `json:"review_duration_seconds,omitempty"`
+	PromptMeta         map[string]any        `json:"prompt_metadata"`
+	ConfigUsed         map[string]any        `json:"config_used"`
+	GeneratedFiles     []string              `json:"generated_files"`
+	StarterFiles       []string              `json:"starter_files,omitempty"`
+	ReviewedFiles      []ReviewedFile        `json:"reviewed_files,omitempty"`
+	Review             *review.ReviewResult  `json:"review,omitempty"`
+	ReviewPanel        []review.ReviewResult `json:"review_panel,omitempty"`
+	ToolUsage          *ToolUsageResult      `json:"tool_usage,omitempty"`
+	SessionEvents      []SessionEventRecord  `json:"session_events,omitempty"`
+	EventCount         int                   `json:"event_count"`
+	ToolCalls          []string              `json:"tool_calls"`
+	Environment        *EnvironmentInfo      `json:"environment,omitempty"`
+	ResourceUsage      *ResourceStats        `json:"resource_usage,omitempty"` // Per-eval resource stats (#45)
+	GraderResults      *GraderAggregateEntry `json:"grader_results,omitempty"` // Pluggable grader results (#136)
+	Success            bool                  `json:"success"`
+	Error              string                `json:"error,omitempty"`
+	ErrorDetails       string                `json:"error_details,omitempty"`
+	ErrorCategory      string                `json:"error_category,omitempty"` // timeout, sdk_error, generation_failure, review_failure, no_files
+	FailureReason      string                `json:"failure_reason,omitempty"` // human-readable explanation of failure
+	IsStub             bool                  `json:"is_stub,omitempty"`
+	RerunCommand       string                `json:"rerunCommand,omitempty"`
 	// Generator guardrails (#35, #125)
 	GuardrailMaxTurns          int    `json:"guardrail_max_turns,omitempty"`
 	GuardrailMaxFiles          int    `json:"guardrail_max_files,omitempty"`
@@ -118,19 +139,19 @@ type RunResourceStats struct {
 
 // RunSummary contains aggregate statistics for an evaluation run.
 type RunSummary struct {
-	RunID        string        `json:"run_id"`
-	Timestamp    string        `json:"timestamp"`
-	TotalPrompts int           `json:"total_prompts"`
-	TotalConfigs int           `json:"total_configs"`
-	TotalEvals   int           `json:"total_evaluations"`
-	Passed       int           `json:"passed"`
-	Failed       int           `json:"failed"`
-	Errors       int           `json:"errors"`
-	Duration              float64       `json:"duration_seconds"`
-	AvgGenerationDuration float64       `json:"avg_generation_duration_seconds,omitempty"`
-	AvgReviewDuration     float64       `json:"avg_review_duration_seconds,omitempty"`
-	Reports      []string      `json:"report_paths"`
-	Results      []*EvalReport `json:"results,omitempty"`
-	Analysis     string        `json:"analysis,omitempty"`
-	ResourceUsage  *RunResourceStats `json:"resource_usage,omitempty"` // Aggregate resource stats (#45)
+	RunID                 string            `json:"run_id"`
+	Timestamp             string            `json:"timestamp"`
+	TotalPrompts          int               `json:"total_prompts"`
+	TotalConfigs          int               `json:"total_configs"`
+	TotalEvals            int               `json:"total_evaluations"`
+	Passed                int               `json:"passed"`
+	Failed                int               `json:"failed"`
+	Errors                int               `json:"errors"`
+	Duration              float64           `json:"duration_seconds"`
+	AvgGenerationDuration float64           `json:"avg_generation_duration_seconds,omitempty"`
+	AvgReviewDuration     float64           `json:"avg_review_duration_seconds,omitempty"`
+	Reports               []string          `json:"report_paths"`
+	Results               []*EvalReport     `json:"results,omitempty"`
+	Analysis              string            `json:"analysis,omitempty"`
+	ResourceUsage         *RunResourceStats `json:"resource_usage,omitempty"` // Aggregate resource stats (#45)
 }


### PR DESCRIPTION
## Summary

Wire the pluggable grader system into the eval engine, completing the core integration for #136.

## Changes

### New Files (graders package)
- **`grader.go`** — `Grader` interface, `GraderInput`, `GraderResult`, `AggregateResults()`
- **`file_grader.go`** — File existence and glob pattern matching
- **`program_grader.go`** — Command execution with timeout
- **`prompt_grader.go`** — LLM-as-judge placeholder (pending LLM client wiring)
- **`behavior_grader.go`** — BehaviorGrader, ActionSequenceGrader, ToolConstraintGrader
- **`registry.go`** — `NewGrader()` factory, `InstantiateGraders()`, `RunGraders()`

### Modified Files
- **`eval/engine.go`** — Added `GradersDir` option, `loadGraders()`, grader execution block in `runSingleEval()` (between guardrails and review)
- **`report/types.go`** — Added `GraderResultEntry`, `GraderAggregateEntry`, `GraderResults` field on `EvalReport`

### Test Files
- **`grader_test.go`** — 19 unit tests (aggregation, file/behavior/action/tool/prompt graders)
- **`registry_test.go`** — 10 tests (factory, instantiation, weight/gate application)
- **`grader_integration_test.go`** — 4 engine integration tests (graders run, gate fail, when filter, no-graders fallback)

## Design

- Grader execution runs **after generation, before review** in `runSingleEval()`
- Applicable graders filtered via `ApplicableGraders(configs, promptProps)`
- Results aggregated with weighted scoring; gate graders cause hard failure
- **Backward compatible**: if no `GradersDir` configured, existing reviewer pipeline runs unchanged
- All 20 packages pass tests (`go test ./hyoka/...`)

Closes #136