### PR TITLE
feat: update report types to center on GraderResult (#137)

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -601,8 +601,9 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	start := time.Now()
 
 	evalReport := &report.EvalReport{
-		PromptID:   task.Prompt.ID,
-		ConfigName: task.Config.Name,
+		SchemaVersion: report.CurrentSchemaVersion,
+		PromptID:      task.Prompt.ID,
+		ConfigName:    task.Config.Name,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		PromptMeta: map[string]any{
 			"service":     task.Prompt.Service(),
@@ -950,23 +951,15 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 				if aggErr != nil {
 					glg.Error("Failed to aggregate grader results", "error", aggErr)
 				} else {
-					reportResults := make([]report.GraderResultEntry, len(agg.Results))
+					reportResults := make([]report.GraderResult, len(agg.Results))
 					for i, r := range agg.Results {
-						reportResults[i] = report.GraderResultEntry{
-							Name:    r.Name,
-							Kind:    r.Kind,
-							Passed:  r.Pass,
-							Score:   r.Score,
-							Message: r.Message,
-							Weight:  r.Weight,
-							Gate:    r.Gate,
+						reportResults[i] = report.GraderResult{
+							GraderName: r.Name,
+							GraderType: r.Kind,
+							Summary:    r.Message,
 						}
 					}
-					evalReport.GraderAgg = &report.GraderAggregateEntry{
-						Results: reportResults,
-						Score:   agg.Score,
-						Passed:  agg.Pass,
-					}
+					evalReport.GraderResults = reportResults
 
 					if !agg.Pass && !evalFailed {
 						evalReport.Success = false
@@ -1034,6 +1027,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			} else {
 				evalReport.ReviewPanel = panel
 				evalReport.Review = consolidated
+				evalReport.GraderResults = report.GraderResultsFromReview(consolidated, panel)
 				// With criteria-based scoring, success = all criteria passed
 				if !evalFailed {
 					evalReport.Success = consolidated.Scores.AllPassed()
@@ -1053,6 +1047,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 				sendEvent(progress.EventReasoning, fmt.Sprintf("Review failed: %v", err))
 			} else {
 				evalReport.Review = reviewResult
+				evalReport.GraderResults = report.GraderResultsFromReview(reviewResult, nil)
 				// With criteria-based scoring, success = all criteria passed
 				if !evalFailed {
 					evalReport.Success = reviewResult.Scores.AllPassed()

--- a/hyoka/internal/report/generator_test.go
+++ b/hyoka/internal/report/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
+	"github.com/ronniegeraghty/hyoka/internal/review"
 )
 
 func TestWriteReport(t *testing.T) {
@@ -63,6 +64,9 @@ func TestWriteReport(t *testing.T) {
 	}
 	if !parsed.Success {
 		t.Error("expected success to be true")
+	}
+	if parsed.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("expected schema version %d, got %d", CurrentSchemaVersion, parsed.SchemaVersion)
 	}
 
 	// Verify directory structure — includes prompt ID for workspace isolation
@@ -125,162 +129,150 @@ func TestWriteReportInvalidDir(t *testing.T) {
 }
 
 func TestGraderResultsRoundTrip(t *testing.T) {
-dir := t.TempDir()
+	dir := t.TempDir()
 
-graders := []GraderResult{
-{
-GraderName:   "claude-opus-4.6",
-GraderType:   "review",
-Model:        "claude-opus-4.6",
-OverallScore: 4,
-MaxScore:     5,
-Summary:      "Good code",
-Issues:       []string{"missing retry"},
-Strengths:    []string{"clean design"},
-},
-{
-GraderName:   "consensus",
-GraderType:   "review",
-OverallScore: 4,
-MaxScore:     5,
-Summary:      "Consensus result",
-IsConsensus:  true,
-},
-}
+	graders := []GraderResult{
+		{
+			GraderName:   "claude-opus-4.6",
+			GraderType:   "review",
+			Model:        "claude-opus-4.6",
+			OverallScore: 4,
+			MaxScore:     5,
+			Summary:      "Good code",
+			Issues:       []string{"missing retry"},
+			Strengths:    []string{"clean design"},
+		},
+		{
+			GraderName:   "consensus",
+			GraderType:   "review",
+			OverallScore: 4,
+			MaxScore:     5,
+			Summary:      "Consensus result",
+			IsConsensus:  true,
+		},
+	}
 
-r := &EvalReport{
-SchemaVersion:  CurrentSchemaVersion,
-PromptID:       "grader-test",
-ConfigName:     "baseline",
-Timestamp:      "2024-01-15T10:00:00Z",
-Duration:       10.0,
-PromptMeta:     map[string]any{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"},
-ConfigUsed:     map[string]any{"name": "baseline"},
-GeneratedFiles: []string{"main.go"},
-GraderResults:  graders,
-Success:        true,
-}
+	r := &EvalReport{
+		SchemaVersion:  CurrentSchemaVersion,
+		PromptID:       "grader-test",
+		ConfigName:     "baseline",
+		Timestamp:      "2024-01-15T10:00:00Z",
+		Duration:       10.0,
+		PromptMeta:     map[string]any{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"},
+		ConfigUsed:     map[string]any{"name": "baseline"},
+		GeneratedFiles: []string{"main.go"},
+		GraderResults:  graders,
+		Success:        true,
+	}
 
-p := &prompt.Prompt{
-ID:         "grader-test",
-Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"},
-}
+	p := &prompt.Prompt{
+		ID:         "grader-test",
+		Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"},
+	}
 
-reportPath, err := WriteReport(r, dir, "run1", p)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
+	reportPath, err := WriteReport(r, dir, "run1", p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-data, err := os.ReadFile(reportPath)
-if err != nil {
-t.Fatalf("failed to read: %v", err)
-}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
 
-var parsed EvalReport
-if err := json.Unmarshal(data, &parsed); err != nil {
-t.Fatalf("invalid JSON: %v", err)
-}
+	var parsed EvalReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
 
-if parsed.SchemaVersion != CurrentSchemaVersion {
-t.Errorf("expected schema version %d, got %d", CurrentSchemaVersion, parsed.SchemaVersion)
-}
-if len(parsed.GraderResults) != 2 {
-t.Fatalf("expected 2 grader results, got %d", len(parsed.GraderResults))
-}
-if parsed.GraderResults[0].GraderName != "claude-opus-4.6" {
-t.Errorf("expected grader name 'claude-opus-4.6', got %q", parsed.GraderResults[0].GraderName)
-}
-if !parsed.GraderResults[1].IsConsensus {
-t.Error("expected second grader result to be consensus")
-}
-if len(parsed.GraderResults[0].Issues) != 1 {
-t.Errorf("expected 1 issue, got %d", len(parsed.GraderResults[0].Issues))
-}
+	if parsed.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("expected schema version %d, got %d", CurrentSchemaVersion, parsed.SchemaVersion)
+	}
+	if len(parsed.GraderResults) != 2 {
+		t.Fatalf("expected 2 grader results, got %d", len(parsed.GraderResults))
+	}
+	if parsed.GraderResults[0].GraderName != "claude-opus-4.6" {
+		t.Errorf("expected grader name claude-opus-4.6, got %q", parsed.GraderResults[0].GraderName)
+	}
+	if !parsed.GraderResults[1].IsConsensus {
+		t.Error("expected second grader result to be consensus")
+	}
 }
 
 func TestGraderResultsFromReviewPanel(t *testing.T) {
-consolidated := &review.ReviewResult{
-Model:        "consolidator",
-OverallScore: 3,
-MaxScore:     5,
-Summary:      "Consensus summary",
-Scores: review.ReviewScores{
-Criteria: []review.CriterionResult{
-{Name: "Builds", Passed: true, Reason: "OK"},
-},
-},
-}
-panel := []review.ReviewResult{
-{Model: "model-a", OverallScore: 4, MaxScore: 5, Summary: "Model A says good"},
-{Model: "model-b", OverallScore: 2, MaxScore: 5, Summary: "Model B says bad"},
-}
+	consolidated := &review.ReviewResult{
+		Model:        "consolidator",
+		OverallScore: 3,
+		MaxScore:     5,
+		Summary:      "Consensus summary",
+		Scores: review.ReviewScores{
+			Criteria: []review.CriterionResult{
+				{Name: "Builds", Passed: true, Reason: "OK"},
+			},
+		},
+	}
+	panel := []review.ReviewResult{
+		{Model: "model-a", OverallScore: 4, MaxScore: 5, Summary: "Model A says good"},
+		{Model: "model-b", OverallScore: 2, MaxScore: 5, Summary: "Model B says bad"},
+	}
 
-results := GraderResultsFromReview(consolidated, panel)
-if len(results) != 3 {
-t.Fatalf("expected 3 grader results (2 panel + 1 consensus), got %d", len(results))
-}
-if results[0].GraderName != "model-a" {
-t.Errorf("expected first grader 'model-a', got %q", results[0].GraderName)
-}
-if results[2].IsConsensus != true {
-t.Error("expected last grader result to be consensus")
-}
-if results[2].GraderName != "consolidator" {
-t.Errorf("expected consensus grader 'consolidator', got %q", results[2].GraderName)
-}
+	results := GraderResultsFromReview(consolidated, panel)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 grader results (2 panel + 1 consensus), got %d", len(results))
+	}
+	if results[0].GraderName != "model-a" {
+		t.Errorf("expected first grader model-a, got %q", results[0].GraderName)
+	}
+	if !results[2].IsConsensus {
+		t.Error("expected last grader result to be consensus")
+	}
 }
 
 func TestGraderResultsFromSingleReview(t *testing.T) {
-single := &review.ReviewResult{
-Model:        "claude-sonnet",
-OverallScore: 5,
-MaxScore:     5,
-Summary:      "Perfect",
-}
+	single := &review.ReviewResult{
+		Model:        "claude-sonnet",
+		OverallScore: 5,
+		MaxScore:     5,
+		Summary:      "Perfect",
+	}
 
-results := GraderResultsFromReview(single, nil)
-if len(results) != 1 {
-t.Fatalf("expected 1 grader result, got %d", len(results))
-}
-if results[0].IsConsensus {
-t.Error("single reviewer should not be marked as consensus")
-}
-if results[0].GraderName != "claude-sonnet" {
-t.Errorf("expected 'claude-sonnet', got %q", results[0].GraderName)
-}
+	results := GraderResultsFromReview(single, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 grader result, got %d", len(results))
+	}
+	if results[0].IsConsensus {
+		t.Error("single reviewer should not be marked as consensus")
+	}
 }
 
 func TestMigrateToV2(t *testing.T) {
-r := &EvalReport{
-PromptID:   "migrate-test",
-ConfigName: "baseline",
-Review: &review.ReviewResult{
-Model:        "test-model",
-OverallScore: 3,
-MaxScore:     5,
-Summary:      "Test summary",
-},
-ReviewPanel: []review.ReviewResult{
-{Model: "panel-a", OverallScore: 4, MaxScore: 5, Summary: "Panel A"},
-},
-}
+	r := &EvalReport{
+		PromptID:   "migrate-test",
+		ConfigName: "baseline",
+		Review: &review.ReviewResult{
+			Model:        "test-model",
+			OverallScore: 3,
+			MaxScore:     5,
+			Summary:      "Test summary",
+		},
+		ReviewPanel: []review.ReviewResult{
+			{Model: "panel-a", OverallScore: 4, MaxScore: 5, Summary: "Panel A"},
+		},
+	}
 
-MigrateToV2(r)
+	MigrateToV2(r)
 
-if r.SchemaVersion != CurrentSchemaVersion {
-t.Errorf("expected schema version %d, got %d", CurrentSchemaVersion, r.SchemaVersion)
-}
-if len(r.GraderResults) != 2 {
-t.Fatalf("expected 2 grader results (1 panel + 1 consensus), got %d", len(r.GraderResults))
-}
-if r.GraderResults[0].GraderName != "panel-a" {
-t.Errorf("expected panel grader 'panel-a', got %q", r.GraderResults[0].GraderName)
-}
+	if r.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("expected schema version %d, got %d", CurrentSchemaVersion, r.SchemaVersion)
+	}
+	if len(r.GraderResults) != 2 {
+		t.Fatalf("expected 2 grader results (1 panel + 1 consensus), got %d", len(r.GraderResults))
+	}
 
-// Idempotent: calling again should not change anything
-r.GraderResults[0].GraderName = "modified"
-MigrateToV2(r)
-if r.GraderResults[0].GraderName != "modified" {
-t.Error("MigrateToV2 should be idempotent and not overwrite existing grader results")
-}
+	// Idempotent: calling again should not change anything
+	r.GraderResults[0].GraderName = "modified"
+	MigrateToV2(r)
+	if r.GraderResults[0].GraderName != "modified" {
+		t.Error("MigrateToV2 should be idempotent")
+	}
 }

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -10,26 +10,6 @@ import (
 // v1 = legacy monolithic ReviewResult; v2 = grader-based.
 const CurrentSchemaVersion = 2
 
-// GraderResultEntry is a serializable representation of a single grader result.
-type GraderResultEntry struct {
-	Name    string  `json:"name"`
-	Kind    string  `json:"kind"`
-	Passed  bool    `json:"passed"`
-	Score   float64 `json:"score"`
-	Message string  `json:"message"`
-	Weight  float64 `json:"weight"`
-	Gate    bool    `json:"gate,omitempty"`
-	Error   string  `json:"error,omitempty"`
-}
-
-// GraderAggregateEntry is a serializable representation of aggregated grader results.
-type GraderAggregateEntry struct {
-	Results     []GraderResultEntry `json:"results"`
-	Score       float64             `json:"score"`
-	Passed      bool                `json:"passed"`
-	GatesFailed []string            `json:"gates_failed,omitempty"`
-}
-
 // GraderResult holds the output from a single grader (LLM reviewer, build check, etc.).
 type GraderResult struct {
 	GraderName   string              `json:"grader_name"`
@@ -129,8 +109,7 @@ type EvalReport struct {
 	ReviewedFiles  []ReviewedFile        `json:"reviewed_files,omitempty"`
 	Review         *review.ReviewResult  `json:"review,omitempty"`
 	ReviewPanel    []review.ReviewResult `json:"review_panel,omitempty"`
-	GraderResults  []GraderResult        `json:"grader_results_legacy,omitempty"`
-	GraderAgg      *GraderAggregateEntry `json:"grader_results,omitempty"` // Pluggable grader results (#136)
+	GraderResults  []GraderResult        `json:"grader_results,omitempty"`
 	ToolUsage      *ToolUsageResult      `json:"tool_usage,omitempty"`
 	SessionEvents  []SessionEventRecord  `json:"session_events,omitempty"`
 	EventCount     int                   `json:"event_count"`

--- a/hyoka/internal/rerender/rerender.go
+++ b/hyoka/internal/rerender/rerender.go
@@ -57,12 +57,21 @@ func rerenderRun(reportsDir, runID string) error {
 
 	// Re-render each individual report
 	var allReports []*report.EvalReport
+	migrated := 0
 	for _, rf := range reportFiles {
 		evalReport, err := loadReport(rf)
 		if err != nil {
 			fmt.Printf("  ⚠️  skipping %s: %v\n", rf, err)
 			continue
 		}
+
+		// Migrate to v2 schema in-place
+		if changed, merr := migrateReport(evalReport, rf); merr != nil {
+			fmt.Printf("  ⚠️  migration failed for %s: %v\n", rf, merr)
+		} else if changed {
+			migrated++
+		}
+
 		allReports = append(allReports, evalReport)
 
 		// Determine report directory components from the path
@@ -91,7 +100,11 @@ func rerenderRun(reportsDir, runID string) error {
 		}
 	}
 
-	fmt.Printf("✅ Re-rendered %d report(s) for run %s\n", len(reportFiles), runID)
+	fmt.Printf("✅ Re-rendered %d report(s) for run %s", len(reportFiles), runID)
+	if migrated > 0 {
+		fmt.Printf(" (%d migrated to v%d)", migrated, report.CurrentSchemaVersion)
+	}
+	fmt.Println()
 	return nil
 }
 
@@ -135,6 +148,23 @@ func loadReport(path string) (*report.EvalReport, error) {
 		return nil, err
 	}
 	return &r, nil
+}
+
+// migrateReport upgrades a report to the current schema version and writes
+// the updated JSON back to disk. Returns true if the report was modified.
+func migrateReport(r *report.EvalReport, path string) (bool, error) {
+	if r.SchemaVersion >= report.CurrentSchemaVersion {
+		return false, nil
+	}
+	report.MigrateToV2(r)
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshaling migrated report: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return false, fmt.Errorf("writing migrated report: %w", err)
+	}
+	return true, nil
 }
 
 func extractMeta(r *report.EvalReport) (service, plane, language, category string) {


### PR DESCRIPTION
## Summary

Updates report types to center on `GraderResult` instead of the monolithic `ReviewResult`, adding schema versioning for future-proofing.

## Changes

### New Types
- **`GraderResult`** — captures output from any grader (LLM reviewer, build check, lint, test) with grader_name, grader_type, model, scores, summary, issues, strengths, duration, and is_consensus fields
- **`CurrentSchemaVersion`** — constant (v2 = grader-based)

### EvalReport Updates
- Added `SchemaVersion int` field (set automatically to v2)
- Added `GraderResults []GraderResult` field (placed after ReviewPanel)
- Existing `Review` and `ReviewPanel` fields preserved for backward compatibility

### Report Generation
- `WriteReport()` ensures SchemaVersion is set
- Eval engine populates GraderResults from review panel and single reviewer
- HTML template includes new Grader Results section with score/type/summary table
- Markdown report includes Grader Results summary table

### Migration (ESC-4: no dual-format)
- `MigrateToV2()` — idempotent in-place migration from v1 → v2
- `GraderResultsFromReview()` — converts ReviewResult/ReviewPanel to GraderResults
- Rerender command automatically migrates existing report.json files during re-render

### Tests
- JSON round-trip serialization with GraderResults
- SchemaVersion set correctly in WriteReport
- Panel → GraderResult conversion (2 panel + 1 consensus = 3 results)
- Single reviewer → GraderResult conversion (1 result, no consensus flag)
- Idempotent MigrateToV2
- HTML/MD report rendering includes grader sections

Closes #137