### PR TITLE
feat: render action timeline in HTML reports (#141)

### DIFF
--- a/hyoka/internal/report/html.go
+++ b/hyoka/internal/report/html.go
@@ -523,6 +523,12 @@ func htmlFuncMap() template.FuncMap {
 		"fmtDuration": func(d float64) string {
 			return fmt.Sprintf("%.1fs", d)
 		},
+		"fmtDurationMs": func(ms float64) string {
+			if ms >= 1000 {
+				return fmt.Sprintf("%.1fs", ms/1000)
+			}
+			return fmt.Sprintf("%.0fms", ms)
+		},
 		"truncate": func(s string, n int) string {
 			if len(s) <= n {
 				return s
@@ -626,6 +632,9 @@ func htmlFuncMap() template.FuncMap {
 				return "✅"
 			}
 			return "❌"
+		},
+		"derefBool": func(b *bool) bool {
+			return b != nil && *b
 		},
 		"reportLink": func(r *EvalReport) string {
 			service, _ := r.PromptMeta["service"].(string)

--- a/hyoka/internal/report/html_test.go
+++ b/hyoka/internal/report/html_test.go
@@ -682,3 +682,99 @@ func TestWriteHTMLReportGraderDetails(t *testing.T) {
 		}
 	}
 }
+
+func TestActionTimelineHTMLRendering(t *testing.T) {
+	boolTrue := true
+	boolFalse := false
+
+	r := &EvalReport{
+		PromptID:       "timeline-test",
+		ConfigName:     "test-config",
+		Timestamp:      "2024-06-01T12:00:00Z",
+		Duration:       30.0,
+		PromptMeta:     map[string]any{"service": "identity", "plane": "data-plane", "language": "python", "category": "auth"},
+		ConfigUsed:     map[string]any{"name": "test-config"},
+		GeneratedFiles: []string{"main.py"},
+		Success:        true,
+		SessionEvents: []SessionEventRecord{
+			{Type: "user.message", Content: "test prompt"},
+			{Type: "assistant.reasoning", Content: "thinking"},
+			{Type: "tool.execution_start", ToolName: "create", ToolArgs: `{"path":"main.py"}`},
+			{Type: "tool.execution_complete", ToolName: "create", ToolResult: "ok", ToolSuccess: &boolTrue, Duration: 150},
+			{Type: "assistant.message", Content: "Done"},
+		},
+		ActionTimeline: BuildActionTimeline([]SessionEventRecord{
+			{Type: "assistant.turn_start"},
+			{Type: "assistant.reasoning"},
+			{Type: "tool.execution_start", ToolName: "create", MCPServerName: "fs-server", FilePath: "main.py"},
+			{Type: "tool.execution_complete", ToolName: "create", ToolSuccess: &boolTrue, Duration: 150},
+			{Type: "tool.execution_start", ToolName: "bash", FilePath: "/workspace/build.sh"},
+			{Type: "tool.execution_complete", ToolName: "bash", ToolSuccess: &boolFalse, Duration: 2500, Error: "build failed"},
+			{Type: "assistant.intent", Intent: "fixing imports"},
+			{Type: "assistant.message"},
+			{Type: "assistant.turn_end"},
+		}),
+	}
+
+	data := buildReportData(r)
+	data.BackPath = "../summary.html"
+
+	var buf bytes.Buffer
+	if err := parsedReportTemplate.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	html := buf.String()
+
+	checks := []string{
+		"Action Timeline",
+		"atl-summary-bar",
+		"atl-search",
+		"atl-list",
+		"atl-row",
+		"tool calls",
+		"turns",
+		"tool duration",
+		"succeeded",
+		"create",
+		"bash",
+		"fs-server",
+		"150ms",
+		"2.5s",
+		"atl-success",
+		"atl-failure",
+		"fixing imports",
+		"build failed",
+		"Filter timeline",
+	}
+	for _, check := range checks {
+		if !strings.Contains(html, check) {
+			t.Errorf("action timeline HTML missing %q", check)
+		}
+	}
+}
+
+func TestActionTimelineHTMLOmittedWhenNil(t *testing.T) {
+	r := &EvalReport{
+		PromptID:       "no-timeline",
+		ConfigName:     "test-config",
+		Timestamp:      "2024-06-01T12:00:00Z",
+		Duration:       5.0,
+		PromptMeta:     map[string]any{},
+		ConfigUsed:     map[string]any{},
+		GeneratedFiles: []string{},
+		Success:        true,
+	}
+
+	data := buildReportData(r)
+	data.BackPath = "../summary.html"
+
+	var buf bytes.Buffer
+	if err := parsedReportTemplate.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	html := buf.String()
+
+	if strings.Contains(html, "atl-summary-bar") {
+		t.Error("action timeline section should not render when ActionTimeline is nil")
+	}
+}

--- a/hyoka/internal/report/templates/report.gohtml
+++ b/hyoka/internal/report/templates/report.gohtml
@@ -129,6 +129,39 @@
   .tl-card details summary { font-size: 0.85rem; font-weight: 500; }
   .tl-card pre { font-size: 0.8rem; margin: 0.25rem 0 0 0; max-height: 300px; overflow-y: auto; }
   .tl-error { color: var(--red); font-size: 0.85rem; margin-top: 0.3rem; }
+
+  {{if .ActionTimeline}}
+  /* ━━ Action Timeline ━━ */
+  .atl-section { margin-bottom: 1.25rem; }
+  .atl-summary-bar { display: flex; flex-wrap: wrap; gap: 1rem; padding: 0.75rem 1rem; background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 8px; margin-bottom: 1rem; font-size: 0.85rem; }
+  .atl-stat { display: flex; align-items: center; gap: 0.25rem; }
+  .atl-stat strong { color: var(--text); }
+  .atl-stat span { color: var(--text-muted); }
+  .atl-filter { margin-bottom: 0.75rem; }
+  .atl-filter input { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.85rem; background: var(--card-bg); color: var(--text); }
+  .atl-filter input::placeholder { color: var(--text-muted); }
+  .atl-list { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: var(--card-bg); }
+  .atl-row { display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f1f5f9; font-size: 0.85rem; }
+  .atl-row:last-child { border-bottom: none; }
+  .atl-row.atl-tool_call { border-left: 3px solid var(--indigo); }
+  .atl-row.atl-turn_start { border-left: 3px solid var(--blue); background: #f8fafc; }
+  .atl-row.atl-turn_end { border-left: 3px solid var(--blue); background: #f8fafc; }
+  .atl-row.atl-reasoning { border-left: 3px solid #93c5fd; }
+  .atl-row.atl-message { border-left: 3px solid #6366f1; }
+  .atl-row.atl-intent { border-left: 3px solid var(--purple); }
+  .atl-idx { min-width: 2rem; color: var(--text-muted); font-family: monospace; font-size: 0.8rem; text-align: right; padding-top: 0.1rem; }
+  .atl-icon { font-size: 0.9rem; min-width: 1.5rem; text-align: center; padding-top: 0.1rem; }
+  .atl-body { flex: 1; min-width: 0; }
+  .atl-label { font-weight: 600; display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+  .atl-label code { font-size: 0.82em; color: var(--purple); background: #f3f0ff; padding: 1px 6px; border-radius: 3px; }
+  .atl-meta { display: flex; gap: 0.75rem; font-size: 0.78rem; color: var(--text-muted); margin-top: 0.15rem; }
+  .atl-success { color: var(--green); }
+  .atl-failure { color: var(--red); }
+  .atl-row details { margin-top: 0.3rem; }
+  .atl-row details summary { font-size: 0.82rem; font-weight: 500; color: var(--text-muted); cursor: pointer; }
+  .atl-row details summary:hover { color: var(--blue); }
+  .atl-row pre { font-size: 0.78rem; margin: 0.2rem 0 0 0; max-height: 200px; overflow-y: auto; }
+  {{end}}
 </style>
 </head>
 <body>
@@ -516,6 +549,52 @@
 </div>
 {{end}}
 
+
+<!-- ━━ Action Timeline ━━ -->
+{{if .ActionTimeline}}
+<div class="section atl-section">
+  <div class="section-header"><span class="icon">📊</span><h2>Action Timeline</h2><span style="margin-left:auto;font-size:0.85rem;color:var(--text-muted)">{{.ActionTimeline.Summary.TotalActions}} actions</span></div>
+  <div class="section-body">
+    <details>
+      <summary>Show action timeline ({{.ActionTimeline.Summary.TotalActions}} actions, {{.ActionTimeline.Summary.TotalToolCalls}} tool calls)</summary>
+
+      <div class="atl-summary-bar" style="margin-top:0.75rem">
+        <div class="atl-stat"><strong>{{.ActionTimeline.Summary.TotalActions}}</strong> <span>actions</span></div>
+        <div class="atl-stat"><strong>{{.ActionTimeline.Summary.TotalToolCalls}}</strong> <span>tool calls</span></div>
+        <div class="atl-stat"><strong>{{.ActionTimeline.Summary.TotalTurns}}</strong> <span>turns</span></div>
+        <div class="atl-stat"><strong>{{fmtDurationMs .ActionTimeline.Summary.ToolCallDuration}}</strong> <span>tool duration</span></div>
+        <div class="atl-stat"><strong class="atl-success">{{.ActionTimeline.Summary.ToolSuccesses}}</strong> <span>succeeded</span></div>
+        {{if gt .ActionTimeline.Summary.ToolFailures 0}}<div class="atl-stat"><strong class="atl-failure">{{.ActionTimeline.Summary.ToolFailures}}</strong> <span>failed</span></div>{{end}}
+      </div>
+
+      <div class="atl-filter">
+        <input type="text" id="atl-search" placeholder="Filter timeline… (tool name, type, file path)" oninput="(function(v){document.querySelectorAll('.atl-row').forEach(function(r){r.style.display=r.textContent.toLowerCase().indexOf(v)!==-1?'':'none'})})(this.value.toLowerCase())">
+      </div>
+
+      <div class="atl-list">
+        {{range .ActionTimeline.Entries}}
+        <div class="atl-row atl-{{.Type}}">
+          <div class="atl-idx">{{.Index}}</div>
+          <div class="atl-icon">{{if eq .Type "tool_call"}}🔧{{else if eq .Type "turn_start"}}▶{{else if eq .Type "turn_end"}}⏹{{else if eq .Type "reasoning"}}🤔{{else if eq .Type "message"}}💬{{else if eq .Type "intent"}}🎯{{else}}·{{end}}</div>
+          <div class="atl-body">
+            <div class="atl-label">
+              {{if eq .Type "tool_call"}}<code>{{.ToolName}}</code>{{if .MCPServer}}<span style="font-size:0.75rem;color:var(--text-muted);font-weight:400">via {{.MCPServer}}</span>{{end}}{{else if eq .Type "turn_start"}}Turn {{.TurnNumber}} start{{else if eq .Type "turn_end"}}Turn {{.TurnNumber}} end{{else if eq .Type "reasoning"}}Reasoning{{else if eq .Type "message"}}Message{{else if eq .Type "intent"}}Intent: {{.Intent}}{{else}}{{.Type}}{{end}}
+            </div>
+            <div class="atl-meta">
+              {{if .TurnNumber}}<span>Turn {{.TurnNumber}}</span>{{end}}
+              {{if gt .Duration 0.0}}<span>{{fmtDurationMs .Duration}}</span>{{end}}
+              {{if .FilePath}}<span>📄 {{.FilePath}}</span>{{end}}
+              {{if .Success}}{{if derefBool .Success}}<span class="atl-success">✅</span>{{else}}<span class="atl-failure">❌</span>{{end}}{{end}}
+            </div>
+            {{if .Error}}<details><summary>Show error</summary><pre>{{.Error}}</pre></details>{{end}}
+          </div>
+        </div>
+        {{end}}
+      </div>
+    </details>
+  </div>
+</div>
+{{end}}
 
 <!-- ━━ Re-run Command ━━ -->
 {{if .RerunCommand}}


### PR DESCRIPTION
## Summary

Renders the structured action timeline (from PR #221) as an expandable, searchable section in HTML evaluation reports.

Closes #141

## Changes

### Template (`templates/report.gohtml`)
- **CSS styles** for action timeline section (`.atl-*` classes) matching existing theme
- **Summary bar** showing total actions, tool calls, turns, tool duration, success/failure counts
- **Timeline list** with each action as a row: index, type icon, tool name/info, duration, status indicator
- **Collapsible** via `<details>/<summary>` — starts collapsed by default
- **Search/filter** input with inline JS text filter (no external dependencies)
- Color-coded left borders per event type (tool=indigo, turn=blue, reasoning=light blue, message=violet, intent=purple)

### Template Functions (`html.go`)
- `fmtDurationMs` — formats milliseconds as human-readable (e.g., `150ms`, `2.5s`)
- `derefBool` — nil-safe bool pointer dereference for template conditionals

### Tests (`html_test.go`)
- `TestActionTimelineHTMLRendering` — verifies timeline renders with all expected elements (summary stats, tool entries, MCP server, duration formatting, success/failure indicators, search filter, error display)
- `TestActionTimelineHTMLOmittedWhenNil` — confirms section is omitted when `ActionTimeline` is nil

## Dependencies
- PR #216 (template extraction into `.gohtml` files)
- PR #221 (`ActionTimelineReport` types and `BuildActionTimeline()`)