### PR TITLE
feat: property-based trend slicing and regression detection (#150, #151)

### DIFF
--- a/hyoka/internal/trends/slice.go
+++ b/hyoka/internal/trends/slice.go
@@ -1,0 +1,218 @@
+package trends
+
+import (
+"math"
+"sort"
+)
+
+// DefaultRegressionThreshold is the default score drop (10%) that triggers a regression.
+const DefaultRegressionThreshold = 0.1
+
+// TrendSlice contains trend data for prompts matching a property filter.
+type TrendSlice struct {
+Properties   map[string]string `json:"properties"`
+TotalRuns    int               `json:"total_runs"`
+Entries      []TrendEntry      `json:"entries"`
+PromptTrends []PromptTrend     `json:"prompt_trends"`
+RunIDs       []string          `json:"run_ids"`
+}
+
+// Regression represents a detected score drop between runs.
+type Regression struct {
+PromptID      string  `json:"prompt_id"`
+Config        string  `json:"config"`
+PreviousScore float64 `json:"previous_score"`
+CurrentScore  float64 `json:"current_score"`
+Delta         float64 `json:"delta"`
+GraderName    string  `json:"grader_name,omitempty"` // empty for overall score
+}
+
+// SliceTrends filters entries by prompt properties (AND logic) and returns
+// trend data for the matching subset.
+//
+// Example: SliceTrends(entries, map[string]string{"language": "python"})
+// returns trends only for Python prompts.
+func SliceTrends(entries []TrendEntry, properties map[string]string) *TrendSlice {
+filtered := filterByProperties(entries, properties)
+
+sort.Slice(filtered, func(i, j int) bool {
+return filtered[i].Timestamp < filtered[j].Timestamp
+})
+
+promptTrends, runIDs := buildPromptTrends(filtered)
+
+return &TrendSlice{
+Properties:   properties,
+TotalRuns:    len(filtered),
+Entries:      filtered,
+PromptTrends: promptTrends,
+RunIDs:       runIDs,
+}
+}
+
+// filterByProperties returns entries whose Properties map contains all the
+// specified key-value pairs (AND logic).
+func filterByProperties(entries []TrendEntry, properties map[string]string) []TrendEntry {
+if len(properties) == 0 {
+// No filter — return a copy of all entries.
+out := make([]TrendEntry, len(entries))
+copy(out, entries)
+return out
+}
+
+var out []TrendEntry
+for _, e := range entries {
+if matchesProperties(e, properties) {
+out = append(out, e)
+}
+}
+return out
+}
+
+// matchesProperties checks whether an entry's Properties contain all the
+// specified key-value pairs.
+func matchesProperties(entry TrendEntry, properties map[string]string) bool {
+for k, v := range properties {
+if entry.Properties[k] != v {
+return false
+}
+}
+return true
+}
+
+// DetectRegressions compares current and previous entries to find score drops
+// exceeding the threshold. The threshold is a fraction (0.0–1.0) of the
+// normalized score (score / maxScore). A threshold of 0.1 detects drops of
+// 10% or more.
+//
+// Both overall scores and per-grader scores are checked.
+func DetectRegressions(current, previous []TrendEntry, threshold float64) []Regression {
+if threshold <= 0 {
+threshold = DefaultRegressionThreshold
+}
+
+prevScores := buildScoreMap(previous)
+currScores := buildScoreMap(current)
+
+var regressions []Regression
+
+for key, curr := range currScores {
+prev, ok := prevScores[key]
+if !ok {
+continue // no previous data to compare
+}
+
+// Check overall score regression.
+if prev.overall > 0 && curr.overall > 0 {
+delta := prev.overall - curr.overall
+if delta > threshold {
+regressions = append(regressions, Regression{
+PromptID:      key.promptID,
+Config:        key.config,
+PreviousScore: roundTo4(prev.overall),
+CurrentScore:  roundTo4(curr.overall),
+Delta:         roundTo4(delta),
+})
+}
+}
+
+// Check per-grader regressions.
+for grader, prevGraderScore := range prev.graders {
+currGraderScore, ok := curr.graders[grader]
+if !ok {
+continue
+}
+if prevGraderScore > 0 && currGraderScore > 0 {
+delta := prevGraderScore - currGraderScore
+if delta > threshold {
+regressions = append(regressions, Regression{
+PromptID:      key.promptID,
+Config:        key.config,
+PreviousScore: roundTo4(prevGraderScore),
+CurrentScore:  roundTo4(currGraderScore),
+Delta:         roundTo4(delta),
+GraderName:    grader,
+})
+}
+}
+}
+}
+
+// Sort for deterministic output.
+sort.Slice(regressions, func(i, j int) bool {
+if regressions[i].PromptID != regressions[j].PromptID {
+return regressions[i].PromptID < regressions[j].PromptID
+}
+if regressions[i].Config != regressions[j].Config {
+return regressions[i].Config < regressions[j].Config
+}
+return regressions[i].GraderName < regressions[j].GraderName
+})
+
+return regressions
+}
+
+type scoreKey struct {
+promptID string
+config   string
+}
+
+type scoreData struct {
+overall float64
+graders map[string]float64
+}
+
+// buildScoreMap aggregates entries into average normalized scores per
+// prompt+config combination. When multiple entries exist for the same
+// prompt+config, scores are averaged.
+func buildScoreMap(entries []TrendEntry) map[scoreKey]*scoreData {
+type acc struct {
+overallSum   float64
+overallCount int
+graderSum    map[string]float64
+graderCount  map[string]int
+}
+
+accMap := map[scoreKey]*acc{}
+for _, e := range entries {
+k := scoreKey{e.PromptID, e.ConfigName}
+a, ok := accMap[k]
+if !ok {
+a = &acc{
+graderSum:   map[string]float64{},
+graderCount: map[string]int{},
+}
+accMap[k] = a
+}
+
+if e.MaxScore > 0 {
+a.overallSum += float64(e.Score) / float64(e.MaxScore)
+a.overallCount++
+}
+
+for _, gs := range e.GraderScores {
+a.graderSum[gs.GraderName] += gs.Score
+a.graderCount[gs.GraderName]++
+}
+}
+
+result := make(map[scoreKey]*scoreData, len(accMap))
+for k, a := range accMap {
+sd := &scoreData{graders: map[string]float64{}}
+if a.overallCount > 0 {
+sd.overall = a.overallSum / float64(a.overallCount)
+}
+for g, sum := range a.graderSum {
+if a.graderCount[g] > 0 {
+sd.graders[g] = sum / float64(a.graderCount[g])
+}
+}
+result[k] = sd
+}
+
+return result
+}
+
+func roundTo4(v float64) float64 {
+return math.Round(v*10000) / 10000
+}

--- a/hyoka/internal/trends/slice_test.go
+++ b/hyoka/internal/trends/slice_test.go
@@ -1,0 +1,371 @@
+package trends
+
+import (
+"testing"
+)
+
+// --- SliceTrends tests ---
+
+func TestSliceTrendsFiltersByLanguage(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "identity-dp-python-auth", ConfigName: "baseline", Success: true, Properties: map[string]string{"language": "python", "service": "identity"}},
+{RunID: "run1", PromptID: "kv-dp-dotnet-crud", ConfigName: "baseline", Success: true, Properties: map[string]string{"language": "dotnet", "service": "key-vault"}},
+{RunID: "run1", PromptID: "storage-dp-python-blob", ConfigName: "baseline", Success: false, Properties: map[string]string{"language": "python", "service": "storage"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "python"})
+
+if slice.TotalRuns != 2 {
+t.Fatalf("expected 2 entries, got %d", slice.TotalRuns)
+}
+if len(slice.PromptTrends) != 2 {
+t.Fatalf("expected 2 prompt trends, got %d", len(slice.PromptTrends))
+}
+for _, e := range slice.Entries {
+if e.Properties["language"] != "python" {
+t.Errorf("unexpected language in slice: %s", e.Properties["language"])
+}
+}
+if slice.Properties["language"] != "python" {
+t.Error("slice Properties should reflect the filter")
+}
+}
+
+func TestSliceTrendsMultipleProperties(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline", Properties: map[string]string{"language": "python", "service": "identity"}},
+{RunID: "run1", PromptID: "p2", ConfigName: "baseline", Properties: map[string]string{"language": "python", "service": "key-vault"}},
+{RunID: "run1", PromptID: "p3", ConfigName: "baseline", Properties: map[string]string{"language": "dotnet", "service": "identity"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "python", "service": "identity"})
+
+if slice.TotalRuns != 1 {
+t.Fatalf("expected 1 entry for python+identity, got %d", slice.TotalRuns)
+}
+if slice.Entries[0].PromptID != "p1" {
+t.Errorf("expected p1, got %s", slice.Entries[0].PromptID)
+}
+}
+
+func TestSliceTrendsEmptyFilter(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline"},
+{RunID: "run1", PromptID: "p2", ConfigName: "baseline"},
+}
+
+slice := SliceTrends(entries, map[string]string{})
+
+if slice.TotalRuns != 2 {
+t.Fatalf("empty filter should return all entries, got %d", slice.TotalRuns)
+}
+}
+
+func TestSliceTrendsNilFilter(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline"},
+}
+
+slice := SliceTrends(entries, nil)
+
+if slice.TotalRuns != 1 {
+t.Fatalf("nil filter should return all entries, got %d", slice.TotalRuns)
+}
+}
+
+func TestSliceTrendsNoMatch(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline", Properties: map[string]string{"language": "python"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "rust"})
+
+if slice.TotalRuns != 0 {
+t.Fatalf("expected 0 entries for non-matching filter, got %d", slice.TotalRuns)
+}
+if len(slice.PromptTrends) != 0 {
+t.Fatalf("expected 0 prompt trends, got %d", len(slice.PromptTrends))
+}
+}
+
+func TestSliceTrendsPreservesRunOrder(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run2", PromptID: "p1", ConfigName: "baseline", Timestamp: "2025-01-02T12:00:00Z", Properties: map[string]string{"language": "python"}},
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline", Timestamp: "2025-01-01T12:00:00Z", Properties: map[string]string{"language": "python"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "python"})
+
+if len(slice.RunIDs) != 2 {
+t.Fatalf("expected 2 run IDs, got %d", len(slice.RunIDs))
+}
+// Entries should be sorted by timestamp after slicing.
+if slice.Entries[0].RunID != "run1" {
+t.Errorf("expected run1 first (earlier timestamp), got %s", slice.Entries[0].RunID)
+}
+}
+
+func TestSliceTrendsNilProperties(t *testing.T) {
+// Entry with nil Properties should not match any property filter.
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline", Properties: nil},
+{RunID: "run1", PromptID: "p2", ConfigName: "baseline", Properties: map[string]string{"language": "python"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "python"})
+
+if slice.TotalRuns != 1 {
+t.Fatalf("expected 1 entry (nil props shouldn't match), got %d", slice.TotalRuns)
+}
+}
+
+func TestSliceTrendsBuildsTrends(t *testing.T) {
+entries := []TrendEntry{
+{RunID: "run1", PromptID: "p1", ConfigName: "baseline", Success: true, Timestamp: "2025-01-01T12:00:00Z", Properties: map[string]string{"language": "python"}},
+{RunID: "run2", PromptID: "p1", ConfigName: "baseline", Success: true, Timestamp: "2025-01-02T12:00:00Z", Properties: map[string]string{"language": "python"}},
+{RunID: "run1", PromptID: "p1", ConfigName: "azure-mcp", Success: false, Timestamp: "2025-01-01T12:00:00Z", Properties: map[string]string{"language": "python"}},
+}
+
+slice := SliceTrends(entries, map[string]string{"language": "python"})
+
+if len(slice.PromptTrends) != 1 {
+t.Fatalf("expected 1 prompt trend, got %d", len(slice.PromptTrends))
+}
+pt := slice.PromptTrends[0]
+if len(pt.Configs) != 2 {
+t.Errorf("expected 2 configs, got %d", len(pt.Configs))
+}
+if pt.Trend["baseline"] != TrendStable {
+t.Errorf("expected baseline trend stable, got %s", pt.Trend["baseline"])
+}
+}
+
+// --- DetectRegressions tests ---
+
+func TestDetectRegressionsOverallScore(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 4, MaxScore: 5}, // 0.8
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 3, MaxScore: 5}, // 0.6
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 1 {
+t.Fatalf("expected 1 regression, got %d", len(regs))
+}
+r := regs[0]
+if r.PromptID != "p1" {
+t.Errorf("expected p1, got %s", r.PromptID)
+}
+if r.Config != "baseline" {
+t.Errorf("expected baseline, got %s", r.Config)
+}
+if r.GraderName != "" {
+t.Errorf("expected empty grader name for overall score, got %s", r.GraderName)
+}
+if r.Delta < 0.19 || r.Delta > 0.21 {
+t.Errorf("expected delta ~0.2, got %f", r.Delta)
+}
+}
+
+func TestDetectRegressionsPerGrader(t *testing.T) {
+previous := []TrendEntry{
+{
+PromptID: "p1", ConfigName: "baseline", Score: 4, MaxScore: 5,
+GraderScores: []GraderScore{
+{GraderName: "correctness", Score: 0.9, MaxScore: 5},
+{GraderName: "style", Score: 0.8, MaxScore: 5},
+},
+},
+}
+current := []TrendEntry{
+{
+PromptID: "p1", ConfigName: "baseline", Score: 4, MaxScore: 5,
+GraderScores: []GraderScore{
+{GraderName: "correctness", Score: 0.5, MaxScore: 5}, // dropped 0.4
+{GraderName: "style", Score: 0.75, MaxScore: 5},       // dropped only 0.05
+},
+},
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+// Should find correctness regression but not style (delta too small).
+correctnessFound := false
+for _, r := range regs {
+if r.GraderName == "correctness" {
+correctnessFound = true
+if r.Delta < 0.39 || r.Delta > 0.41 {
+t.Errorf("expected correctness delta ~0.4, got %f", r.Delta)
+}
+}
+if r.GraderName == "style" {
+t.Error("style should not be flagged as regression (delta < threshold)")
+}
+}
+if !correctnessFound {
+t.Error("expected correctness grader regression to be detected")
+}
+}
+
+func TestDetectRegressionsNoRegression(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 3, MaxScore: 5},
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 4, MaxScore: 5}, // improved
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 0 {
+t.Fatalf("expected 0 regressions for improved score, got %d", len(regs))
+}
+}
+
+func TestDetectRegressionsDefaultThreshold(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 5, MaxScore: 5},
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 4, MaxScore: 5}, // 0.2 drop
+}
+
+// threshold <= 0 should use default (0.1).
+regs := DetectRegressions(current, previous, 0)
+
+if len(regs) != 1 {
+t.Fatalf("expected 1 regression with default threshold, got %d", len(regs))
+}
+}
+
+func TestDetectRegressionsNoPreviousData(t *testing.T) {
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 3, MaxScore: 5},
+}
+
+regs := DetectRegressions(current, nil, 0.1)
+
+if len(regs) != 0 {
+t.Fatalf("expected 0 regressions without previous data, got %d", len(regs))
+}
+}
+
+func TestDetectRegressionsMultipleConfigs(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 5, MaxScore: 5},
+{PromptID: "p1", ConfigName: "azure-mcp", Score: 5, MaxScore: 5},
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 2, MaxScore: 5},   // regressed
+{PromptID: "p1", ConfigName: "azure-mcp", Score: 5, MaxScore: 5}, // stable
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 1 {
+t.Fatalf("expected 1 regression (baseline only), got %d", len(regs))
+}
+if regs[0].Config != "baseline" {
+t.Errorf("expected baseline regression, got %s", regs[0].Config)
+}
+}
+
+func TestDetectRegressionsAveragesMultipleEntries(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 5, MaxScore: 5},
+{PromptID: "p1", ConfigName: "baseline", Score: 5, MaxScore: 5},
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 3, MaxScore: 5},
+{PromptID: "p1", ConfigName: "baseline", Score: 3, MaxScore: 5},
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 1 {
+t.Fatalf("expected 1 regression, got %d", len(regs))
+}
+// Previous avg: 1.0, Current avg: 0.6, Delta: 0.4
+if regs[0].Delta < 0.39 || regs[0].Delta > 0.41 {
+t.Errorf("expected delta ~0.4, got %f", regs[0].Delta)
+}
+}
+
+func TestDetectRegressionsZeroMaxScore(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 0, MaxScore: 0},
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 0, MaxScore: 0},
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 0 {
+t.Fatalf("expected 0 regressions for zero max score, got %d", len(regs))
+}
+}
+
+func TestDetectRegressionsExactThreshold(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 10, MaxScore: 10}, // 1.0
+}
+current := []TrendEntry{
+{PromptID: "p1", ConfigName: "baseline", Score: 9, MaxScore: 10}, // 0.9, delta = exactly 0.1
+}
+
+// Exact threshold should NOT trigger (> threshold, not >=).
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 0 {
+t.Fatalf("expected 0 regressions for delta exactly at threshold, got %d", len(regs))
+}
+}
+
+func TestDetectRegressionsSorted(t *testing.T) {
+previous := []TrendEntry{
+{PromptID: "p2", ConfigName: "baseline", Score: 5, MaxScore: 5},
+{PromptID: "p1", ConfigName: "azure-mcp", Score: 5, MaxScore: 5},
+{PromptID: "p1", ConfigName: "baseline", Score: 5, MaxScore: 5},
+}
+current := []TrendEntry{
+{PromptID: "p2", ConfigName: "baseline", Score: 1, MaxScore: 5},
+{PromptID: "p1", ConfigName: "azure-mcp", Score: 1, MaxScore: 5},
+{PromptID: "p1", ConfigName: "baseline", Score: 1, MaxScore: 5},
+}
+
+regs := DetectRegressions(current, previous, 0.1)
+
+if len(regs) != 3 {
+t.Fatalf("expected 3 regressions, got %d", len(regs))
+}
+// Should be sorted: p1/azure-mcp, p1/baseline, p2/baseline.
+if regs[0].PromptID != "p1" || regs[0].Config != "azure-mcp" {
+t.Errorf("first regression should be p1/azure-mcp, got %s/%s", regs[0].PromptID, regs[0].Config)
+}
+if regs[1].PromptID != "p1" || regs[1].Config != "baseline" {
+t.Errorf("second regression should be p1/baseline, got %s/%s", regs[1].PromptID, regs[1].Config)
+}
+if regs[2].PromptID != "p2" || regs[2].Config != "baseline" {
+t.Errorf("third regression should be p2/baseline, got %s/%s", regs[2].PromptID, regs[2].Config)
+}
+}
+
+// --- matchesProperties tests ---
+
+func TestMatchesPropertiesEmptyProps(t *testing.T) {
+entry := TrendEntry{Properties: map[string]string{"language": "python"}}
+if !matchesProperties(entry, map[string]string{}) {
+t.Error("empty filter should match any entry")
+}
+}
+
+func TestMatchesPropertiesMissingKey(t *testing.T) {
+entry := TrendEntry{Properties: map[string]string{"language": "python"}}
+if matchesProperties(entry, map[string]string{"service": "identity"}) {
+t.Error("entry without service property should not match service filter")
+}
+}

