### PR TITLE
feat: define action event schema for agent timeline (#138)

### DIFF
--- a/hyoka/internal/eval/action.go
+++ b/hyoka/internal/eval/action.go
@@ -1,0 +1,83 @@
+package eval
+
+import "time"
+
+// ActionEvent captures a single agent action during an evaluation session.
+// This is the rich timeline event used for report rendering, distinct from
+// the lightweight graders.ActionEvent used for rubric evaluation.
+type ActionEvent struct {
+	Timestamp  time.Time     `json:"timestamp"`
+	Type       string        `json:"type"`                  // "tool_call", "file_read", "file_write", "bash", "response"
+	Tool       string        `json:"tool"`                  // Tool name (e.g., "editFile", "bash")
+	Input      string        `json:"input"`                 // Tool input (truncated if large)
+	Output     string        `json:"output"`                // Tool output (truncated if large)
+	Duration   time.Duration `json:"duration"`              // Wall-clock duration of this action
+	TurnNumber int           `json:"turn_number"`           // Which conversation turn this belongs to
+	Success    bool          `json:"success"`               // Whether the action completed successfully
+	Error      string        `json:"error,omitempty"`       // Error message if action failed
+}
+
+// ActionTimeline aggregates all action events from a session with computed
+// summary statistics. It provides the full action history for report rendering.
+type ActionTimeline struct {
+	Events        []ActionEvent   `json:"events"`
+	TotalTurns    int             `json:"total_turns"`
+	TotalDuration time.Duration   `json:"total_duration"`
+	Summary       TimelineSummary `json:"summary"`
+}
+
+// TimelineSummary provides aggregate counts of action types within a timeline.
+type TimelineSummary struct {
+	ToolCalls  int `json:"tool_calls"`
+	FileReads  int `json:"file_reads"`
+	FileWrites int `json:"file_writes"`
+	BashCmds   int `json:"bash_commands"`
+}
+
+// NewActionTimeline builds an ActionTimeline from a slice of events, computing
+// the total turns, total duration, and per-type summary counts.
+func NewActionTimeline(events []ActionEvent) *ActionTimeline {
+	tl := &ActionTimeline{
+		Events: events,
+	}
+
+	if len(events) == 0 {
+		return tl
+	}
+
+	maxTurn := 0
+	var totalDur time.Duration
+	for _, e := range events {
+		totalDur += e.Duration
+		if e.TurnNumber > maxTurn {
+			maxTurn = e.TurnNumber
+		}
+		switch e.Type {
+		case "tool_call":
+			tl.Summary.ToolCalls++
+		case "file_read":
+			tl.Summary.FileReads++
+		case "file_write":
+			tl.Summary.FileWrites++
+		case "bash":
+			tl.Summary.BashCmds++
+		}
+	}
+
+	tl.TotalTurns = maxTurn
+	tl.TotalDuration = totalDur
+	return tl
+}
+
+// TruncateField truncates s to maxLen characters, appending an ellipsis
+// indicator when truncation occurs. Returns s unchanged if within limit.
+func TruncateField(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	suffix := "... [truncated]"
+	if maxLen <= len(suffix) {
+		return s[:maxLen]
+	}
+	return s[:maxLen-len(suffix)] + suffix
+}

--- a/hyoka/internal/eval/action_test.go
+++ b/hyoka/internal/eval/action_test.go
@@ -1,0 +1,129 @@
+package eval
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewActionTimeline_Empty(t *testing.T) {
+	tl := NewActionTimeline(nil)
+	if tl == nil {
+		t.Fatal("expected non-nil timeline")
+	}
+	if len(tl.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(tl.Events))
+	}
+	if tl.TotalTurns != 0 {
+		t.Errorf("expected 0 turns, got %d", tl.TotalTurns)
+	}
+	if tl.TotalDuration != 0 {
+		t.Errorf("expected 0 duration, got %v", tl.TotalDuration)
+	}
+	if tl.Summary != (TimelineSummary{}) {
+		t.Errorf("expected zero summary, got %+v", tl.Summary)
+	}
+}
+
+func TestNewActionTimeline_SummaryCounts(t *testing.T) {
+	events := []ActionEvent{
+		{Type: "tool_call", TurnNumber: 1, Duration: 100 * time.Millisecond, Success: true},
+		{Type: "file_read", TurnNumber: 1, Duration: 50 * time.Millisecond, Success: true},
+		{Type: "file_write", TurnNumber: 2, Duration: 200 * time.Millisecond, Success: true},
+		{Type: "bash", TurnNumber: 2, Duration: 300 * time.Millisecond, Success: true},
+		{Type: "bash", TurnNumber: 3, Duration: 150 * time.Millisecond, Success: false, Error: "exit 1"},
+		{Type: "tool_call", TurnNumber: 3, Duration: 75 * time.Millisecond, Success: true},
+		{Type: "response", TurnNumber: 3, Duration: 10 * time.Millisecond, Success: true},
+	}
+
+	tl := NewActionTimeline(events)
+
+	if tl.TotalTurns != 3 {
+		t.Errorf("expected 3 turns, got %d", tl.TotalTurns)
+	}
+
+	wantDur := 885 * time.Millisecond
+	if tl.TotalDuration != wantDur {
+		t.Errorf("expected total duration %v, got %v", wantDur, tl.TotalDuration)
+	}
+
+	if tl.Summary.ToolCalls != 2 {
+		t.Errorf("expected 2 tool_calls, got %d", tl.Summary.ToolCalls)
+	}
+	if tl.Summary.FileReads != 1 {
+		t.Errorf("expected 1 file_read, got %d", tl.Summary.FileReads)
+	}
+	if tl.Summary.FileWrites != 1 {
+		t.Errorf("expected 1 file_write, got %d", tl.Summary.FileWrites)
+	}
+	if tl.Summary.BashCmds != 2 {
+		t.Errorf("expected 2 bash commands, got %d", tl.Summary.BashCmds)
+	}
+}
+
+func TestNewActionTimeline_ResponseTypeNotCounted(t *testing.T) {
+	events := []ActionEvent{
+		{Type: "response", TurnNumber: 1, Duration: 10 * time.Millisecond},
+	}
+	tl := NewActionTimeline(events)
+
+	if tl.Summary.ToolCalls != 0 || tl.Summary.FileReads != 0 ||
+		tl.Summary.FileWrites != 0 || tl.Summary.BashCmds != 0 {
+		t.Errorf("response events should not increment summary counts: %+v", tl.Summary)
+	}
+}
+
+func TestTruncateField_NoTruncation(t *testing.T) {
+	input := "short string"
+	got := TruncateField(input, 100)
+	if got != input {
+		t.Errorf("expected %q, got %q", input, got)
+	}
+}
+
+func TestTruncateField_ExactLimit(t *testing.T) {
+	input := "exact"
+	got := TruncateField(input, 5)
+	if got != input {
+		t.Errorf("expected %q, got %q", input, got)
+	}
+}
+
+func TestTruncateField_Truncates(t *testing.T) {
+	input := "this is a long string that should be truncated at some point"
+	got := TruncateField(input, 30)
+
+	if len(got) > 30 {
+		t.Errorf("expected length <= 30, got %d: %q", len(got), got)
+	}
+	if got[len(got)-1] != ']' {
+		t.Errorf("expected truncated suffix, got %q", got)
+	}
+}
+
+func TestTruncateField_ZeroMax(t *testing.T) {
+	got := TruncateField("hello", 0)
+	if got != "hello" {
+		t.Errorf("expected unchanged string for maxLen=0, got %q", got)
+	}
+}
+
+func TestTruncateField_NegativeMax(t *testing.T) {
+	got := TruncateField("hello", -1)
+	if got != "hello" {
+		t.Errorf("expected unchanged string for negative maxLen, got %q", got)
+	}
+}
+
+func TestTruncateField_VerySmallMax(t *testing.T) {
+	got := TruncateField("hello world", 3)
+	if len(got) != 3 {
+		t.Errorf("expected length 3, got %d: %q", len(got), got)
+	}
+}
+
+func TestTruncateField_EmptyString(t *testing.T) {
+	got := TruncateField("", 10)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Defines the action event schema (Phase 3, task 3.1a) for capturing agent actions during evaluation sessions. This enables the full action timeline in reports.

### New types in `hyoka/internal/eval/action.go`

- **`ActionEvent`** — Rich event capturing timestamp, type, tool, input/output, duration, turn number, success/error. Distinct from the lightweight `graders.ActionEvent` used for rubric scoring.
- **`ActionTimeline`** — Aggregates events with computed total turns, total duration, and per-type summary.
- **`TimelineSummary`** — Counts of tool_calls, file_reads, file_writes, and bash_commands.

### Helper functions

- `NewActionTimeline(events)` — Builds timeline with computed summary
- `TruncateField(s, maxLen)` — Truncates large input/output fields with ellipsis indicator

### Tests

10 unit tests covering empty timelines, summary computation, response-type exclusion, truncation edge cases.

Closes #138