### PR TITLE
feat: include action timeline in JSON report output (#140)

### DIFF
--- a/hyoka/internal/report/generator.go
+++ b/hyoka/internal/report/generator.go
@@ -34,6 +34,11 @@ func WriteReport(r *EvalReport, outputDir string, runID string, p *prompt.Prompt
 		return "", fmt.Errorf("creating report directory: %w", err)
 	}
 
+	// Build the action timeline from session events if not already set.
+	if r.ActionTimeline == nil && len(r.SessionEvents) > 0 {
+		r.ActionTimeline = BuildActionTimeline(r.SessionEvents)
+	}
+
 	// Truncate verbose fields when the report is excessively large.
 	TruncateReport(r)
 

--- a/hyoka/internal/report/generator_test.go
+++ b/hyoka/internal/report/generator_test.go
@@ -245,6 +245,221 @@ func TestGraderResultsFromSingleReview(t *testing.T) {
 	}
 }
 
+func TestBuildActionTimeline(t *testing.T) {
+	boolTrue := true
+	boolFalse := false
+	events := []SessionEventRecord{
+		{Type: "assistant.turn_start"},
+		{Type: "assistant.reasoning"},
+		{Type: "tool.execution_start", ToolName: "create_file", FilePath: "main.go"},
+		{Type: "tool.execution_complete", ToolName: "create_file", Duration: 150.0, ToolSuccess: &boolTrue},
+		{Type: "tool.execution_start", ToolName: "edit_file", MCPServerName: "editor"},
+		{Type: "tool.execution_complete", ToolName: "edit_file", Duration: 80.0, ToolSuccess: &boolFalse, Error: "conflict"},
+		{Type: "assistant.intent", Intent: "fixing imports"},
+		{Type: "assistant.message"},
+		{Type: "assistant.turn_end"},
+	}
+
+	tl := BuildActionTimeline(events)
+	if tl == nil {
+		t.Fatal("expected non-nil timeline")
+	}
+
+	// Verify entries (tool.execution_complete updates existing entries, doesn't create new ones)
+	if len(tl.Entries) != 7 {
+		t.Fatalf("expected 7 entries, got %d", len(tl.Entries))
+	}
+
+	// Verify turn_start
+	if tl.Entries[0].Type != "turn_start" || tl.Entries[0].TurnNumber != 1 {
+		t.Errorf("entry 0: expected turn_start turn=1, got %s turn=%d", tl.Entries[0].Type, tl.Entries[0].TurnNumber)
+	}
+
+	// Verify tool_call with completion data
+	if tl.Entries[2].Type != "tool_call" || tl.Entries[2].ToolName != "create_file" {
+		t.Errorf("entry 2: expected tool_call create_file, got %s %s", tl.Entries[2].Type, tl.Entries[2].ToolName)
+	}
+	if tl.Entries[2].Duration != 150.0 {
+		t.Errorf("entry 2: expected duration 150, got %.1f", tl.Entries[2].Duration)
+	}
+	if tl.Entries[2].Success == nil || !*tl.Entries[2].Success {
+		t.Error("entry 2: expected success=true")
+	}
+	if tl.Entries[2].FilePath != "main.go" {
+		t.Errorf("entry 2: expected file_path main.go, got %q", tl.Entries[2].FilePath)
+	}
+
+	// Verify failed tool (entry index 3)
+	if tl.Entries[3].ToolName != "edit_file" || tl.Entries[3].Error != "conflict" {
+		t.Errorf("entry 3: expected edit_file with conflict error, got %s err=%s", tl.Entries[3].ToolName, tl.Entries[3].Error)
+	}
+	if tl.Entries[3].MCPServer != "editor" {
+		t.Errorf("entry 3: expected mcp_server editor, got %q", tl.Entries[3].MCPServer)
+	}
+
+	// Verify intent (entry index 4)
+	if tl.Entries[4].Type != "intent" || tl.Entries[4].Intent != "fixing imports" {
+		t.Errorf("entry 4: expected intent 'fixing imports', got type=%s intent=%q", tl.Entries[4].Type, tl.Entries[4].Intent)
+	}
+
+	// Verify summary
+	if tl.Summary.TotalActions != 7 {
+		t.Errorf("summary: expected 7 total actions, got %d", tl.Summary.TotalActions)
+	}
+	if tl.Summary.TotalToolCalls != 2 {
+		t.Errorf("summary: expected 2 tool calls, got %d", tl.Summary.TotalToolCalls)
+	}
+	if tl.Summary.TotalTurns != 1 {
+		t.Errorf("summary: expected 1 turn, got %d", tl.Summary.TotalTurns)
+	}
+	if tl.Summary.ToolCallDuration != 230.0 {
+		t.Errorf("summary: expected tool duration 230, got %.1f", tl.Summary.ToolCallDuration)
+	}
+	if tl.Summary.ToolSuccesses != 1 {
+		t.Errorf("summary: expected 1 success, got %d", tl.Summary.ToolSuccesses)
+	}
+	if tl.Summary.ToolFailures != 1 {
+		t.Errorf("summary: expected 1 failure, got %d", tl.Summary.ToolFailures)
+	}
+}
+
+func TestBuildActionTimelineEmpty(t *testing.T) {
+	tl := BuildActionTimeline(nil)
+	if tl != nil {
+		t.Error("expected nil timeline for empty events")
+	}
+	tl = BuildActionTimeline([]SessionEventRecord{})
+	if tl != nil {
+		t.Error("expected nil timeline for zero-length events")
+	}
+}
+
+func TestActionTimelineJSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	boolTrue := true
+	events := []SessionEventRecord{
+		{Type: "assistant.turn_start"},
+		{Type: "tool.execution_start", ToolName: "create_file"},
+		{Type: "tool.execution_complete", ToolName: "create_file", Duration: 100.0, ToolSuccess: &boolTrue},
+		{Type: "assistant.message"},
+		{Type: "assistant.turn_end"},
+	}
+
+	r := &EvalReport{
+		SchemaVersion:  CurrentSchemaVersion,
+		PromptID:       "timeline-roundtrip",
+		ConfigName:     "baseline",
+		Timestamp:      "2024-01-15T10:00:00Z",
+		Duration:       10.0,
+		PromptMeta:     map[string]any{"service": "identity", "plane": "data-plane", "language": "python", "category": "auth"},
+		ConfigUsed:     map[string]any{"name": "baseline"},
+		GeneratedFiles: []string{"main.py"},
+		SessionEvents:  events,
+		EventCount:     5,
+		Success:        true,
+	}
+
+	p := &prompt.Prompt{
+		ID:         "timeline-roundtrip",
+		Properties: map[string]string{"service": "identity", "plane": "data-plane", "language": "python", "category": "auth"},
+	}
+
+	// WriteReport should auto-build the timeline
+	reportPath, err := WriteReport(r, dir, "run-tl", p)
+	if err != nil {
+		t.Fatalf("WriteReport failed: %v", err)
+	}
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("failed to read report: %v", err)
+	}
+
+	var parsed EvalReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if parsed.ActionTimeline == nil {
+		t.Fatal("expected action_timeline in JSON output")
+	}
+	if len(parsed.ActionTimeline.Entries) != 4 {
+		t.Errorf("expected 4 timeline entries, got %d", len(parsed.ActionTimeline.Entries))
+	}
+	if parsed.ActionTimeline.Summary.TotalToolCalls != 1 {
+		t.Errorf("expected 1 tool call in summary, got %d", parsed.ActionTimeline.Summary.TotalToolCalls)
+	}
+	if parsed.ActionTimeline.Summary.ToolCallDuration != 100.0 {
+		t.Errorf("expected tool duration 100, got %.1f", parsed.ActionTimeline.Summary.ToolCallDuration)
+	}
+
+	// Verify the timeline entry details survive round-trip
+	var foundToolCall bool
+	for _, e := range parsed.ActionTimeline.Entries {
+		if e.Type == "tool_call" && e.ToolName == "create_file" {
+			foundToolCall = true
+			if e.Duration != 100.0 {
+				t.Errorf("tool_call duration: expected 100, got %.1f", e.Duration)
+			}
+			if e.Success == nil || !*e.Success {
+				t.Error("tool_call: expected success=true")
+			}
+		}
+	}
+	if !foundToolCall {
+		t.Error("expected to find tool_call entry for create_file")
+	}
+}
+
+func TestActionTimelinePresetNotOverwritten(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-set a timeline — WriteReport should not overwrite it.
+	preset := &ActionTimelineReport{
+		Entries: []ActionTimelineEntry{{Index: 1, Type: "custom"}},
+		Summary: ActionTimelineSummary{TotalActions: 99},
+	}
+
+	r := &EvalReport{
+		SchemaVersion:  CurrentSchemaVersion,
+		PromptID:       "timeline-preset",
+		ConfigName:     "baseline",
+		Timestamp:      "2024-01-15T10:00:00Z",
+		Duration:       5.0,
+		PromptMeta:     map[string]any{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"},
+		ConfigUsed:     map[string]any{"name": "baseline"},
+		GeneratedFiles: []string{"main.go"},
+		SessionEvents:  []SessionEventRecord{{Type: "assistant.message"}},
+		ActionTimeline: preset,
+		Success:        true,
+	}
+
+	p := &prompt.Prompt{
+		ID:         "timeline-preset",
+		Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"},
+	}
+
+	reportPath, err := WriteReport(r, dir, "run-preset", p)
+	if err != nil {
+		t.Fatalf("WriteReport failed: %v", err)
+	}
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+
+	var parsed EvalReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if parsed.ActionTimeline.Summary.TotalActions != 99 {
+		t.Errorf("expected preset total_actions=99, got %d", parsed.ActionTimeline.Summary.TotalActions)
+	}
+}
+
 func TestMigrateToV2(t *testing.T) {
 	r := &EvalReport{
 		PromptID:   "migrate-test",

--- a/hyoka/internal/report/summary_stats.go
+++ b/hyoka/internal/report/summary_stats.go
@@ -50,6 +50,18 @@ type ToolStat struct {
 	Rate      float64 `json:"success_rate"` // 0-100
 }
 
+// TimelineSummary holds aggregate action timeline statistics across all evals.
+type TimelineSummary struct {
+	TotalActions        int     `json:"total_actions"`
+	TotalToolCalls      int     `json:"total_tool_calls"`
+	TotalTurns          int     `json:"total_turns"`
+	AvgActionsPerEval   float64 `json:"avg_actions_per_eval"`
+	AvgToolCallsPerEval float64 `json:"avg_tool_calls_per_eval"`
+	AvgTurnsPerEval     float64 `json:"avg_turns_per_eval"`
+	AvgToolCallDuration float64 `json:"avg_tool_call_duration_ms"`
+	ToolSuccessRate     float64 `json:"tool_success_rate"` // 0-100
+}
+
 // SummaryStats holds computed aggregate statistics for a run summary.
 type SummaryStats struct {
 	// Duration analysis
@@ -72,6 +84,9 @@ type SummaryStats struct {
 
 	// Pairwise tool impact (#123)
 	PairwiseImpacts []pairwise.ToolImpact `json:"pairwise_impacts,omitempty"`
+
+	// Action timeline (#140)
+	Timeline *TimelineSummary `json:"timeline_summary,omitempty"`
 }
 
 // ComputeSummaryStats computes aggregate statistics from a RunSummary.
@@ -241,6 +256,44 @@ func ComputeSummaryStats(s *RunSummary) *SummaryStats {
 	// Pairwise aggregation (#123)
 	if len(s.PairwiseResults) > 0 {
 		stats.PairwiseImpacts = pairwise.AggregateImpacts(s.PairwiseResults)
+	}
+
+	// Action timeline aggregation (#140)
+	var tlActions, tlToolCalls, tlTurns, tlSuccesses, tlFailures int
+	var tlToolDuration float64
+	evalsWithTimeline := 0
+	for _, r := range s.Results {
+		if r.ActionTimeline != nil {
+			evalsWithTimeline++
+			tlActions += r.ActionTimeline.Summary.TotalActions
+			tlToolCalls += r.ActionTimeline.Summary.TotalToolCalls
+			tlTurns += r.ActionTimeline.Summary.TotalTurns
+			tlToolDuration += r.ActionTimeline.Summary.ToolCallDuration
+			tlSuccesses += r.ActionTimeline.Summary.ToolSuccesses
+			tlFailures += r.ActionTimeline.Summary.ToolFailures
+		}
+	}
+	if evalsWithTimeline > 0 {
+		successDenom := tlSuccesses + tlFailures
+		successRate := 0.0
+		if successDenom > 0 {
+			successRate = float64(tlSuccesses) / float64(successDenom) * 100
+		}
+		avgDuration := 0.0
+		if tlToolCalls > 0 {
+			avgDuration = tlToolDuration / float64(tlToolCalls)
+		}
+		n := float64(evalsWithTimeline)
+		stats.Timeline = &TimelineSummary{
+			TotalActions:        tlActions,
+			TotalToolCalls:      tlToolCalls,
+			TotalTurns:          tlTurns,
+			AvgActionsPerEval:   math.Round(float64(tlActions)/n*10) / 10,
+			AvgToolCallsPerEval: math.Round(float64(tlToolCalls)/n*10) / 10,
+			AvgTurnsPerEval:     math.Round(float64(tlTurns)/n*10) / 10,
+			AvgToolCallDuration: math.Round(avgDuration*10) / 10,
+			ToolSuccessRate:     math.Round(successRate*10) / 10,
+		}
 	}
 
 	return stats

--- a/hyoka/internal/report/summary_stats_test.go
+++ b/hyoka/internal/report/summary_stats_test.go
@@ -134,3 +134,98 @@ func TestCalcDurationStats(t *testing.T) {
 		t.Error("expected zero stats for nil slice")
 	}
 }
+
+func TestComputeSummaryStatsTimeline(t *testing.T) {
+	s := &RunSummary{
+		Results: []*EvalReport{
+			{
+				PromptID:   "p1",
+				ConfigName: "baseline",
+				Duration:   10.0,
+				Success:    true,
+				ActionTimeline: &ActionTimelineReport{
+					Summary: ActionTimelineSummary{
+						TotalActions:     12,
+						TotalToolCalls:   4,
+						TotalTurns:       2,
+						ToolCallDuration: 400.0,
+						ToolSuccesses:    3,
+						ToolFailures:     1,
+					},
+				},
+			},
+			{
+				PromptID:   "p2",
+				ConfigName: "baseline",
+				Duration:   8.0,
+				Success:    true,
+				ActionTimeline: &ActionTimelineReport{
+					Summary: ActionTimelineSummary{
+						TotalActions:     8,
+						TotalToolCalls:   2,
+						TotalTurns:       1,
+						ToolCallDuration: 200.0,
+						ToolSuccesses:    2,
+						ToolFailures:     0,
+					},
+				},
+			},
+			{
+				// Eval without timeline (e.g. failed early)
+				PromptID:   "p3",
+				ConfigName: "baseline",
+				Duration:   1.0,
+				Success:    false,
+			},
+		},
+	}
+
+	stats := ComputeSummaryStats(s)
+
+	if stats.Timeline == nil {
+		t.Fatal("expected timeline summary")
+	}
+
+	tl := stats.Timeline
+	if tl.TotalActions != 20 {
+		t.Errorf("expected total_actions=20, got %d", tl.TotalActions)
+	}
+	if tl.TotalToolCalls != 6 {
+		t.Errorf("expected total_tool_calls=6, got %d", tl.TotalToolCalls)
+	}
+	if tl.TotalTurns != 3 {
+		t.Errorf("expected total_turns=3, got %d", tl.TotalTurns)
+	}
+	// avg actions per eval: 20/2 = 10.0
+	if tl.AvgActionsPerEval != 10.0 {
+		t.Errorf("expected avg_actions_per_eval=10.0, got %.1f", tl.AvgActionsPerEval)
+	}
+	// avg tool calls per eval: 6/2 = 3.0
+	if tl.AvgToolCallsPerEval != 3.0 {
+		t.Errorf("expected avg_tool_calls_per_eval=3.0, got %.1f", tl.AvgToolCallsPerEval)
+	}
+	// avg turns per eval: 3/2 = 1.5
+	if tl.AvgTurnsPerEval != 1.5 {
+		t.Errorf("expected avg_turns_per_eval=1.5, got %.1f", tl.AvgTurnsPerEval)
+	}
+	// avg tool duration: 600/6 = 100.0
+	if tl.AvgToolCallDuration != 100.0 {
+		t.Errorf("expected avg_tool_call_duration=100.0, got %.1f", tl.AvgToolCallDuration)
+	}
+	// tool success rate: 5/(5+1) * 100 = 83.3
+	if tl.ToolSuccessRate != 83.3 {
+		t.Errorf("expected tool_success_rate=83.3, got %.1f", tl.ToolSuccessRate)
+	}
+}
+
+func TestComputeSummaryStatsNoTimeline(t *testing.T) {
+	s := &RunSummary{
+		Results: []*EvalReport{
+			{PromptID: "p1", ConfigName: "c1", Duration: 5.0, Success: true},
+		},
+	}
+	stats := ComputeSummaryStats(s)
+	if stats.Timeline != nil {
+		t.Error("expected nil timeline when no evals have timelines")
+	}
+}

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -178,16 +178,21 @@ type ActionEventReport struct {
 
 // ActionSummaryReport holds aggregate statistics for the timeline.
 type ActionSummaryReport struct {
-	TotalEvents     int            `json:"total_events"`
-	TotalTurns      int            `json:"total_turns"`
-	ToolCalls       int            `json:"tool_calls"`
-	FileReads       int            `json:"file_reads"`
-	FileWrites      int            `json:"file_writes"`
-	BashCommands    int            `json:"bash_commands"`
-	MCPCalls        int            `json:"mcp_calls"`
-	Errors          int            `json:"errors"`
-	ToolBreakdown   map[string]int `json:"tool_breakdown"`
-	TotalDurationMs float64        `json:"total_duration_ms,omitempty"`
+	TotalEvents      int            `json:"total_events"`
+	TotalTurns       int            `json:"total_turns"`
+	TotalActions     int            `json:"total_actions"`
+	TotalToolCalls   int            `json:"total_tool_calls"`
+	ToolCalls        int            `json:"tool_calls"`
+	FileReads        int            `json:"file_reads"`
+	FileWrites       int            `json:"file_writes"`
+	BashCommands     int            `json:"bash_commands"`
+	MCPCalls         int            `json:"mcp_calls"`
+	Errors           int            `json:"errors"`
+	ToolBreakdown    map[string]int `json:"tool_breakdown"`
+	TotalDurationMs  float64        `json:"total_duration_ms,omitempty"`
+	ToolCallDuration float64        `json:"tool_call_duration_ms,omitempty"`
+	ToolSuccesses    int            `json:"tool_successes"`
+	ToolFailures     int            `json:"tool_failures"`
 }
 
 // EvalReport contains the results of a single prompt evaluation.
@@ -229,6 +234,59 @@ type EvalReport struct {
 	GuardrailAbortReason       string `json:"guardrail_abort_reason,omitempty"`
 }
 
+
+// BuildActionTimeline derives a structured action timeline from SessionEvents.
+// This is a fallback for reports that don't have a pre-built timeline from the
+// eval engine (e.g., when re-rendering from JSON).
+func BuildActionTimeline(events []SessionEventRecord) *ActionTimelineReport {
+	if len(events) == 0 {
+		return nil
+	}
+	var reportEvents []ActionEventReport
+	var summary ActionSummaryReport
+	seq := 0
+	turnNumber := 0
+
+	for _, ev := range events {
+		seq++
+		switch ev.Type {
+		case "assistant.turn_start":
+			turnNumber++
+			summary.TotalTurns++
+			summary.TotalActions++
+		case "assistant.turn_end":
+			summary.TotalActions++
+		case "tool.execution_start":
+			summary.TotalToolCalls++
+			summary.TotalActions++
+			summary.ToolCalls++
+			reportEvents = append(reportEvents, ActionEventReport{
+				Sequence:   seq,
+				Type:       "tool_call",
+				Tool:       ev.ToolName,
+				Path:       ev.FilePath,
+				TurnNumber: turnNumber,
+				MCPServer:  ev.MCPServerName,
+			})
+		case "tool.execution_complete":
+			summary.TotalActions++
+			summary.ToolCallDuration += ev.Duration
+			summary.TotalDurationMs += ev.Duration
+			if ev.ToolSuccess != nil {
+				if *ev.ToolSuccess {
+					summary.ToolSuccesses++
+				} else {
+					summary.ToolFailures++
+				}
+			}
+		}
+	}
+	summary.TotalEvents = len(events)
+	return &ActionTimelineReport{
+		Events:  reportEvents,
+		Summary: summary,
+	}
+}
 
 // RunResourceStats holds aggregate resource utilization across all evals (#45).
 type RunResourceStats struct {


### PR DESCRIPTION
## Summary

Adds structured action timeline to JSON report output, enabling downstream consumers to analyze the sequence and timing of actions during code generation sessions.

Closes #140

## Changes

### New Types (report/types.go)
- **`ActionTimelineEntry`** — individual timeline action (tool call, reasoning, message, turn, intent) with timing, success, and metadata
- **`ActionTimelineSummary`** — per-eval aggregate stats (total actions, tool calls, turns, tool duration, success/failure counts)
- **`ActionTimelineReport`** — entries + summary, serialized as `action_timeline` in JSON

### Timeline Builder
- **`BuildActionTimeline()`** processes `SessionEvents` into structured entries using LIFO tool-call pairing (`tool.execution_start` → `tool.execution_complete`)
- Handles all action event types: turn lifecycle, reasoning, messages, tool calls, intents

### Report Integration
- **`WriteReport()`** automatically builds the timeline before serialization when not already set
- **`EvalReport.ActionTimeline`** field with `omitempty` for backward compatibility
- **`TimelineSummary`** added to `SummaryStats` with cross-eval aggregation (avg actions/tool calls/turns per eval, tool success rate, avg tool call duration)

### Tests
- `TestBuildActionTimeline` — verifies entry creation, LIFO tool pairing, success/failure tracking, MCP server propagation
- `TestBuildActionTimelineEmpty` — nil/empty input edge cases
- `TestActionTimelineJSONRoundTrip` — marshal → write → read → unmarshal → field verification
- `TestActionTimelinePresetNotOverwritten` — pre-set timelines preserved
- `TestComputeSummaryStatsTimeline` — aggregation across multiple evals
- `TestComputeSummaryStatsNoTimeline` — graceful handling when no evals have timelines