--- a/hyoka/internal/trends/trends.go
+++ b/hyoka/internal/trends/trends.go
@@ -29,18 +29,27 @@ TrendNew        TrendClassification = "new"
 
 // TrendEntry holds data from a single historical evaluation run.
 type TrendEntry struct {
-RunID      string   `json:"run_id"`
-Timestamp  string   `json:"timestamp"`
-ConfigName string   `json:"config_name"`
-PromptID   string   `json:"prompt_id"`
-Success    bool     `json:"success"`
-Duration   float64  `json:"duration_seconds"`
-Score      int      `json:"score"`
-MaxScore   int      `json:"max_score"`
-HasReview  bool     `json:"has_review"`
-ToolCalls  []string `json:"tool_calls"`
-FileCount  int      `json:"file_count"`
-Error      string   `json:"error,omitempty"`
+RunID        string            `json:"run_id"`
+Timestamp    string            `json:"timestamp"`
+ConfigName   string            `json:"config_name"`
+PromptID     string            `json:"prompt_id"`
+Success      bool              `json:"success"`
+Duration     float64           `json:"duration_seconds"`
+Score        int               `json:"score"`
+MaxScore     int               `json:"max_score"`
+HasReview    bool              `json:"has_review"`
+ToolCalls    []string          `json:"tool_calls"`
+FileCount    int               `json:"file_count"`
+Error        string            `json:"error,omitempty"`
+Properties   map[string]string `json:"properties,omitempty"`
+GraderScores []GraderScore     `json:"grader_scores,omitempty"`
+}
+
+// GraderScore holds a single grader's normalized score for trend tracking.
+type GraderScore struct {
+GraderName string  `json:"grader_name"`
+Score      float64 `json:"score"`     // 0.0–1.0 normalized
+MaxScore   int     `json:"max_score"` // integer max from the grader
 }
 
 // RunResult holds a single run's metrics for a specific prompt+config.
