### PR TITLE
feat: design dashboard API endpoints (#147)

### DIFF
--- a/hyoka/internal/serve/serve.go
+++ b/hyoka/internal/serve/serve.go
@@ -180,9 +180,20 @@ func handleAPIRunDetail(w http.ResponseWriter, r *http.Request, reportsDir strin
 		return
 	}
 
-	// /api/runs/{runId}/eval?path=...
-	if len(parts) == 2 && parts[1] == "eval" {
-		handleAPIEval(w, r, reportsDir, runID)
+	// Sub-resource dispatch for /api/runs/{runId}/{sub}
+	if len(parts) == 2 {
+		switch parts[1] {
+		case "eval":
+			handleAPIEval(w, r, reportsDir, runID)
+		case "graders":
+			handleAPIGraders(w, r, reportsDir, runID)
+		case "timeline":
+			handleAPITimeline(w, r, reportsDir, runID)
+		case "score-breakdown":
+			handleAPIScoreBreakdown(w, r, reportsDir, runID)
+		default:
+			http.NotFound(w, r)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary

Adds six new API endpoints to the serve package powering the React SPA dashboard.

### New endpoints

| Endpoint | Description | Status |
|---|---|---|
| `GET /api/runs/{runId}/graders` | Grader results for a run | ✅ Functional |
| `GET /api/runs/{runId}/timeline` | Action timeline for a run | ✅ Functional |
| `GET /api/runs/{runId}/score-breakdown` | Score aggregation details | ✅ Functional |
| `GET /api/compare?configA=X&configB=Y` | Config comparison | 🔲 Stub |
| `GET /api/trends?promptId=Z&service=S` | Trend data | ✅ Functional |
| `GET /api/prompts/{promptId}/history` | Historical results for a prompt | ✅ Functional |

### Implementation

- **Drill-down endpoints** (graders, timeline, score-breakdown) load eval report.json files from the reports directory with fallback computation when pre-built data is missing
- **Compare** is stubbed pending the comparison/ package
- **Trends** and **prompt history** delegate to the existing `trends.Generate` engine
- Refactored `handleAPIRunDetail` to use a switch for cleaner sub-route dispatch
- Extended `handleAPIPromptDetail` to dispatch `/history` suffix to the new handler

### Tests

16 new tests covering: valid requests, 404s, parameter validation, path traversal protection, fallback score computation, and unknown sub-route handling.

Closes #147