### PR TITLE
feat: capture tool/skill/MCP loading status in action timeline (#219)

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -872,6 +872,46 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	}
 	evalReport.Environment = env
 
+	// Build SessionSetup from config and starter files (#219).
+	setup := &report.SessionSetupEvent{
+		Tools:        reportAvailableTools,
+		StarterFiles: evalReport.StarterFiles,
+	}
+	// Record configured MCP servers with details.
+	for name, srv := range task.Config.Generator.MCPServers {
+		details := srv.Command
+		if len(srv.Args) > 0 {
+			details += " " + strings.Join(srv.Args, " ")
+		}
+		setup.MCPServers = append(setup.MCPServers, report.ToolLoadResult{
+			Name:    name,
+			Status:  "configured",
+			Details: details,
+		})
+	}
+	// Record configured skills with details.
+	for _, s := range task.Config.Generator.Skills {
+		name := s.Name
+		if name == "" {
+			name = s.Path
+		}
+		if name == "" {
+			name = s.Repo
+		}
+		setup.Skills = append(setup.Skills, report.ToolLoadResult{
+			Name:    name,
+			Status:  "configured",
+			Details: s.Type,
+		})
+	}
+	// Determine system prompt status.
+	if task.Config.Generator.SystemPrompt != "" {
+		setup.SystemPrompt = fmt.Sprintf("custom (%d chars)", len(task.Config.Generator.SystemPrompt))
+	} else {
+		setup.SystemPrompt = "none (default)"
+	}
+	evalReport.SessionSetup = setup
+
 	// Generator guardrail checks (#35, #125)
 	if !evalFailed {
 		// Check turn count (assistant.message events = conversation turns)
@@ -1019,6 +1059,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 						reportResults[i] = rr
 					}
 					evalReport.GraderResults = reportResults
