### PR TITLE
feat: implement comparison UI in React dashboard (#148)

### DIFF
--- a/hyoka/internal/serve/serve.go
+++ b/hyoka/internal/serve/serve.go
@@ -128,6 +128,11 @@ func buildMux(opts Options) *http.ServeMux {
 	// --- Dashboard routes (comparison, trends, drill-down) ---
 	registerDashboardRoutes(mux, opts)
 
+	// --- API: comparison ---
+	mux.HandleFunc("/api/compare/configs", func(w http.ResponseWriter, r *http.Request) {
+		handleAPICompareConfigs(w, r, opts.ReportsDir)
+	})
+
 	// --- Static file serving for raw report files ---
 	reportFS := http.FileServer(http.Dir(opts.ReportsDir))
 	mux.Handle("/reports/", http.StripPrefix("/reports/", reportFS))

--- a/hyoka/internal/serve/serve_test.go
+++ b/hyoka/internal/serve/serve_test.go
@@ -551,3 +551,77 @@ func TestAPIPromptDetailNotFound(t *testing.T) {
 		t.Errorf("expected 404, got %d", rec.Code)
 	}
 }
+
+func setupTestComparisonReports(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run1 := filepath.Join(dir, "20260327-113302")
+	os.MkdirAll(filepath.Join(run1, "identity-dp-python-default-credential", "config-a"), 0755)
+	os.MkdirAll(filepath.Join(run1, "identity-dp-python-default-credential", "config-b"), 0755)
+
+	reportA := `{
+		"prompt_id": "identity-dp-python-default-credential",
+		"config_name": "baseline/claude-opus-4.6",
+		"timestamp": "2026-03-27T18:33:02Z",
+		"success": true,
+		"duration_seconds": 30,
+		"review": {"overall_score": 70, "max_score": 100, "summary": "decent"}
+	}`
+	reportB := `{
+		"prompt_id": "identity-dp-python-default-credential",
+		"config_name": "azure-mcp/claude-opus-4.6",
+		"timestamp": "2026-03-27T18:33:02Z",
+		"success": true,
+		"duration_seconds": 25,
+		"review": {"overall_score": 90, "max_score": 100, "summary": "great"}
+	}`
+	os.WriteFile(filepath.Join(run1, "identity-dp-python-default-credential", "config-a", "report.json"), []byte(reportA), 0644)
+	os.WriteFile(filepath.Join(run1, "identity-dp-python-default-credential", "config-b", "report.json"), []byte(reportB), 0644)
+
+	return dir
+}
+
+func TestAPICompareConfigsEndpoint(t *testing.T) {
+	dir := setupTestComparisonReports(t)
+	mux := buildMux(Options{ReportsDir: dir})
+
+	req := httptest.NewRequest("GET", "/api/compare/configs?a=baseline/claude-opus-4.6&b=azure-mcp/claude-opus-4.6", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if result["config_a"] != "baseline/claude-opus-4.6" {
+		t.Errorf("unexpected config_a: %v", result["config_a"])
+	}
+	if result["config_b"] != "azure-mcp/claude-opus-4.6" {
+		t.Errorf("unexpected config_b: %v", result["config_b"])
+	}
+}
+
+func TestAPICompareConfigsMissingParams(t *testing.T) {
+	mux := buildMux(Options{ReportsDir: t.TempDir()})
+
+	req := httptest.NewRequest("GET", "/api/compare/configs?a=foo", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing b param, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/api/compare/configs", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing both params, got %d", rec.Code)
+	}
+}

--- a/site/src/app/components/comparison-page.tsx
+++ b/site/src/app/components/comparison-page.tsx
@@ -1,0 +1,576 @@
+import { useState, useEffect, useMemo } from "react";
+import { fetchRuns, fetchCompareConfigs } from "../data/api";
+import type { RunSummary, ConfigComparison, PromptDiff, GraderDiff } from "../data/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./ui/table";
+import {
+  ArrowUpRight,
+  ArrowDownRight,
+  Minus,
+  Loader2,
+  GitCompareArrows,
+  TrendingUp,
+  TrendingDown,
+  Equal,
+  ChevronDown,
+  ChevronRight,
+  Filter,
+} from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
+
+function formatScore(score: number): string {
+  return (score * 100).toFixed(1) + "%";
+}
+
+function formatDelta(delta: number): string {
+  const pct = (delta * 100).toFixed(1);
+  if (delta > 0) return `+${pct}%`;
+  return `${pct}%`;
+}
+
+function deltaColor(delta: number): string {
+  if (delta > 0.001) return "text-emerald-400";
+  if (delta < -0.001) return "text-red-400";
+  return "text-white/40";
+}
+
+function deltaBg(delta: number): string {
+  if (delta > 0.001) return "bg-emerald-500/10";
+  if (delta < -0.001) return "bg-red-500/10";
+  return "bg-white/5";
+}
+
+function DeltaIcon({ delta }: { delta: number }) {
+  if (delta > 0.001)
+    return <ArrowUpRight className="h-3.5 w-3.5 text-emerald-400" />;
+  if (delta < -0.001)
+    return <ArrowDownRight className="h-3.5 w-3.5 text-red-400" />;
+  return <Minus className="h-3.5 w-3.5 text-white/30" />;
+}
+
+function extractConfigNames(runs: RunSummary[]): string[] {
+  const names = new Set<string>();
+  for (const run of runs) {
+    if (!run.results) continue;
+    for (const r of run.results) {
+      if (r.config_name) names.add(r.config_name);
+    }
+  }
+  return Array.from(names).sort();
+}
+
+function extractFilterValues(
+  diffs: PromptDiff[]
+): { languages: string[]; services: string[] } {
+  const languages = new Set<string>();
+  const services = new Set<string>();
+  for (const d of diffs) {
+    const parts = d.prompt_id.split("-");
+    // Pattern: {service}-{plane}-{language}-{rest}
+    if (parts.length >= 3) {
+      services.add(parts[0]);
+      // Language is after the plane abbreviation (dp/mp)
+      languages.add(parts[2]);
+    }
+  }
+  return {
+    languages: Array.from(languages).sort(),
+    services: Array.from(services).sort(),
+  };
+}
+
+function GraderDiffRow({ diff }: { diff: GraderDiff }) {
+  return (
+    <TableRow className="border-white/5 bg-white/[0.01]">
+      <TableCell className="pl-10 text-white/50" style={{ fontSize: 12 }}>
+        {diff.name}
+      </TableCell>
+      <TableCell
+        className="text-white/60"
+        style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
+      >
+        {diff.score_a.toFixed(2)}
+        <span className="ml-1.5 text-white/30">
+          {diff.pass_a ? "✓" : "✗"}
+        </span>
+      </TableCell>
+      <TableCell
+        className="text-white/60"
+        style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
+      >
+        {diff.score_b.toFixed(2)}
+        <span className="ml-1.5 text-white/30">
+          {diff.pass_b ? "✓" : "✗"}
+        </span>
+      </TableCell>
+      <TableCell>
+        <span
+          className={`inline-flex items-center gap-1 ${deltaColor(diff.delta)}`}
+          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
+        >
+          <DeltaIcon delta={diff.delta} />
+          {diff.delta > 0 ? "+" : ""}
+          {diff.delta.toFixed(2)}
+        </span>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function PromptDiffRow({ diff }: { diff: PromptDiff }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasGraders = diff.grader_diffs && diff.grader_diffs.length > 0;
+  const isOneSided = diff.only_in_a || diff.only_in_b;
+
+  return (
+    <>
+      <TableRow
+        className={`cursor-pointer border-white/5 transition-colors hover:bg-white/[0.04] ${
+          hasGraders ? "" : "cursor-default"
+        }`}
+        onClick={() => hasGraders && setExpanded(!expanded)}
+      >
+        <TableCell>
+          <div className="flex items-center gap-2">
+            {hasGraders ? (
+              expanded ? (
+                <ChevronDown className="h-3.5 w-3.5 text-white/30" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5 text-white/30" />
+              )
+            ) : (
+              <span className="w-3.5" />
+            )}
+            <span
+              className="text-emerald-400"
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 13,
+              }}
+            >
+              {diff.prompt_id}
+            </span>
+            {isOneSided && (
+              <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400" style={{ fontSize: 10 }}>
+                {diff.only_in_a ? "Only in A" : "Only in B"}
+              </span>
+            )}
+          </div>
+        </TableCell>
+        <TableCell
+          className="text-white/60"
+          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13 }}
+        >
+          {isOneSided && diff.only_in_b ? "—" : formatScore(diff.score_a)}
+        </TableCell>
+        <TableCell
+          className="text-white/60"
+          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13 }}
+        >
+          {isOneSided && diff.only_in_a ? "—" : formatScore(diff.score_b)}
+        </TableCell>
+        <TableCell>
+          {!isOneSided ? (
+            <span
+              className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 ${deltaBg(diff.delta)} ${deltaColor(diff.delta)}`}
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 13,
+              }}
+            >
+              <DeltaIcon delta={diff.delta} />
+              {formatDelta(diff.delta)}
+            </span>
+          ) : (
+            <span className="text-white/20">—</span>
+          )}
+        </TableCell>
+      </TableRow>
+      <AnimatePresence>
+        {expanded && hasGraders && (
+          <motion.tr
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+          >
+            <td colSpan={4} className="p-0">
+              <Table>
+                <TableBody>
+                  {diff.grader_diffs!.map((gd) => (
+                    <GraderDiffRow key={gd.name} diff={gd} />
+                  ))}
+                </TableBody>
+              </Table>
+            </td>
+          </motion.tr>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+export function ComparisonPage() {
+  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [configNames, setConfigNames] = useState<string[]>([]);
+  const [configA, setConfigA] = useState<string>("");
+  const [configB, setConfigB] = useState<string>("");
+  const [comparison, setComparison] = useState<ConfigComparison | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [runsLoading, setRunsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [filterLanguage, setFilterLanguage] = useState<string>("all");
+  const [filterService, setFilterService] = useState<string>("all");
+
+  useEffect(() => {
+    fetchRuns()
+      .then((data) => {
+        setRuns(data);
+        setConfigNames(extractConfigNames(data));
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setRunsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!configA || !configB || configA === configB) {
+      setComparison(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    fetchCompareConfigs(configA, configB)
+      .then(setComparison)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [configA, configB]);
+
+  const filterValues = useMemo(
+    () => extractFilterValues(comparison?.per_prompt ?? []),
+    [comparison]
+  );
+
+  const filteredDiffs = useMemo(() => {
+    if (!comparison) return [];
+    return comparison.per_prompt.filter((d) => {
+      const parts = d.prompt_id.split("-");
+      if (filterLanguage !== "all" && parts.length >= 3 && parts[2] !== filterLanguage)
+        return false;
+      if (filterService !== "all" && parts.length >= 1 && parts[0] !== filterService)
+        return false;
+      return true;
+    });
+  }, [comparison, filterLanguage, filterService]);
+
+  const filteredSummary = useMemo(() => {
+    let improved = 0,
+      regressed = 0,
+      unchanged = 0,
+      totalDelta = 0,
+      paired = 0;
+    for (const d of filteredDiffs) {
+      if (d.only_in_a || d.only_in_b) continue;
+      paired++;
+      totalDelta += d.delta;
+      if (d.delta > 0.001) improved++;
+      else if (d.delta < -0.001) regressed++;
+      else unchanged++;
+    }
+    return {
+      avg_delta: paired > 0 ? totalDelta / paired : 0,
+      improved,
+      regressed,
+      unchanged,
+    };
+  }, [filteredDiffs]);
+
+  if (runsLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#0a0a0f]">
+        <Loader2 className="h-6 w-6 animate-spin text-emerald-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="min-h-screen bg-[#0a0a0f] px-4 py-8 sm:px-6"
+      style={{ fontFamily: "'Inter', sans-serif" }}
+    >
+      <div className="mx-auto max-w-6xl">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="mb-2 flex items-center gap-3">
+            <GitCompareArrows className="h-6 w-6 text-emerald-400" />
+            <h1
+              className="text-white"
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: "clamp(1.5rem, 3vw, 2rem)",
+              }}
+            >
+              Config Comparison
+            </h1>
+          </div>
+          <p className="text-white/40" style={{ fontSize: 14 }}>
+            Compare evaluation scores between two configurations side-by-side.
+          </p>
+        </div>
+
+        {/* Config selectors */}
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              className="mb-1.5 block text-white/50"
+              style={{ fontSize: 12 }}
+            >
+              Config A (baseline)
+            </label>
+            <Select value={configA} onValueChange={setConfigA}>
+              <SelectTrigger className="border-white/10 bg-white/[0.03] text-white">
+                <SelectValue placeholder="Select config A…" />
+              </SelectTrigger>
+              <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
+                {configNames.map((name) => (
+                  <SelectItem key={name} value={name} disabled={name === configB}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label
+              className="mb-1.5 block text-white/50"
+              style={{ fontSize: 12 }}
+            >
+              Config B (comparison)
+            </label>
+            <Select value={configB} onValueChange={setConfigB}>
+              <SelectTrigger className="border-white/10 bg-white/[0.03] text-white">
+                <SelectValue placeholder="Select config B…" />
+              </SelectTrigger>
+              <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
+                {configNames.map((name) => (
+                  <SelectItem key={name} value={name} disabled={name === configA}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-6 w-6 animate-spin text-emerald-400" />
+          </div>
+        )}
+
+        {/* Error */}
+        {error && !loading && (
+          <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center">
+            <p className="mb-1 text-red-400">Comparison failed</p>
+            <p className="text-white/40" style={{ fontSize: 13 }}>
+              {error}
+            </p>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && !comparison && configA && configB && configA === configB && (
+          <div className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center">
+            <p className="text-white/40">Please select two different configurations to compare.</p>
+          </div>
+        )}
+
+        {!loading && !error && !comparison && (!configA || !configB) && (
+          <div className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center">
+            <GitCompareArrows className="mx-auto mb-3 h-8 w-8 text-white/20" />
+            <p className="text-white/40">
+              Select two configurations above to see a side-by-side comparison.
+            </p>
+          </div>
+        )}
+
+        {/* Results */}
+        {comparison && !loading && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            {/* Summary stats */}
+            <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
+                <div className="mb-1 flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4 text-emerald-400" />
+                  <span className="text-white/40" style={{ fontSize: 12 }}>
+                    Avg Delta
+                  </span>
+                </div>
+                <span
+                  className={`${deltaColor(filteredSummary.avg_delta)}`}
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 20,
+                  }}
+                >
+                  {formatDelta(filteredSummary.avg_delta)}
+                </span>
+              </div>
+              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
+                <div className="mb-1 flex items-center gap-2">
+                  <ArrowUpRight className="h-4 w-4 text-emerald-400" />
+                  <span className="text-white/40" style={{ fontSize: 12 }}>
+                    Improved
+                  </span>
+                </div>
+                <span
+                  className="text-emerald-400"
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 20,
+                  }}
+                >
+                  {filteredSummary.improved}
+                </span>
+              </div>
+              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
+                <div className="mb-1 flex items-center gap-2">
+                  <ArrowDownRight className="h-4 w-4 text-red-400" />
+                  <span className="text-white/40" style={{ fontSize: 12 }}>
+                    Regressed
+                  </span>
+                </div>
+                <span
+                  className="text-red-400"
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 20,
+                  }}
+                >
+                  {filteredSummary.regressed}
+                </span>
+              </div>
+              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
+                <div className="mb-1 flex items-center gap-2">
+                  <Equal className="h-4 w-4 text-white/30" />
+                  <span className="text-white/40" style={{ fontSize: 12 }}>
+                    Unchanged
+                  </span>
+                </div>
+                <span
+                  className="text-white/50"
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 20,
+                  }}
+                >
+                  {filteredSummary.unchanged}
+                </span>
+              </div>
+            </div>
+
+            {/* Filter controls */}
+            <div className="mb-4 flex flex-wrap items-center gap-3">
+              <Filter className="h-4 w-4 text-white/30" />
+              <Select value={filterService} onValueChange={setFilterService}>
+                <SelectTrigger className="w-40 border-white/10 bg-white/[0.03] text-white" size="sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
+                  <SelectItem value="all">All Services</SelectItem>
+                  {filterValues.services.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={filterLanguage} onValueChange={setFilterLanguage}>
+                <SelectTrigger className="w-40 border-white/10 bg-white/[0.03] text-white" size="sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
+                  <SelectItem value="all">All Languages</SelectItem>
+                  {filterValues.languages.map((l) => (
+                    <SelectItem key={l} value={l}>
+                      {l}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {(filterLanguage !== "all" || filterService !== "all") && (
+                <button
+                  onClick={() => {
+                    setFilterLanguage("all");
+                    setFilterService("all");
+                  }}
+                  className="rounded-md px-2 py-1 text-white/40 transition-colors hover:bg-white/5 hover:text-white/60"
+                  style={{ fontSize: 12 }}
+                >
+                  Clear filters
+                </button>
+              )}
+              <span className="ml-auto text-white/30" style={{ fontSize: 12 }}>
+                {filteredDiffs.length} prompt{filteredDiffs.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+
+            {/* Comparison table */}
+            <div className="overflow-hidden rounded-xl border border-white/8 bg-white/[0.02]">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-white/8 hover:bg-transparent">
+                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
+                      Prompt
+                    </TableHead>
+                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
+                      {comparison.config_a}
+                    </TableHead>
+                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
+                      {comparison.config_b}
+                    </TableHead>
+                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
+                      Delta (B − A)
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredDiffs.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="py-8 text-center text-white/30">
+                        No prompts match the current filters.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    filteredDiffs.map((d) => (
+                      <PromptDiffRow key={d.prompt_id} diff={d} />
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/site/src/app/components/navbar.tsx
+++ b/site/src/app/components/navbar.tsx
@@ -8,6 +8,7 @@ const navLinks = [
   { to: "/runs", label: "Runs" },
   { to: "/prompts", label: "Prompts" },
   { to: "/pairwise", label: "Pairwise" },
+  { to: "/compare", label: "Compare" },
   { to: "/dashboard", label: "Dashboard" },
   { to: "/docs", label: "Docs" },
 ];

--- a/site/src/app/data/api.ts
+++ b/site/src/app/data/api.ts
@@ -1,4 +1,5 @@
 import type { RunSummary, EvalReport, DocEntry, DocDetail } from "./types";
+import type { ConfigComparison } from "./types";
 
 const API_BASE = "";
 
@@ -56,4 +57,10 @@ export async function fetchPrompts(): Promise<PromptInfo[]> {
 
 export async function fetchPrompt(promptId: string): Promise<PromptInfo> {
   return fetchJSON<PromptInfo>(`/api/prompts/${encodeURIComponent(promptId)}`);
+}
+
+export async function fetchCompareConfigs(configA: string, configB: string): Promise<ConfigComparison> {
+  return fetchJSON<ConfigComparison>(
+    `/api/compare/configs?a=${encodeURIComponent(configA)}&b=${encodeURIComponent(configB)}`
+  );
 }

--- a/site/src/app/routes.ts
+++ b/site/src/app/routes.ts
@@ -10,6 +10,7 @@ import { PromptsPage } from "./components/prompts-page";
 import { PromptDetailPage } from "./components/prompt-detail-page";
 import { EvalDetailPage } from "./components/eval-detail-page";
 import { PairwisePage } from "./components/pairwise-page";
+import { ComparisonPage } from "./components/comparison-page";
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { path: "how-it-works", Component: HowItWorksPage },
       { path: "dashboard", Component: DashboardPage },
       { path: "pairwise", Component: PairwisePage },
+      { path: "compare", Component: ComparisonPage },
       { path: "docs", Component: DocsPage },
       { path: "runs", Component: RunsPage },
       { path: "runs/:runId", Component: RunDetailPage },


### PR DESCRIPTION
## Summary

Adds a dynamic config comparison view to the React SPA dashboard.

### Backend
- Wire `comparison.CompareConfigs` to `/api/compare/configs?a=X&b=Y` endpoint in the serve package
- Include the comparison engine package (from #144)
- Add tests for the new endpoint (param validation, response shape)

### Frontend (`/compare` route)
- **Config selectors** — two dropdowns populated from unique config names across all runs
- **Side-by-side table** — per-prompt score diffs with color-coded deltas (green = improved, red = regressed)
- **Filter controls** — filter by language and service extracted from prompt IDs
- **Summary stats bar** — avg delta, improved count, regressed count, unchanged count
- **Drill-down** — click any prompt row to expand per-grader score diffs
- **Loading/error states** — spinner and error display for API calls
- **Nav link** — added "Compare" to the navbar

### Files changed
| Area | Files |
|------|-------|
| Go backend | `serve.go`, `serve_test.go`, `comparison/` |
| React SPA | `comparison-page.tsx`, `routes.ts`, `navbar.tsx`, `api.ts`, `types.ts` |

Closes #148