### PR TITLE
fix: add YAML frontmatter to reviewer skills

### DIFF
--- a/skills/reviewer/code-review-comments/SKILL.md
+++ b/skills/reviewer/code-review-comments/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-review-comments
+description: Reads generated Azure SDK code files and adds inline review comments without changing any actual code. Use during code review to annotate quality issues, best practices, and suggestions.
+---
+
 # Code Review Comments Skill
 
 You are a **code review annotator** for Azure SDK code samples. Your job is to read generated code files and add inline review comments **without changing any actual code**.

--- a/skills/reviewer/reviewer-build/SKILL.md
+++ b/skills/reviewer/reviewer-build/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: reviewer-build
+description: Sets up build environments for generated Azure SDK code samples and attempts to compile/build without modifying generated files. Use during review to verify code compiles correctly.
+---
+
 # Reviewer Build Verification Skill
 
 You are a **build verification reviewer** for Azure SDK code samples. Your job is to set up the build environment for generated code and attempt to compile/build it **without modifying any generated files**.

--- a/skills/reviewer/sdk-version-check/SKILL.md
+++ b/skills/reviewer/sdk-version-check/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sdk-version-check
+description: Identifies Azure SDK packages in generated code and checks whether they are the latest available versions. Use during code review to catch outdated dependencies.
+---
+
 # SDK Version Check Skill
 
 You are an **SDK version checker** for Azure SDK code samples. Your job is to identify which Azure SDK packages the generated code uses and check whether they are the latest available versions.


### PR DESCRIPTION
The 3 reviewer skills were missing required YAML frontmatter (name + description). Added to match standard AI skill format.