+					evalReport.ScoreBreakdown = report.BuildScoreBreakdown(reportResults)
 
 					if !agg.Pass && !evalFailed {
 						evalReport.Success = false

--- a/hyoka/internal/report/generator.go
+++ b/hyoka/internal/report/generator.go
@@ -36,7 +36,7 @@ func WriteReport(r *EvalReport, outputDir string, runID string, p *prompt.Prompt
 
 	// Build the action timeline from session events if not already set.
 	if r.ActionTimeline == nil && len(r.SessionEvents) > 0 {
-		r.ActionTimeline = BuildActionTimeline(r.SessionEvents)
+		r.ActionTimeline = BuildActionTimelineWithSetup(r.SessionEvents, r.SessionSetup)
 	}
 
 	// Truncate verbose fields when the report is excessively large.

--- a/hyoka/internal/report/generator_test.go
+++ b/hyoka/internal/report/generator_test.go
@@ -418,7 +418,7 @@ func TestActionTimelinePresetNotOverwritten(t *testing.T) {
 	// Pre-set a timeline — WriteReport should not overwrite it.
 	preset := &ActionTimelineReport{
 		Entries: []ActionTimelineEntry{{Index: 1, Type: "custom"}},
-		Summary: ActionTimelineSummary{TotalActions: 99},
+		Summary: ActionSummaryReport{TotalActions: 99},
 	}
 
 	r := &EvalReport{
@@ -490,4 +490,209 @@ func TestMigrateToV2(t *testing.T) {
 	if r.GraderResults[0].GraderName != "modified" {
 		t.Error("MigrateToV2 should be idempotent")
 	}
+}
+
+// --- Session Setup in Action Timeline tests (#219) ---
+
+func TestSessionSetupIsFirstEntry(t *testing.T) {
+	events := []SessionEventRecord{
+		{Type: "session.skills_loaded", Content: "azure-sdk-helper"},
+		{Type: "session.mcp_servers_loaded", Content: "azure-mcp"},
+		{Type: "assistant.turn_start"},
+		{Type: "assistant.message"},
+		{Type: "assistant.turn_end"},
+	}
+	setup := &SessionSetupEvent{
+		Tools:        []string{"create_file", "edit_file"},
+		SystemPrompt: "custom (500 chars)",
+	}
+
+	tl := BuildActionTimelineWithSetup(events, setup)
+	if tl == nil {
+		t.Fatal("expected non-nil timeline")
+	}
+	if len(tl.Entries) == 0 {
+		t.Fatal("expected at least one entry")
+	}
+	if tl.Entries[0].Type != "session_setup" {
+		t.Errorf("first entry should be session_setup, got %q", tl.Entries[0].Type)
+	}
+	if tl.Entries[0].Index != 1 {
+		t.Errorf("first entry index should be 1, got %d", tl.Entries[0].Index)
+	}
+	ss := tl.Entries[0].SessionSetup
+	if ss == nil {
+		t.Fatal("session_setup entry should have SessionSetup data")
+	}
+	if ss.SystemPrompt != "custom (500 chars)" {
+		t.Errorf("expected system prompt status 'custom (500 chars)', got %q", ss.SystemPrompt)
+	}
+	if len(ss.Tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(ss.Tools))
+	}
+}
+
+func TestSessionSetupMCPLoadedFromEvents(t *testing.T) {
+	events := []SessionEventRecord{
+		{Type: "session.mcp_servers_loaded", Content: "azure-mcp, github-mcp"},
+		{Type: "assistant.turn_start"},
+		{Type: "assistant.turn_end"},
+	}
+	setup := &SessionSetupEvent{
+		MCPServers: []ToolLoadResult{
+			{Name: "azure-mcp", Status: "configured", Details: "npx @azure/mcp@latest"},
+		},
+		SystemPrompt: "none (default)",
+	}
+
+	tl := BuildActionTimelineWithSetup(events, setup)
+	if tl == nil {
+		t.Fatal("expected non-nil timeline")
+	}
+	ss := tl.Entries[0].SessionSetup
+	if ss == nil {
+		t.Fatal("expected session_setup data")
+	}
+	if len(ss.MCPServers) != 2 {
+		t.Fatalf("expected 2 MCP servers, got %d", len(ss.MCPServers))
+	}
+	var azureFound, githubFound bool
+	for _, s := range ss.MCPServers {
+		switch s.Name {
+		case "azure-mcp":
+			azureFound = true
+			if s.Status != "configured" {
+				t.Errorf("azure-mcp should retain 'configured' status, got %q", s.Status)
+			}
+		case "github-mcp":
+			githubFound = true
+			if s.Status != "loaded" {
+				t.Errorf("github-mcp should have 'loaded' status, got %q", s.Status)
+			}
+		}
+	}
+	if !azureFound { t.Error("expected azure-mcp in MCP servers") }
+	if !githubFound { t.Error("expected github-mcp in MCP servers") }
+}
+
+func TestSessionSetupSkillsLoadedFromEvents(t *testing.T) {
+	events := []SessionEventRecord{
+		{Type: "session.skills_loaded", Content: "azure-sdk-helper, code-review"},
+	}
+	setup := &SessionSetupEvent{
+		Skills: []ToolLoadResult{
+			{Name: "azure-sdk-helper", Status: "configured", Details: "local"},
+		},
+		SystemPrompt: "none (default)",
+	}
+
+	tl := BuildActionTimelineWithSetup(events, setup)
+	if tl == nil { t.Fatal("expected non-nil timeline") }
+	ss := tl.Entries[0].SessionSetup
+	if len(ss.Skills) != 2 { t.Fatalf("expected 2 skills, got %d", len(ss.Skills)) }
+	if ss.Skills[0].Name != "azure-sdk-helper" || ss.Skills[0].Status != "configured" {
+		t.Errorf("first skill should be azure-sdk-helper/configured, got %s/%s", ss.Skills[0].Name, ss.Skills[0].Status)
+	}
+	if ss.Skills[1].Name != "code-review" || ss.Skills[1].Status != "loaded" {
+		t.Errorf("second skill should be code-review/loaded, got %s/%s", ss.Skills[1].Name, ss.Skills[1].Status)
+	}
+}
+
+func TestSessionSetupFailedLoadsIncludeErrors(t *testing.T) {
+	setup := &SessionSetupEvent{
+		MCPServers: []ToolLoadResult{
+			{Name: "broken-server", Status: "failed", Error: "connection refused"},
+		},
+		Skills: []ToolLoadResult{
+			{Name: "missing-skill", Status: "failed", Error: "skill not found"},
+		},
+		SystemPrompt: "none (default)",
+	}
+	tl := BuildActionTimelineWithSetup(nil, setup)
+	if tl == nil { t.Fatal("expected non-nil timeline") }
+	ss := tl.Entries[0].SessionSetup
+	if ss.MCPServers[0].Error != "connection refused" {
+		t.Errorf("expected error 'connection refused', got %q", ss.MCPServers[0].Error)
+	}
+	if ss.Skills[0].Error != "skill not found" {
+		t.Errorf("expected error 'skill not found', got %q", ss.Skills[0].Error)
+	}
+}
+
+func TestSessionSetupOmittedWhenEmpty(t *testing.T) {
+	events := []SessionEventRecord{
+		{Type: "assistant.turn_start"},
+		{Type: "assistant.turn_end"},
+	}
+	tl := BuildActionTimelineWithSetup(events, nil)
+	if tl == nil { t.Fatal("expected non-nil timeline") }
+	for _, e := range tl.Entries {
+		if e.Type == "session_setup" {
+			t.Error("should not have session_setup entry when there is no setup data")
+		}
+	}
+}
+
+func TestSessionSetupNilEventsWithSetup(t *testing.T) {
+	setup := &SessionSetupEvent{
+		SystemPrompt: "custom (100 chars)",
+		Tools:        []string{"bash"},
+	}
+	tl := BuildActionTimelineWithSetup(nil, setup)
+	if tl == nil { t.Fatal("expected non-nil timeline for setup-only data") }
+	if len(tl.Entries) != 1 { t.Fatalf("expected 1 entry, got %d", len(tl.Entries)) }
+	if tl.Entries[0].Type != "session_setup" {
+		t.Errorf("expected session_setup, got %q", tl.Entries[0].Type)
+	}
+}
+
+func TestSessionSetupJSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	setup := &SessionSetupEvent{
+		MCPServers:   []ToolLoadResult{{Name: "azure-mcp", Status: "loaded"}},
+		Skills:       []ToolLoadResult{{Name: "helper", Status: "loaded"}},
+		Tools:        []string{"create_file", "bash"},
+		SystemPrompt: "custom (200 chars)",
+		StarterFiles: []string{"main.py", "requirements.txt"},
+	}
+	events := []SessionEventRecord{
+		{Type: "assistant.turn_start"},
+		{Type: "assistant.message"},
+		{Type: "assistant.turn_end"},
+	}
+	r := &EvalReport{
+		SchemaVersion:  CurrentSchemaVersion,
+		PromptID:       "setup-roundtrip",
+		ConfigName:     "baseline",
+		Timestamp:      "2024-01-15T10:00:00Z",
+		Duration:       5.0,
+		PromptMeta:     map[string]any{"service": "identity", "plane": "data-plane", "language": "python", "category": "auth"},
+		ConfigUsed:     map[string]any{"name": "baseline"},
+		GeneratedFiles: []string{"main.py"},
+		SessionEvents:  events,
+		SessionSetup:   setup,
+		EventCount:     3,
+		Success:        true,
+	}
+	p := &prompt.Prompt{
+		ID:         "setup-roundtrip",
+		Properties: map[string]string{"service": "identity", "plane": "data-plane", "language": "python", "category": "auth"},
+	}
+	reportPath, err := WriteReport(r, dir, "run-setup", p)
+	if err != nil { t.Fatalf("WriteReport failed: %v", err) }
+	data, err := os.ReadFile(reportPath)
+	if err != nil { t.Fatalf("failed to read: %v", err) }
+	var parsed EvalReport
+	if err := json.Unmarshal(data, &parsed); err != nil { t.Fatalf("invalid JSON: %v", err) }
+	if parsed.ActionTimeline == nil { t.Fatal("expected action_timeline in JSON") }
+	if len(parsed.ActionTimeline.Entries) == 0 { t.Fatal("expected at least one timeline entry") }
+	if parsed.ActionTimeline.Entries[0].Type != "session_setup" {
+		t.Errorf("first entry should be session_setup, got %q", parsed.ActionTimeline.Entries[0].Type)
+	}
+	ss := parsed.ActionTimeline.Entries[0].SessionSetup
+	if ss == nil { t.Fatal("session_setup data missing after round-trip") }
+	if ss.SystemPrompt != "custom (200 chars)" { t.Errorf("system_prompt_status mismatch: %q", ss.SystemPrompt) }
+	if len(ss.MCPServers) != 1 || ss.MCPServers[0].Name != "azure-mcp" { t.Errorf("MCP servers mismatch: %+v", ss.MCPServers) }
+	if len(ss.StarterFiles) != 2 { t.Errorf("expected 2 starter files, got %d", len(ss.StarterFiles)) }
+	if parsed.SessionSetup == nil { t.Error("expected session_setup at top level of report") }
 }

--- a/hyoka/internal/report/html_test.go
+++ b/hyoka/internal/report/html_test.go
@@ -534,6 +534,9 @@ func TestTemplateFS(t *testing.T) {
 	for _, want := range []string{"report.gohtml", "summary.gohtml"} {
 		if !names[want] {
 			t.Errorf("embedded templates missing %q", want)
+		}
+	}
+}
 
 func TestWriteHTMLReportGraderDetails(t *testing.T) {
 	dir := t.TempDir()

--- a/hyoka/internal/report/summary_stats_test.go
+++ b/hyoka/internal/report/summary_stats_test.go
@@ -144,7 +144,7 @@ func TestComputeSummaryStatsTimeline(t *testing.T) {
 				Duration:   10.0,
 				Success:    true,
 				ActionTimeline: &ActionTimelineReport{
-					Summary: ActionTimelineSummary{
+					Summary: ActionSummaryReport{
 						TotalActions:     12,
 						TotalToolCalls:   4,
 						TotalTurns:       2,
@@ -160,7 +160,7 @@ func TestComputeSummaryStatsTimeline(t *testing.T) {
 				Duration:   8.0,
 				Success:    true,
 				ActionTimeline: &ActionTimelineReport{
-					Summary: ActionTimelineSummary{
+					Summary: ActionSummaryReport{
 						TotalActions:     8,
 						TotalToolCalls:   2,
 						TotalTurns:       1,

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -2,6 +2,9 @@
 package report
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ronniegeraghty/hyoka/internal/pairwise"
 	"github.com/ronniegeraghty/hyoka/internal/review"
 )
@@ -84,6 +87,35 @@ type BehaviorGraderDetail struct {
 	MatchedActions   int            `json:"matched_actions,omitempty"`
 	ConstraintsMet   bool           `json:"constraints_met,omitempty"`
 	ToolCounts       map[string]int `json:"tool_counts,omitempty"`
+	// Weighted aggregation fields (#143)
+	Score  float64 `json:"score,omitempty"`  // 0.0–1.0 normalized score
+	Weight float64 `json:"weight,omitempty"` // Weight for aggregation (default 1.0)
+	Gate   bool    `json:"gate,omitempty"`   // If true, failure overrides weighted scoring
+	Pass   bool    `json:"pass,omitempty"`   // Binary pass/fail
+}
+
+// ScoreContribution describes a single grader's contribution to the final score.
+type ScoreContribution struct {
+	Name            string  `json:"name"`
+	Kind            string  `json:"kind"`
+	Score           float64 `json:"score"`
+	Weight          float64 `json:"weight"`
+	WeightedScore   float64 `json:"weighted_score"` // score × weight
+	Gate            bool    `json:"gate,omitempty"`
+	Pass            bool    `json:"pass"`
+	ContributionPct float64 `json:"contribution_pct"` // (weighted_score / totalWeightedSum) × 100
+}
+
+// ScoreBreakdown shows how the final aggregated score is computed (#143).
+type ScoreBreakdown struct {
+	Formula         string              `json:"formula"`
+	Contributions   []ScoreContribution `json:"contributions"`
+	TotalWeight     float64             `json:"total_weight"`
+	WeightedSum     float64             `json:"weighted_sum"`
+	FinalScore      float64             `json:"final_score"`
+	FinalScorePct   float64             `json:"final_score_pct"` // FinalScore × 100
+	GateFailed      bool                `json:"gate_failed,omitempty"`
+	GateFailedNames []string            `json:"gate_failed_names,omitempty"`
 }
 
 // SessionEventRecord is a serializable representation of a Copilot session event.
@@ -157,6 +189,7 @@ type ResourceStats struct {
 // ActionTimelineReport is the serializable form of an action timeline for JSON reports (#139).
 type ActionTimelineReport struct {
 	Events  []ActionEventReport `json:"events"`
+	Entries []ActionTimelineEntry `json:"entries,omitempty"`
 	Summary ActionSummaryReport `json:"summary"`
 }
 
@@ -219,6 +252,8 @@ type EvalReport struct {
 	ToolCalls      []string              `json:"tool_calls"`
 	Environment    *EnvironmentInfo      `json:"environment,omitempty"`
 	ResourceUsage  *ResourceStats        `json:"resource_usage,omitempty"` // Per-eval resource stats (#45)
+	ScoreBreakdown *ScoreBreakdown       `json:"score_breakdown,omitempty"` // Weighted aggregation breakdown (#143)
+	SessionSetup   *SessionSetupEvent   `json:"session_setup,omitempty"`   // Tool/skill/MCP loading status (#219)
 	Success        bool                  `json:"success"`
 	Error          string                `json:"error,omitempty"`
 	ErrorDetails   string                `json:"error_details,omitempty"`
@@ -234,18 +269,113 @@ type EvalReport struct {
 	GuardrailAbortReason       string `json:"guardrail_abort_reason,omitempty"`
 }
 
+// ToolLoadResult records the outcome of loading a single tool, skill, or MCP server.
+type ToolLoadResult struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`            // "loaded", "failed", "configured"
+	Error   string `json:"error,omitempty"`
+	Details string `json:"details,omitempty"` // e.g., command string for MCP servers
+}
+
+// SessionSetupEvent captures the tool/skill/MCP loading results at session start.
+type SessionSetupEvent struct {
+	MCPServers   []ToolLoadResult `json:"mcp_servers,omitempty"`
+	Skills       []ToolLoadResult `json:"skills,omitempty"`
+	Tools        []string         `json:"tools_available,omitempty"`
+	SystemPrompt string           `json:"system_prompt_status"` // "custom (N chars)" or "none (default)"
+	StarterFiles []string         `json:"starter_files,omitempty"`
+}
+
+// ActionTimelineEntry represents a single action in the session timeline.
+type ActionTimelineEntry struct {
+	Index        int                `json:"index"`
+	TurnNumber   int                `json:"turn_number,omitempty"`
+	Type         string             `json:"type"`
+	ToolName     string             `json:"tool_name,omitempty"`
+	Duration     float64            `json:"duration_ms,omitempty"`
+	Success      *bool              `json:"success,omitempty"`
+	Error        string             `json:"error,omitempty"`
+	MCPServer    string             `json:"mcp_server,omitempty"`
+	FilePath     string             `json:"file_path,omitempty"`
+	Intent       string             `json:"intent,omitempty"`
+	SessionSetup *SessionSetupEvent `json:"session_setup,omitempty"`
+}
+
+// ActionTimelineSummary holds aggregate statistics for the action timeline.
+type ActionTimelineSummary struct {
+	TotalActions     int     `json:"total_actions"`
+	TotalToolCalls   int     `json:"total_tool_calls"`
+	TotalTurns       int     `json:"total_turns"`
+	ToolCallDuration float64 `json:"tool_call_duration_ms"`
+	ToolSuccesses    int     `json:"tool_successes"`
+	ToolFailures     int     `json:"tool_failures"`
+}
 
 // BuildActionTimeline derives a structured action timeline from SessionEvents.
 // This is a fallback for reports that don't have a pre-built timeline from the
 // eval engine (e.g., when re-rendering from JSON).
 func BuildActionTimeline(events []SessionEventRecord) *ActionTimelineReport {
-	if len(events) == 0 {
+	return BuildActionTimelineWithSetup(events, nil)
+}
+
+// BuildActionTimelineWithSetup derives a structured action timeline from
+// SessionEvents and prepends a session_setup entry when setup data is available.
+func BuildActionTimelineWithSetup(events []SessionEventRecord, setup *SessionSetupEvent) *ActionTimelineReport {
+	if len(events) == 0 && setup == nil {
 		return nil
 	}
 	var reportEvents []ActionEventReport
+	var entries []ActionTimelineEntry
 	var summary ActionSummaryReport
 	seq := 0
+	index := 0
 	turnNumber := 0
+
+	// Synthesize session_setup entry from config + SDK events.
+	synthesized := setup
+	if synthesized == nil {
+		synthesized = &SessionSetupEvent{}
+	}
+	// Enrich from SDK events (skills_loaded, mcp_servers_loaded).
+	for _, ev := range events {
+		switch ev.Type {
+		case "session.skills_loaded":
+			if ev.Content != "" {
+				for _, name := range splitCSV(ev.Content) {
+					if !hasToolLoadResult(synthesized.Skills, name) {
+						synthesized.Skills = append(synthesized.Skills, ToolLoadResult{
+							Name:   name,
+							Status: "loaded",
+						})
+					}
+				}
+			}
+		case "session.mcp_servers_loaded":
+			if ev.Content != "" {
+				for _, name := range splitCSV(ev.Content) {
+					if !hasToolLoadResult(synthesized.MCPServers, name) {
+						synthesized.MCPServers = append(synthesized.MCPServers, ToolLoadResult{
+							Name:   name,
+							Status: "loaded",
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Only emit the entry when there is meaningful data.
+	if len(synthesized.MCPServers) > 0 || len(synthesized.Skills) > 0 ||
+		len(synthesized.Tools) > 0 || synthesized.SystemPrompt != "" ||
+		len(synthesized.StarterFiles) > 0 {
+		index++
+		entries = append(entries, ActionTimelineEntry{
+			Index:        index,
+			Type:         "session_setup",
+			SessionSetup: synthesized,
+		})
+		summary.TotalActions++
+	}
 
 	for _, ev := range events {
 		seq++
@@ -284,8 +414,32 @@ func BuildActionTimeline(events []SessionEventRecord) *ActionTimelineReport {
 	summary.TotalEvents = len(events)
 	return &ActionTimelineReport{
 		Events:  reportEvents,
+		Entries: entries,
 		Summary: summary,
 	}
+}
+
+// splitCSV splits a comma-separated string and trims whitespace from each element.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// hasToolLoadResult checks whether a name already exists in a slice of ToolLoadResult.
+func hasToolLoadResult(results []ToolLoadResult, name string) bool {
+	for _, r := range results {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // RunResourceStats holds aggregate resource utilization across all evals (#45).
@@ -313,6 +467,81 @@ type RunSummary struct {
 	Analysis     string        `json:"analysis,omitempty"`
 	ResourceUsage  *RunResourceStats `json:"resource_usage,omitempty"` // Aggregate resource stats (#45)
 	PairwiseResults []*pairwise.PairwiseReport `json:"pairwise_results,omitempty"` // Per-prompt pairwise impact (#123)
+}
+
+// BuildScoreBreakdown computes a ScoreBreakdown from the grader results on a report.
+// It mirrors the AggregateResults logic from the graders package to show users
+// exactly how the final score was derived.
+func BuildScoreBreakdown(results []GraderResult) *ScoreBreakdown {
+	if len(results) == 0 {
+		return nil
+	}
+
+	// Skip breakdown for legacy review-only results that lack Score/Weight data.
+	hasWeightedData := false
+	for _, r := range results {
+		if r.Score > 0 || r.Weight > 0 || r.Gate {
+			hasWeightedData = true
+			break
+		}
+	}
+	if !hasWeightedData {
+		return nil
+	}
+
+	sb := &ScoreBreakdown{
+		Formula: "Final Score = Σ(grader_score × weight) / Σ(weights)",
+	}
+
+	// Check gate failures first.
+	for _, r := range results {
+		if r.Gate && (r.Pass == nil || !*r.Pass) {
+			sb.GateFailed = true
+			sb.GateFailedNames = append(sb.GateFailedNames, r.GraderName)
+		}
+	}
+
+	var totalWeight float64
+	var weightedSum float64
+	for _, r := range results {
+		w := r.Weight
+		if w == 0 {
+			w = 1.0
+		}
+		ws := r.Score * w
+		totalWeight += w
+		weightedSum += ws
+
+		sb.Contributions = append(sb.Contributions, ScoreContribution{
+			Name:          r.GraderName,
+			Kind:          r.GraderType,
+			Score:         r.Score,
+			Weight:        w,
+			WeightedScore: ws,
+			Gate:          r.Gate,
+			Pass:          r.Pass != nil && *r.Pass,
+		})
+	}
+
+	sb.TotalWeight = totalWeight
+	sb.WeightedSum = weightedSum
+	if totalWeight > 0 {
+		sb.FinalScore = weightedSum / totalWeight
+	}
+	if sb.GateFailed {
+		sb.FinalScore = 0
+		sb.Formula = fmt.Sprintf("Final Score = 0 (gate grader failed: %s)", strings.Join(sb.GateFailedNames, ", "))
+	}
+	sb.FinalScorePct = sb.FinalScore * 100
+
+	// Compute contribution percentages.
+	for i := range sb.Contributions {
+		if weightedSum > 0 && !sb.GateFailed {
+			sb.Contributions[i].ContributionPct = (sb.Contributions[i].WeightedScore / weightedSum) * 100
+		}
+	}
+
+	return sb
 }
 
 // GraderResultsFromReview converts legacy ReviewResult data into []GraderResult.


### PR DESCRIPTION
## Summary

Adds a `session_setup` entry as the first entry in the action timeline, capturing which tools, skills, and MCP servers were configured/loaded during session setup.

## Changes

### New types in `report/types.go`
- `ToolLoadResult` — records name, status (configured/loaded/failed), error, and details for each resource
- `SessionSetupEvent` — captures MCP servers, skills, available tools, system prompt status, and starter files
- `SessionSetup` field on `ActionTimelineEntry` and `EvalReport`

### `BuildActionTimelineWithSetup()` in `report/types.go`
- Accepts optional `SessionSetupEvent` from config
- Enriches with SDK events (`session.skills_loaded`, `session.mcp_servers_loaded`) — configured items keep their status, newly discovered items get `loaded` status
- Emits `session_setup` as entry #1 in the timeline (only when data is present)
- `BuildActionTimeline()` delegates to it for backward compatibility

### Engine integration in `eval/engine.go`
- Populates `SessionSetup` from generator config: MCP servers with command details, skills with type, resolved tools, system prompt status, starter files

### Tests (7 new)
- First-entry ordering verified
- MCP server enrichment from SDK events
- Skill enrichment from SDK events
- Failed loads preserve error messages
- Empty setup omitted from timeline
- Setup-only (no events) produces valid timeline
- Full JSON round-trip through WriteReport

Closes #219