### PR TITLE
Fix report links using backslashes on Windows

### DIFF
--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -157,7 +157,7 @@ func buildMatrix(s *RunSummary) *MatrixData {
 		language, _ := r.PromptMeta["language"].(string)
 		category, _ := r.PromptMeta["category"].(string)
 		if service != "" && plane != "" && language != "" && category != "" {
-			cell.ReportLink = filepath.Join("results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html")
+			cell.ReportLink = strings.Join([]string{"results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html"}, "/")
 		}
 		m.Cells[r.PromptID][r.ConfigName] = cell
 	}
@@ -631,7 +631,8 @@ func htmlFuncMap() template.FuncMap {
 			if service == "" || plane == "" || language == "" || category == "" {
 				return ""
 			}
-			return filepath.Join("results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html")
+			// Use forward slashes for HTML links (filepath.Join uses OS-native backslashes on Windows)
+			return strings.Join([]string{"results", service, plane, language, category, r.PromptID, r.ConfigName, "report.html"}, "/")
 		},
 	}
 }

--- a/hyoka/internal/report/markdown.go
+++ b/hyoka/internal/report/markdown.go
@@ -410,7 +410,7 @@ func WriteSummaryMarkdown(s *RunSummary, outputDir string) (string, error) {
 		category, _ := r.PromptMeta["category"].(string)
 		promptCell := r.PromptID
 		if service != "" && plane != "" && language != "" && category != "" {
-			link := filepath.Join("results", service, plane, language, category, r.ConfigName, "report.md")
+			link := strings.Join([]string{"results", service, plane, language, category, r.ConfigName, "report.md"}, "/")
 			promptCell = fmt.Sprintf("[%s](%s)", r.PromptID, link)
 		}
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %.1fs | %d |\n",


### PR DESCRIPTION
Fix report View links broken on Windows due to backslash path separators.

filepath.Join produces backslashes on Windows which get URL-encoded as %5c in browser links.
Replaced with forward-slash strings.Join for all HTML/MD report link paths.

Fixes #87
