### PR TITLE
feat: create comparison engine package (#144)

### DIFF
--- a/hyoka/internal/comparison/comparison.go
+++ b/hyoka/internal/comparison/comparison.go
@@ -1,0 +1,526 @@
+// Package comparison provides config-vs-config, run-vs-run, and temporal diff
+// analysis for hyoka evaluation reports. It operates on EvalReport data and
+// produces structured diffs suitable for display or further aggregation.
+package comparison
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ronniegeraghty/hyoka/internal/report"
+)
+
+// ---------- Types ----------
+
+// GraderDiff holds the per-grader score delta between two evaluations.
+type GraderDiff struct {
+	Name   string  `json:"name"`
+	ScoreA float64 `json:"score_a"`
+	ScoreB float64 `json:"score_b"`
+	Delta  float64 `json:"delta"` // B − A
+	PassA  bool    `json:"pass_a"`
+	PassB  bool    `json:"pass_b"`
+}
+
+// PromptDiff holds the per-prompt aggregate delta between two evaluations.
+type PromptDiff struct {
+	PromptID    string      `json:"prompt_id"`
+	ScoreA      float64     `json:"score_a"`
+	ScoreB      float64     `json:"score_b"`
+	Delta       float64     `json:"delta"` // B − A
+	GraderDiffs []GraderDiff `json:"grader_diffs,omitempty"`
+	OnlyInA     bool        `json:"only_in_a,omitempty"`
+	OnlyInB     bool        `json:"only_in_b,omitempty"`
+}
+
+// ComparisonSummary aggregates high-level comparison metrics.
+type ComparisonSummary struct {
+	AvgDelta      float64      `json:"avg_delta"`
+	Improved      int          `json:"improved"`
+	Regressed     int          `json:"regressed"`
+	Unchanged     int          `json:"unchanged"`
+	TopImproved   []PromptDiff `json:"top_improved,omitempty"`
+	TopRegressed  []PromptDiff `json:"top_regressed,omitempty"`
+}
+
+// ConfigComparison holds the result of comparing two configs across a shared prompt set.
+type ConfigComparison struct {
+	ConfigA   string            `json:"config_a"`
+	ConfigB   string            `json:"config_b"`
+	PerPrompt []PromptDiff      `json:"per_prompt"`
+	Summary   ComparisonSummary `json:"summary"`
+}
+
+// RunComparison holds the result of comparing two specific runs.
+type RunComparison struct {
+	RunA      string            `json:"run_a"`
+	RunB      string            `json:"run_b"`
+	PerPrompt []PromptDiff      `json:"per_prompt"`
+	Summary   ComparisonSummary `json:"summary"`
+}
+
+// TemporalComparison holds the result of comparing the latest run against a historical baseline.
+type TemporalComparison struct {
+	Config    string            `json:"config"`
+	LatestRun string            `json:"latest_run"`
+	BaseRun   string            `json:"base_run"`
+	Since     time.Time         `json:"since"`
+	PerPrompt []PromptDiff      `json:"per_prompt"`
+	Summary   ComparisonSummary `json:"summary"`
+}
+
+// ---------- Public API ----------
+
+// CompareConfigs loads all reports from reportsDir for the two given config
+// names, matches them by prompt ID, and produces a ConfigComparison.
+func CompareConfigs(reportsDir, configA, configB string) (*ConfigComparison, error) {
+	lg := slog.With("role", "comparison")
+	lg.Debug("Comparing configs", "config_a", configA, "config_b", configB)
+
+	reportsA, err := loadReportsByConfig(reportsDir, configA)
+	if err != nil {
+		return nil, fmt.Errorf("loading config %s: %w", configA, err)
+	}
+	reportsB, err := loadReportsByConfig(reportsDir, configB)
+	if err != nil {
+		return nil, fmt.Errorf("loading config %s: %w", configB, err)
+	}
+
+	if len(reportsA) == 0 && len(reportsB) == 0 {
+		return nil, fmt.Errorf("no reports found for either config %q or %q", configA, configB)
+	}
+
+	// Use latest report per prompt for each config.
+	latestA := latestByPrompt(reportsA)
+	latestB := latestByPrompt(reportsB)
+
+	diffs := diffPromptMaps(latestA, latestB)
+	summary := buildSummary(diffs)
+
+	lg.Info("Config comparison complete",
+		"config_a", configA, "config_b", configB,
+		"prompts", len(diffs),
+		"improved", summary.Improved,
+		"regressed", summary.Regressed,
+	)
+
+	return &ConfigComparison{
+		ConfigA:   configA,
+		ConfigB:   configB,
+		PerPrompt: diffs,
+		Summary:   summary,
+	}, nil
+}
+
+// CompareRuns loads all reports from two specific run directories and produces
+// a RunComparison. Run IDs are the timestamp-based directory names under reportsDir.
+func CompareRuns(reportsDir, runA, runB string) (*RunComparison, error) {
+	lg := slog.With("role", "comparison")
+	lg.Debug("Comparing runs", "run_a", runA, "run_b", runB)
+
+	reportsA, err := loadReportsFromRun(reportsDir, runA)
+	if err != nil {
+		return nil, fmt.Errorf("loading run %s: %w", runA, err)
+	}
+	reportsB, err := loadReportsFromRun(reportsDir, runB)
+	if err != nil {
+		return nil, fmt.Errorf("loading run %s: %w", runB, err)
+	}
+
+	if len(reportsA) == 0 && len(reportsB) == 0 {
+		return nil, fmt.Errorf("no reports found for either run %q or %q", runA, runB)
+	}
+
+	mapA := indexByPromptConfig(reportsA)
+	mapB := indexByPromptConfig(reportsB)
+
+	diffs := diffPromptMaps(mapA, mapB)
+	summary := buildSummary(diffs)
+
+	lg.Info("Run comparison complete",
+		"run_a", runA, "run_b", runB,
+		"prompts", len(diffs),
+		"improved", summary.Improved,
+		"regressed", summary.Regressed,
+	)
+
+	return &RunComparison{
+		RunA:      runA,
+		RunB:      runB,
+		PerPrompt: diffs,
+		Summary:   summary,
+	}, nil
+}
+
+// TemporalDiff compares the latest run for a config against the most recent run
+// at or before `since`. This enables "how has this config changed since date X?"
+func TemporalDiff(reportsDir, config string, since time.Time) (*TemporalComparison, error) {
+	lg := slog.With("role", "comparison")
+	lg.Debug("Temporal diff", "config", config, "since", since)
+
+	all, err := loadReportsByConfig(reportsDir, config)
+	if err != nil {
+		return nil, fmt.Errorf("loading config %s: %w", config, err)
+	}
+	if len(all) == 0 {
+		return nil, fmt.Errorf("no reports found for config %q", config)
+	}
+
+	// Partition into base (≤ since) and recent (> since).
+	var base, recent []report.EvalReport
+	for _, r := range all {
+		ts, err := time.Parse(time.RFC3339, r.Timestamp)
+		if err != nil {
+			// Try fallback format (some reports use a compact timestamp).
+			ts, err = time.Parse("2006-01-02T15:04:05", r.Timestamp)
+			if err != nil {
+				continue
+			}
+		}
+		if ts.Before(since) || ts.Equal(since) {
+			base = append(base, r)
+		} else {
+			recent = append(recent, r)
+		}
+	}
+
+	if len(base) == 0 {
+		return nil, fmt.Errorf("no reports found for config %q at or before %s", config, since.Format(time.RFC3339))
+	}
+	if len(recent) == 0 {
+		return nil, fmt.Errorf("no reports found for config %q after %s", config, since.Format(time.RFC3339))
+	}
+
+	latestBase := latestByPrompt(base)
+	latestRecent := latestByPrompt(recent)
+
+	diffs := diffPromptMaps(latestBase, latestRecent)
+	summary := buildSummary(diffs)
+
+	// Determine run IDs from the partitioned reports.
+	baseRun := runIDFromReport(base[len(base)-1], reportsDir)
+	latestRun := runIDFromReport(recent[len(recent)-1], reportsDir)
+
+	lg.Info("Temporal diff complete",
+		"config", config, "since", since,
+		"base_run", baseRun, "latest_run", latestRun,
+		"prompts", len(diffs),
+		"improved", summary.Improved,
+		"regressed", summary.Regressed,
+	)
+
+	return &TemporalComparison{
+		Config:    config,
+		LatestRun: latestRun,
+		BaseRun:   baseRun,
+		Since:     since,
+		PerPrompt: diffs,
+		Summary:   summary,
+	}, nil
+}
+
+// ---------- Internal helpers ----------
+
+// loadReportsByConfig walks reportsDir and loads all report.json files
+// whose ConfigName matches the given config.
+func loadReportsByConfig(reportsDir, config string) ([]report.EvalReport, error) {
+	var reports []report.EvalReport
+	err := filepath.Walk(reportsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || info.Name() != "report.json" {
+			return nil
+		}
+		r, err := loadReport(path)
+		if err != nil {
+			return nil
+		}
+		if r.ConfigName == config {
+			reports = append(reports, *r)
+		}
+		return nil
+	})
+	return reports, err
+}
+
+// loadReportsFromRun loads all report.json files from a specific run directory.
+func loadReportsFromRun(reportsDir, runID string) ([]report.EvalReport, error) {
+	runDir := filepath.Join(reportsDir, runID)
+	info, err := os.Stat(runDir)
+	if err != nil {
+		return nil, fmt.Errorf("run directory %q not found: %w", runID, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", runID)
+	}
+
+	var reports []report.EvalReport
+	err = filepath.Walk(runDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || info.Name() != "report.json" {
+			return nil
+		}
+		r, err := loadReport(path)
+		if err != nil {
+			return nil
+		}
+		reports = append(reports, *r)
+		return nil
+	})
+	return reports, err
+}
+
+// loadReport reads and decodes a single report.json file.
+func loadReport(path string) (*report.EvalReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var r report.EvalReport
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// latestByPrompt selects the most recent report per prompt ID (by timestamp).
+// The returned map key is "{promptID}|{configName}" to uniquely identify entries.
+func latestByPrompt(reports []report.EvalReport) map[string]*report.EvalReport {
+	result := make(map[string]*report.EvalReport)
+	for i := range reports {
+		r := &reports[i]
+		key := r.PromptID
+		existing, ok := result[key]
+		if !ok || r.Timestamp > existing.Timestamp {
+			result[key] = r
+		}
+	}
+	return result
+}
+
+// indexByPromptConfig indexes reports by a composite key of promptID + configName.
+// For run-vs-run comparison where both runs may have different configs.
+func indexByPromptConfig(reports []report.EvalReport) map[string]*report.EvalReport {
+	result := make(map[string]*report.EvalReport)
+	for i := range reports {
+		r := &reports[i]
+		key := r.PromptID + "|" + r.ConfigName
+		existing, ok := result[key]
+		if !ok || r.Timestamp > existing.Timestamp {
+			result[key] = r
+		}
+	}
+	return result
+}
+
+// scoreFromReport computes a normalized 0.0–1.0 score from a report.
+// It prefers the ScoreBreakdown.FinalScore (grader-based), falls back to
+// Review.OverallScore/MaxScore (legacy), then 0.0.
+func scoreFromReport(r *report.EvalReport) float64 {
+	if r.ScoreBreakdown != nil {
+		return r.ScoreBreakdown.FinalScore
+	}
+	// Compute from grader results if present.
+	if len(r.GraderResults) > 0 {
+		sb := report.BuildScoreBreakdown(r.GraderResults)
+		if sb != nil {
+			return sb.FinalScore
+		}
+	}
+	// Legacy review-based scoring.
+	if r.Review != nil && r.Review.MaxScore > 0 {
+		return float64(r.Review.OverallScore) / float64(r.Review.MaxScore)
+	}
+	return 0.0
+}
+
+// graderDiffs computes per-grader deltas between two reports.
+func graderDiffs(a, b *report.EvalReport) []GraderDiff {
+	indexA := make(map[string]*report.GraderResult)
+	for i := range a.GraderResults {
+		indexA[a.GraderResults[i].GraderName] = &a.GraderResults[i]
+	}
+	indexB := make(map[string]*report.GraderResult)
+	for i := range b.GraderResults {
+		indexB[b.GraderResults[i].GraderName] = &b.GraderResults[i]
+	}
+
+	// Collect all grader names in deterministic order.
+	seen := make(map[string]bool)
+	var names []string
+	for _, g := range a.GraderResults {
+		if !seen[g.GraderName] {
+			seen[g.GraderName] = true
+			names = append(names, g.GraderName)
+		}
+	}
+	for _, g := range b.GraderResults {
+		if !seen[g.GraderName] {
+			seen[g.GraderName] = true
+			names = append(names, g.GraderName)
+		}
+	}
+
+	var diffs []GraderDiff
+	for _, name := range names {
+		gd := GraderDiff{Name: name}
+		if ga, ok := indexA[name]; ok {
+			gd.ScoreA = ga.Score
+			gd.PassA = ga.Pass != nil && *ga.Pass
+		}
+		if gb, ok := indexB[name]; ok {
+			gd.ScoreB = gb.Score
+			gd.PassB = gb.Pass != nil && *gb.Pass
+		}
+		gd.Delta = gd.ScoreB - gd.ScoreA
+		diffs = append(diffs, gd)
+	}
+	return diffs
+}
+
+// diffPromptMaps produces PromptDiff entries from two prompt-keyed maps.
+func diffPromptMaps(mapA, mapB map[string]*report.EvalReport) []PromptDiff {
+	seen := make(map[string]bool)
+	var keys []string
+	for k := range mapA {
+		// Strip config suffix from composite keys if present.
+		pid := promptIDFromKey(k)
+		if !seen[pid] {
+			seen[pid] = true
+			keys = append(keys, pid)
+		}
+	}
+	for k := range mapB {
+		pid := promptIDFromKey(k)
+		if !seen[pid] {
+			seen[pid] = true
+			keys = append(keys, pid)
+		}
+	}
+	sort.Strings(keys)
+
+	var diffs []PromptDiff
+	for _, pid := range keys {
+		rA := findByPromptID(mapA, pid)
+		rB := findByPromptID(mapB, pid)
+
+		pd := PromptDiff{PromptID: pid}
+		switch {
+		case rA != nil && rB != nil:
+			pd.ScoreA = scoreFromReport(rA)
+			pd.ScoreB = scoreFromReport(rB)
+			pd.Delta = pd.ScoreB - pd.ScoreA
+			pd.GraderDiffs = graderDiffs(rA, rB)
+		case rA != nil:
+			pd.ScoreA = scoreFromReport(rA)
+			pd.OnlyInA = true
+		case rB != nil:
+			pd.ScoreB = scoreFromReport(rB)
+			pd.OnlyInB = true
+		}
+		diffs = append(diffs, pd)
+	}
+	return diffs
+}
+
+// buildSummary computes aggregate metrics and top N lists from prompt diffs.
+func buildSummary(diffs []PromptDiff) ComparisonSummary {
+	const topN = 5
+	const unchangedThreshold = 0.001
+
+	var s ComparisonSummary
+	var totalDelta float64
+	var paired int
+
+	for _, d := range diffs {
+		if d.OnlyInA || d.OnlyInB {
+			continue
+		}
+		paired++
+		totalDelta += d.Delta
+		switch {
+		case d.Delta > unchangedThreshold:
+			s.Improved++
+		case d.Delta < -unchangedThreshold:
+			s.Regressed++
+		default:
+			s.Unchanged++
+		}
+	}
+
+	if paired > 0 {
+		s.AvgDelta = totalDelta / float64(paired)
+	}
+
+	// Top improved — largest positive delta first.
+	improved := filterPaired(diffs, func(d PromptDiff) bool { return d.Delta > unchangedThreshold })
+	sort.Slice(improved, func(i, j int) bool { return improved[i].Delta > improved[j].Delta })
+	s.TopImproved = take(improved, topN)
+
+	// Top regressed — largest negative delta first (most negative = worst).
+	regressed := filterPaired(diffs, func(d PromptDiff) bool { return d.Delta < -unchangedThreshold })
+	sort.Slice(regressed, func(i, j int) bool { return regressed[i].Delta < regressed[j].Delta })
+	s.TopRegressed = take(regressed, topN)
+
+	return s
+}
+
+// promptIDFromKey strips a composite "promptID|config" key to just the promptID.
+func promptIDFromKey(key string) string {
+	if idx := strings.Index(key, "|"); idx >= 0 {
+		return key[:idx]
+	}
+	return key
+}
+
+// findByPromptID finds the first entry in a map whose key starts with the given
+// prompt ID (handling both bare keys and composite "promptID|config" keys).
+func findByPromptID(m map[string]*report.EvalReport, promptID string) *report.EvalReport {
+	// Direct lookup (simple key).
+	if r, ok := m[promptID]; ok {
+		return r
+	}
+	// Composite key scan.
+	for k, r := range m {
+		if promptIDFromKey(k) == promptID {
+			return r
+		}
+	}
+	return nil
+}
+
+// runIDFromReport attempts to extract the run ID from a report's timestamp.
+func runIDFromReport(r report.EvalReport, _ string) string {
+	ts, err := time.Parse(time.RFC3339, r.Timestamp)
+	if err != nil {
+		return r.Timestamp
+	}
+	return ts.Format("20060102-150405")
+}
+
+// filterPaired returns only diffs that appear in both sides.
+func filterPaired(diffs []PromptDiff, pred func(PromptDiff) bool) []PromptDiff {
+	var out []PromptDiff
+	for _, d := range diffs {
+		if d.OnlyInA || d.OnlyInB {
+			continue
+		}
+		if pred(d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// take returns up to n elements from the slice.
+func take(s []PromptDiff, n int) []PromptDiff {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+

--- a/hyoka/internal/comparison/comparison_test.go
+++ b/hyoka/internal/comparison/comparison_test.go
@@ -1,0 +1,486 @@
+package comparison
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ronniegeraghty/hyoka/internal/report"
+	"github.com/ronniegeraghty/hyoka/internal/review"
+)
+
+// ---------- Helpers ----------
+
+func boolPtr(b bool) *bool { return &b }
+
+// writeReport writes a report.json file under reportsDir/{runID}/results/{promptID}/{config}/report.json
+func writeReport(t *testing.T, reportsDir, runID, promptID, config, timestamp string, graders []report.GraderResult, rev *review.ReviewResult) {
+	t.Helper()
+	// Flatten config path (replace / with os separator for directory nesting).
+	configDir := filepath.Join(reportsDir, runID, "results", promptID, filepath.FromSlash(config))
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := report.EvalReport{
+		SchemaVersion: 2,
+		PromptID:      promptID,
+		ConfigName:    config,
+		Timestamp:     timestamp,
+		Success:       true,
+		GraderResults: graders,
+		Review:        rev,
+	}
+	if len(graders) > 0 {
+		r.ScoreBreakdown = report.BuildScoreBreakdown(graders)
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "report.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeGraders(scores ...float64) []report.GraderResult {
+	var graders []report.GraderResult
+	for i, s := range scores {
+		pass := s >= 0.5
+		graders = append(graders, report.GraderResult{
+			GraderName: graderName(i),
+			GraderType: "prompt",
+			Score:      s,
+			Weight:     1.0,
+			Pass:       boolPtr(pass),
+		})
+	}
+	return graders
+}
+
+func graderName(i int) string {
+	names := []string{"correctness", "completeness", "best-practices", "security", "documentation"}
+	if i < len(names) {
+		return names[i]
+	}
+	return "grader-" + string(rune('a'+i))
+}
+
+// ---------- CompareConfigs ----------
+
+func TestCompareConfigs_BasicDiff(t *testing.T) {
+	dir := t.TempDir()
+
+	// Config A: two prompts, scores 0.6 and 0.8
+	writeReport(t, dir, "run-001", "prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.6), nil)
+	writeReport(t, dir, "run-001", "prompt-beta", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.8), nil)
+
+	// Config B: same prompts, scores 0.9 and 0.7
+	writeReport(t, dir, "run-001", "prompt-alpha", "azure-mcp/opus", "2025-01-01T10:00:00Z", makeGraders(0.9), nil)
+	writeReport(t, dir, "run-001", "prompt-beta", "azure-mcp/opus", "2025-01-01T10:00:00Z", makeGraders(0.7), nil)
+
+	cmp, err := CompareConfigs(dir, "baseline/opus", "azure-mcp/opus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmp.ConfigA != "baseline/opus" || cmp.ConfigB != "azure-mcp/opus" {
+		t.Errorf("config names mismatch: got %q / %q", cmp.ConfigA, cmp.ConfigB)
+	}
+	if len(cmp.PerPrompt) != 2 {
+		t.Fatalf("expected 2 prompt diffs, got %d", len(cmp.PerPrompt))
+	}
+
+	// Find prompt-alpha: delta should be +0.3
+	for _, pd := range cmp.PerPrompt {
+		if pd.PromptID == "prompt-alpha" {
+			if math.Abs(pd.Delta-0.3) > 0.01 {
+				t.Errorf("prompt-alpha: expected delta ~0.3, got %f", pd.Delta)
+			}
+		}
+		if pd.PromptID == "prompt-beta" {
+			if math.Abs(pd.Delta-(-0.1)) > 0.01 {
+				t.Errorf("prompt-beta: expected delta ~-0.1, got %f", pd.Delta)
+			}
+		}
+	}
+
+	if cmp.Summary.Improved != 1 {
+		t.Errorf("expected 1 improved, got %d", cmp.Summary.Improved)
+	}
+	if cmp.Summary.Regressed != 1 {
+		t.Errorf("expected 1 regressed, got %d", cmp.Summary.Regressed)
+	}
+}
+
+func TestCompareConfigs_PicksLatestReport(t *testing.T) {
+	dir := t.TempDir()
+
+	// Two runs for config A, same prompt — older run has score 0.4, newer has 0.9
+	writeReport(t, dir, "run-001", "prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.4), nil)
+	writeReport(t, dir, "run-002", "prompt-alpha", "baseline/opus", "2025-01-02T10:00:00Z", makeGraders(0.9), nil)
+
+	// Config B with score 0.9
+	writeReport(t, dir, "run-001", "prompt-alpha", "azure-mcp/opus", "2025-01-01T10:00:00Z", makeGraders(0.9), nil)
+
+	cmp, err := CompareConfigs(dir, "baseline/opus", "azure-mcp/opus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should use the latest (0.9), so delta ≈ 0
+	for _, pd := range cmp.PerPrompt {
+		if pd.PromptID == "prompt-alpha" {
+			if math.Abs(pd.Delta) > 0.01 {
+				t.Errorf("expected delta ~0 (latest used), got %f", pd.Delta)
+			}
+		}
+	}
+}
+
+func TestCompareConfigs_DisjointPrompts(t *testing.T) {
+	dir := t.TempDir()
+
+	writeReport(t, dir, "run-001", "prompt-alpha", "config-a", "2025-01-01T10:00:00Z", makeGraders(0.7), nil)
+	writeReport(t, dir, "run-001", "prompt-beta", "config-b", "2025-01-01T10:00:00Z", makeGraders(0.8), nil)
+
+	cmp, err := CompareConfigs(dir, "config-a", "config-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cmp.PerPrompt) != 2 {
+		t.Fatalf("expected 2 diffs (disjoint), got %d", len(cmp.PerPrompt))
+	}
+
+	for _, pd := range cmp.PerPrompt {
+		if pd.PromptID == "prompt-alpha" && !pd.OnlyInA {
+			t.Error("prompt-alpha should be OnlyInA")
+		}
+		if pd.PromptID == "prompt-beta" && !pd.OnlyInB {
+			t.Error("prompt-beta should be OnlyInB")
+		}
+	}
+
+	// Disjoint prompts don't contribute to improved/regressed counts.
+	if cmp.Summary.Improved != 0 || cmp.Summary.Regressed != 0 {
+		t.Errorf("disjoint prompts should not affect improved/regressed counts")
+	}
+}
+
+func TestCompareConfigs_NoReports(t *testing.T) {
+	dir := t.TempDir()
+	_, err := CompareConfigs(dir, "no-such", "also-missing")
+	if err == nil {
+		t.Error("expected error for empty reports dir")
+	}
+}
+
+func TestCompareConfigs_GraderDiffs(t *testing.T) {
+	dir := t.TempDir()
+
+	gradersA := []report.GraderResult{
+		{GraderName: "correctness", GraderType: "prompt", Score: 0.5, Weight: 1.0, Pass: boolPtr(true)},
+		{GraderName: "security", GraderType: "prompt", Score: 0.3, Weight: 1.0, Pass: boolPtr(false)},
+	}
+	gradersB := []report.GraderResult{
+		{GraderName: "correctness", GraderType: "prompt", Score: 0.8, Weight: 1.0, Pass: boolPtr(true)},
+		{GraderName: "security", GraderType: "prompt", Score: 0.9, Weight: 1.0, Pass: boolPtr(true)},
+	}
+
+	writeReport(t, dir, "run-001", "prompt-alpha", "config-a", "2025-01-01T10:00:00Z", gradersA, nil)
+	writeReport(t, dir, "run-001", "prompt-alpha", "config-b", "2025-01-01T10:00:00Z", gradersB, nil)
+
+	cmp, err := CompareConfigs(dir, "config-a", "config-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cmp.PerPrompt) != 1 {
+		t.Fatalf("expected 1 prompt diff, got %d", len(cmp.PerPrompt))
+	}
+
+	pd := cmp.PerPrompt[0]
+	if len(pd.GraderDiffs) != 2 {
+		t.Fatalf("expected 2 grader diffs, got %d", len(pd.GraderDiffs))
+	}
+
+	for _, gd := range pd.GraderDiffs {
+		switch gd.Name {
+		case "correctness":
+			if math.Abs(gd.Delta-0.3) > 0.01 {
+				t.Errorf("correctness delta: expected 0.3, got %f", gd.Delta)
+			}
+		case "security":
+			if math.Abs(gd.Delta-0.6) > 0.01 {
+				t.Errorf("security delta: expected 0.6, got %f", gd.Delta)
+			}
+			if gd.PassA != false || gd.PassB != true {
+				t.Errorf("security pass: expected false→true, got %v→%v", gd.PassA, gd.PassB)
+			}
+		}
+	}
+}
+
+// ---------- CompareRuns ----------
+
+func TestCompareRuns_BasicDiff(t *testing.T) {
+	dir := t.TempDir()
+
+	writeReport(t, dir, "20250101-100000", "prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.5), nil)
+	writeReport(t, dir, "20250102-100000", "prompt-alpha", "baseline/opus", "2025-01-02T10:00:00Z", makeGraders(0.8), nil)
+
+	cmp, err := CompareRuns(dir, "20250101-100000", "20250102-100000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmp.RunA != "20250101-100000" || cmp.RunB != "20250102-100000" {
+		t.Errorf("run IDs mismatch")
+	}
+	if len(cmp.PerPrompt) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(cmp.PerPrompt))
+	}
+	if math.Abs(cmp.PerPrompt[0].Delta-0.3) > 0.01 {
+		t.Errorf("expected delta ~0.3, got %f", cmp.PerPrompt[0].Delta)
+	}
+	if cmp.Summary.Improved != 1 {
+		t.Errorf("expected 1 improved, got %d", cmp.Summary.Improved)
+	}
+}
+
+func TestCompareRuns_MissingRun(t *testing.T) {
+	dir := t.TempDir()
+	_, err := CompareRuns(dir, "nonexistent-a", "nonexistent-b")
+	if err == nil {
+		t.Error("expected error for missing run directories")
+	}
+}
+
+func TestCompareRuns_MultipleConfigs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Run A has two configs for the same prompt.
+	writeReport(t, dir, "run-a", "prompt-alpha", "config-x", "2025-01-01T10:00:00Z", makeGraders(0.4), nil)
+	writeReport(t, dir, "run-a", "prompt-alpha", "config-y", "2025-01-01T10:00:00Z", makeGraders(0.6), nil)
+
+	// Run B has the same.
+	writeReport(t, dir, "run-b", "prompt-alpha", "config-x", "2025-01-02T10:00:00Z", makeGraders(0.8), nil)
+	writeReport(t, dir, "run-b", "prompt-alpha", "config-y", "2025-01-02T10:00:00Z", makeGraders(0.7), nil)
+
+	cmp, err := CompareRuns(dir, "run-a", "run-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Each prompt+config combination is a separate entry.
+	if len(cmp.PerPrompt) < 1 {
+		t.Fatal("expected at least 1 prompt diff")
+	}
+
+	// All should show improvement.
+	if cmp.Summary.Improved < 1 {
+		t.Errorf("expected at least 1 improved, got %d", cmp.Summary.Improved)
+	}
+}
+
+// ---------- TemporalDiff ----------
+
+func TestTemporalDiff_BasicSplit(t *testing.T) {
+	dir := t.TempDir()
+
+	// Historical report (before cutoff).
+	writeReport(t, dir, "run-old", "prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.4), nil)
+	// Recent report (after cutoff).
+	writeReport(t, dir, "run-new", "prompt-alpha", "baseline/opus", "2025-02-01T10:00:00Z", makeGraders(0.9), nil)
+
+	since := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	tc, err := TemporalDiff(dir, "baseline/opus", since)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tc.Config != "baseline/opus" {
+		t.Errorf("config mismatch: %q", tc.Config)
+	}
+	if len(tc.PerPrompt) != 1 {
+		t.Fatalf("expected 1 prompt diff, got %d", len(tc.PerPrompt))
+	}
+	if math.Abs(tc.PerPrompt[0].Delta-0.5) > 0.01 {
+		t.Errorf("expected delta ~0.5, got %f", tc.PerPrompt[0].Delta)
+	}
+	if tc.Summary.Improved != 1 {
+		t.Errorf("expected 1 improved, got %d", tc.Summary.Improved)
+	}
+}
+
+func TestTemporalDiff_NoBaseReports(t *testing.T) {
+	dir := t.TempDir()
+	writeReport(t, dir, "run-new", "prompt-alpha", "baseline/opus", "2025-02-01T10:00:00Z", makeGraders(0.9), nil)
+
+	since := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := TemporalDiff(dir, "baseline/opus", since)
+	if err == nil {
+		t.Error("expected error when no base reports exist")
+	}
+}
+
+func TestTemporalDiff_NoRecentReports(t *testing.T) {
+	dir := t.TempDir()
+	writeReport(t, dir, "run-old", "prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", makeGraders(0.5), nil)
+
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := TemporalDiff(dir, "baseline/opus", since)
+	if err == nil {
+		t.Error("expected error when no recent reports exist")
+	}
+}
+
+func TestTemporalDiff_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := TemporalDiff(dir, "nonexistent", since)
+	if err == nil {
+		t.Error("expected error for nonexistent config")
+	}
+}
+
+// ---------- LegacyReviewScoring ----------
+
+func TestCompareConfigs_LegacyReviewScoring(t *testing.T) {
+	dir := t.TempDir()
+
+	// Config A: legacy review-based scoring (no graders).
+	writeReport(t, dir, "run-001", "prompt-alpha", "config-a", "2025-01-01T10:00:00Z", nil,
+		&review.ReviewResult{OverallScore: 7, MaxScore: 10})
+
+	// Config B: legacy review-based scoring.
+	writeReport(t, dir, "run-001", "prompt-alpha", "config-b", "2025-01-01T10:00:00Z", nil,
+		&review.ReviewResult{OverallScore: 9, MaxScore: 10})
+
+	cmp, err := CompareConfigs(dir, "config-a", "config-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cmp.PerPrompt) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(cmp.PerPrompt))
+	}
+	// 0.9 - 0.7 = 0.2
+	if math.Abs(cmp.PerPrompt[0].Delta-0.2) > 0.01 {
+		t.Errorf("expected delta ~0.2, got %f", cmp.PerPrompt[0].Delta)
+	}
+}
+
+// ---------- Summary ----------
+
+func TestBuildSummary_TopN(t *testing.T) {
+	// Create 10 diffs: 7 improved, 3 regressed.
+	var diffs []PromptDiff
+	for i := 0; i < 7; i++ {
+		diffs = append(diffs, PromptDiff{
+			PromptID: "improved-" + string(rune('a'+i)),
+			ScoreA:   0.3,
+			ScoreB:   0.3 + float64(i+1)*0.05,
+			Delta:    float64(i+1) * 0.05,
+		})
+	}
+	for i := 0; i < 3; i++ {
+		diffs = append(diffs, PromptDiff{
+			PromptID: "regressed-" + string(rune('a'+i)),
+			ScoreA:   0.8,
+			ScoreB:   0.8 - float64(i+1)*0.1,
+			Delta:    -float64(i+1) * 0.1,
+		})
+	}
+
+	s := buildSummary(diffs)
+
+	if s.Improved != 7 {
+		t.Errorf("expected 7 improved, got %d", s.Improved)
+	}
+	if s.Regressed != 3 {
+		t.Errorf("expected 3 regressed, got %d", s.Regressed)
+	}
+	if len(s.TopImproved) != 5 {
+		t.Errorf("expected top 5 improved, got %d", len(s.TopImproved))
+	}
+	if len(s.TopRegressed) != 3 {
+		t.Errorf("expected top 3 regressed, got %d", len(s.TopRegressed))
+	}
+
+	// TopImproved should be sorted descending by delta.
+	if s.TopImproved[0].Delta < s.TopImproved[len(s.TopImproved)-1].Delta {
+		t.Error("TopImproved should be sorted by delta descending")
+	}
+	// TopRegressed should be sorted ascending (most negative first).
+	if s.TopRegressed[0].Delta > s.TopRegressed[len(s.TopRegressed)-1].Delta {
+		t.Error("TopRegressed should be sorted by delta ascending (most negative first)")
+	}
+}
+
+func TestBuildSummary_AllUnchanged(t *testing.T) {
+	diffs := []PromptDiff{
+		{PromptID: "p1", ScoreA: 0.5, ScoreB: 0.5, Delta: 0.0},
+		{PromptID: "p2", ScoreA: 0.7, ScoreB: 0.7, Delta: 0.0},
+	}
+	s := buildSummary(diffs)
+	if s.Unchanged != 2 {
+		t.Errorf("expected 2 unchanged, got %d", s.Unchanged)
+	}
+	if s.AvgDelta != 0 {
+		t.Errorf("expected avg delta 0, got %f", s.AvgDelta)
+	}
+}
+
+// ---------- Internal Helpers ----------
+
+func TestScoreFromReport_Graders(t *testing.T) {
+	graders := makeGraders(0.6, 0.8)
+	r := &report.EvalReport{GraderResults: graders}
+	r.ScoreBreakdown = report.BuildScoreBreakdown(graders)
+
+	score := scoreFromReport(r)
+	// Average of 0.6, 0.8 = 0.7
+	if math.Abs(score-0.7) > 0.01 {
+		t.Errorf("expected score ~0.7, got %f", score)
+	}
+}
+
+func TestScoreFromReport_LegacyReview(t *testing.T) {
+	r := &report.EvalReport{
+		Review: &review.ReviewResult{OverallScore: 8, MaxScore: 10},
+	}
+	score := scoreFromReport(r)
+	if math.Abs(score-0.8) > 0.01 {
+		t.Errorf("expected score ~0.8, got %f", score)
+	}
+}
+
+func TestScoreFromReport_NoScore(t *testing.T) {
+	r := &report.EvalReport{}
+	score := scoreFromReport(r)
+	if score != 0.0 {
+		t.Errorf("expected 0.0 for empty report, got %f", score)
+	}
+}
+
+func TestPromptIDFromKey(t *testing.T) {
+	cases := []struct {
+		key, want string
+	}{
+		{"prompt-alpha", "prompt-alpha"},
+		{"prompt-alpha|baseline/opus", "prompt-alpha"},
+		{"a|b|c", "a"},
+	}
+	for _, tc := range cases {
+		got := promptIDFromKey(tc.key)
+		if got != tc.want {
+			t.Errorf("promptIDFromKey(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Create the core comparison engine package (`hyoka/internal/comparison/`) for Phase 4 of the comparison dashboard (issue #144, task 4.1a).

### What's included

- **`CompareConfigs(reportsDir, configA, configB)`** — loads reports for two configs, matches by prompt ID, computes per-prompt and per-grader score deltas
- **`CompareRuns(reportsDir, runA, runB)`** — compares two specific run directories with composite prompt+config keying
- **`TemporalDiff(reportsDir, config, since)`** — compares latest run against most recent historical baseline before a given date

### Key design decisions

- Uses latest report per prompt when multiple runs exist for a config
- Supports both grader-based scoring (`ScoreBreakdown.FinalScore`) and legacy review scoring (`Review.OverallScore/MaxScore`)
- Disjoint prompts (only in A or B) are tracked but don't affect improved/regressed counts
- Top-5 improved and top-5 regressed prompt lists in summary
- Per-grader drill-down with pass/fail transition tracking

### Tests

19 tests covering:
- Basic config and run diffs
- Latest-report selection across multiple runs
- Disjoint prompt handling
- Grader-level diffs with pass/fail transitions
- Temporal split with edge cases (no base, no recent, no config)
- Legacy review scoring fallback
- Summary aggregation and top-N capping
- Internal helpers (key parsing, score extraction)

Closes #144