@@ -375,6 +384,26 @@ if r.Review != nil {
 entry.Score = r.Review.OverallScore
 entry.MaxScore = r.Review.MaxScore
 entry.HasReview = true
+}
+
+// Populate properties from prompt metadata for trend slicing.
+if len(r.PromptMeta) > 0 {
+props := make(map[string]string, len(r.PromptMeta))
+for k, v := range r.PromptMeta {
+if s, ok := v.(string); ok {
+props[k] = s
+}
+}
+entry.Properties = props
+}
+
+// Populate per-grader scores for regression detection.
+for _, gr := range r.GraderResults {
+entry.GraderScores = append(entry.GraderScores, GraderScore{
+GraderName: gr.GraderName,
+Score:      gr.Score,
+MaxScore:   gr.MaxScore,
+})
 }
 
 entries = append(entries, entry)


### PR DESCRIPTION
## Summary

Adds two new capabilities to the trends package:

### Task 4.3a — Property-based trend slicing (#150)
- `SliceTrends(entries, properties)` filters trend data by any prompt property combination (language, service, plane, category, etc.)
- AND logic: `map[string]string{"language": "python", "service": "identity"}` returns only Python Identity prompts
- Returns a `TrendSlice` with filtered entries, prompt trends, and run IDs

### Task 4.3b — Automatic regression detection (#151)
- `DetectRegressions(current, previous, threshold)` compares run data to find score drops
- Checks both overall scores and per-grader scores
- Default threshold: 0.1 (10% drop)
- Returns sorted `[]Regression` with prompt ID, config, scores, delta, and grader name

### Implementation details
- Extended `TrendEntry` with `Properties` (from PromptMeta) and `GraderScores` (from GraderResults)
- `scanReports` now populates both fields during report scanning
- 20 new tests covering filtering, regression detection, edge cases (nil props, zero scores, exact thresholds)

Closes #150
Closes #151