### PR TITLE
feat: create 14 hyoka project-specific skills

### DIFF
--- a/skills/hyoka/cli-patterns/SKILL.md
+++ b/skills/hyoka/cli-patterns/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: "cli-patterns"
+description: "Cobra commands in cmd/ package, flag conventions"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/cmd/*.go"
+---
+
+## Context
+
+Hyoka's CLI is built with Cobra, a popular Go CLI framework. Commands are organized in the `cmd/` package with consistent flag naming and help text patterns.
+
+## Command Structure
+
+Each command is a Cobra command object:
+
+```go
+// cmd/run.go
+var runCmd = &cobra.Command{
+    Use:   "run",
+    Short: "Run evaluation",
+    Long:  "Run an evaluation with prompts and configs.",
+    
+    Args: cobra.NoArgs,  // Positional arguments check
+    
+    RunE: func(cmd *cobra.Command, args []string) error {
+        // Retrieve flags
+        promptID, _ := cmd.Flags().GetString("prompt-id")
+        config, _ := cmd.Flags().GetString("config")
+        
+        // Validate
+        if promptID == "" && config == "" {
+            return fmt.Errorf("either --prompt-id or --config required")
+        }
+        
+        // Execute
+        return run(promptID, config)
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(runCmd)
+    runCmd.Flags().StringP("prompt-id", "", "", "Single prompt ID")
+    runCmd.Flags().StringP("config", "", "", "Config (comma-sep for multiple)")
+}
+```
+
+## Flag Naming Conventions
+
+- **Kebab-case:** `--log-level`, `--max-files`, `--prompt-id` (not `--logLevel`, `--maxfiles`)
+- **Short flags:** Single-letter for common flags (e.g., `-v` for `--verbose`)
+- **Suffixes:**
+  - `--*-timeout` for duration limits (e.g., `--gen-timeout`)
+  - `--skip-*` for skipping phases (e.g., `--skip-review`)
+  - `--*-file` for file paths (e.g., `--log-file`)
+
+## Flag Types and Patterns
+
+**String flags:**
+```go
+cmd.Flags().StringP("config", "", "", "Config name")
+```
+
+**Comma-separated lists:**
+```go
+cmd.Flags().String("tags", "", "Comma-separated tags (must quote: \"auth,crud\")")
+// Parsed as: strings.Split(value, ",")
+```
+
+**Boolean flags:**
+```go
+cmd.Flags().Bool("dry-run", false, "Show what would run without executing")
+```
+
+**Numeric flags:**
+```go
+cmd.Flags().Int("max-files", 50, "Max files per eval")
+cmd.Flags().Duration("gen-timeout", 600*time.Second, "Generation timeout")
+```
+
+## Help Text Guidelines
+
+Keep help text brief but actionable:
+
+```
+// Good
+--config          Config name or comma-sep list
+--prompt-id       Single prompt ID (e.g., identity-dp-python-default-credential)
+--service         Azure service (e.g., identity, key-vault)
+--dry-run         List matching prompts without executing
+
+// Bad (too verbose, no examples)
+--prompt-id       The prompt identifier
+--config          The configuration to use
+```
+
+## Command Execution Pattern
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    // 1. Get flags
+    promptID, _ := cmd.Flags().GetString("prompt-id")
+    config, _ := cmd.Flags().GetString("config")
+    
+    // 2. Validate
+    if promptID == "" {
+        return fmt.Errorf("--prompt-id required")
+    }
+    
+    // 3. Execute
+    ctx := context.Background()
+    return executeEval(ctx, promptID, config)
+}
+```
+
+## Common Commands in Hyoka
+
+- `run` — Execute evaluation
+- `list` — List available prompts
+- `validate` — Validate prompt schema
+- `check-env` — Check environment (Copilot SDK, Go version)
+- `clean` — Clean orphaned sessions
+- `serve` — Start local web server for results
+
+## Error Handling in Commands
+
+Return errors from `RunE`. Cobra catches them and prints with exit code 1:
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    result, err := runEval(...)
+    if err != nil {
+        slog.Error("Evaluation failed", "error", err)
+        return err  // Cobra handles exit
+    }
+    return nil
+}
+```
+
+## Output and Logging
+
+- **User output (results, progress):** Write to stdout
+- **Diagnostic logs:** Use slog with `--log-level` flag
+- **Errors:** Return error from `RunE`, let Cobra print
+
+## Flag Validation Example
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    config, _ := cmd.Flags().GetString("config")
+    allConfigs, _ := cmd.Flags().GetBool("all-configs")
+    
+    if config == "" && !allConfigs {
+        return fmt.Errorf("either --config or --all-configs required")
+    }
+    
+    if config != "" && allConfigs {
+        return fmt.Errorf("cannot use both --config and --all-configs")
+    }
+    
+    return runWithConfig(config, allConfigs)
+}
+```
+
+## Related Code Locations
+
+- **Root command:** `hyoka/cmd/root.go`
+- **Subcommands:** `hyoka/cmd/*.go`
+- **Flag parsing utilities:** `hyoka/cmd/common.go` (if shared parsing logic)
+
+## Anti-Patterns
+
+- CamelCase flag names
+- Positional arguments instead of flags
+- Ambiguous short flags (avoid single `-a` if context unclear)
+- Printing errors and returning them (let Cobra handle)
+- Hardcoding defaults without CLI override

--- a/skills/hyoka/config-system/SKILL.md
+++ b/skills/hyoka/config-system/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "config-system"
+description: "Generator/Reviewer sub-structs, property-based tool filters"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/config/config.go"
+---
+
+## Context
+
+Hyoka's config system is YAML-driven and highly composable. Each evaluation config defines separate generator and reviewer specifications, with tool filtering via properties (allow/deny lists and skill injection).
+
+## Config Structure
+
+### Top-Level ToolConfig
+```yaml
+name: baseline/claude-opus-4.6
+description: "Baseline Opus eval"
+generator:
+  model: claude-opus-4.6
+  system_prompt: "You are..."
+  skills: [...]
+  mcp_servers: {...}
+  tools: [...]
+  available_tools: [...]    # Allowlist
+  excluded_tools: [...]     # Denylist
+reviewer:
+  models: [claude-opus-4.6, gpt-5.4]
+  system_prompt: "Review this code..."
+plugins: [...]
+limits:
+  max_turns: 25
+  max_files: 50
+  max_output_size: 1048576
+  max_session_actions: 50
+```
+
+### Generator vs. Reviewer Separation
+
+**GeneratorConfig** (code generation):
+- Single `model` field (one generator model)
+- Optional `system_prompt` override
+- Skills injection for generator context
+- MCP servers for external tools
+- Tool filters (available_tools / excluded_tools)
+
+**ReviewerConfig** (code review):
+- `models` array (multiple reviewers in parallel)
+- Optional `system_prompt` for review instructions
+- Skills injection for review guidance
+- No MCP servers (reviewers don't call tools)
+
+## Tool Filtering
+
+Tools are filtered via **ToolEntry** specs:
+```go
+type ToolEntry struct {
+    Name       string            `yaml:"name"`
+    Include    bool              `yaml:"include"`           // whitelist
+    Exclude    bool              `yaml:"exclude"`           // blacklist
+    Properties map[string]string `yaml:"properties"`        // filters by context
+}
+```
+
+### Property-Based Tool Filtering
+
+Properties are **snake_case** metadata on tools (e.g., `language:python`, `service:keyvault`). Generator model sees only tools matching the current prompt's properties.
+
+**Example:**
+```yaml
+# Config
+tools:
+  - name: python_test_runner
+    include: true
+    properties:
+      language: python
+
+# Prompt metadata
+language: python  # Matches → tool included
+
+language: dotnet  # No match → tool hidden
+```
+
+## Composition Patterns
+
+**Skill Injection:**
+```yaml
+generator:
+  skills:
+    - type: local
+      path: ./skills/generator/**/*.md
+    - type: remote
+      name: azure-prompt-patterns
+      repo: github.com/Azure/hyoka-skills
+```
+
+**MCP Server Configuration:**
+```yaml
+generator:
+  mcp_servers:
+    azure-cli:
+      type: command
+      command: az
+      args: ["--version"]
+      tools: ["azure_resource_list", "azure_resource_get"]
+```
+
+## Key Patterns
+
+- **Single model for generation, multiple for review:** Enables comparison across reviewers
+- **Property-based filtering:** Tools scope automatically to prompt language/service
+- **SessionLimits as guardrails:** Per-config turn/file/action limits override engine defaults
+- **Plugins for extensibility:** Config-level plugin registration (for future custom scoring)
+
+## Related Code Locations
+
+- **Config loading:** `hyoka/internal/config/config.go`
+- **Tool filtering logic:** `hyoka/internal/config/tools.go`
+- **Example configs:** `configs/*.yaml`
+
+## Anti-Patterns
+
+- Hardcoding tool availability (use properties instead)
+- Using different skill sets for generator and reviewer without documentation
+- Conflicting available_tools and excluded_tools (excluded wins)
+- Ignoring SessionLimits in custom configs (defaults should be sufficient)

--- a/skills/hyoka/contributor-guide/SKILL.md
+++ b/skills/hyoka/contributor-guide/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: "contributor-guide"
+description: "How to contribute, build, test"
+domain: "collaboration"
+confidence: "high"
+source: "hyoka/README.md, docs/contributing.md"
+---
+
+## Context
+
+Hyoka is an open evaluation tool for Azure SDK code generation. Contributors should follow the setup and workflow documented here to ensure smooth development and testing.
+
+## Development Setup
+
+### Prerequisites
+
+- **Go 1.24.5+** (check with `go version`)
+- **Copilot SDK** installed and authenticated
+- **git** configured with GitHub SSH access
+
+### Clone and Build
+
+```bash
+# Clone the repo
+git clone https://github.com/ronniegeraghty/hyoka.git
+cd hyoka
+
+# Install dependencies (uses go.work for workspace)
+go mod download
+
+# Build the CLI
+go build ./hyoka/...
+
+# Run the CLI
+go run ./hyoka <command>
+```
+
+## Development Workflow
+
+### Before Starting Work
+
+1. **Create a branch** from `ronniegeraghty/dev`:
+   ```bash
+   git checkout ronniegeraghty/dev
+   git pull origin ronniegeraghty/dev
+   git checkout -b ronniegeraghty/issue-{N}-{description}
+   ```
+
+2. **Configure git identity:**
+   ```bash
+   git config user.name "ronniegeraghty"
+   git config user.email "ronniegeraghty@users.noreply.github.com"
+   ```
+
+### Making Changes
+
+1. **Edit code** in `hyoka/internal/` or `hyoka/cmd/`
+2. **Run tests** to verify no regressions:
+   ```bash
+   go test -race ./hyoka/...
+   ```
+3. **Run linter** (if configured):
+   ```bash
+   go fmt ./hyoka/...
+   ```
+4. **Test manually** with a quick eval run:
+   ```bash
+   go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+     --config baseline/claude-opus-4.6 --log-level debug
+   ```
+
+### Before Committing
+
+1. **Ensure tests pass** with race detector:
+   ```bash
+   go test -race ./hyoka/...
+   ```
+
+2. **Clean up orphaned sessions** from test runs:
+   ```bash
+   go run ./hyoka clean
+   ```
+
+3. **Include the Co-authored-by trailer** in commit message:
+   ```
+   git commit -m "Fix eval engine timeout handling
+
+   - Add timeout context to generation phase
+   - Capture timeout error in action timeline
+   
+   Closes #162
+   
+   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+   ```
+
+### Pushing and Creating a PR
+
+1. **Push to your fork:**
+   ```bash
+   gh auth switch --user ronniegeraghty
+   git push origin ronniegeraghty/issue-{N}-{description}
+   ```
+
+2. **Create a PR** against `ronniegeraghty/dev`:
+   ```bash
+   gh pr create --base ronniegeraghty/dev \
+     --title "Fix: eval engine timeout" \
+     --body "Closes #162"
+   ```
+
+3. **Link to board:** Edit issue on Azure/projects/424 and set Status → "In Progress"
+
+## Testing During Development
+
+### Quick Test Run
+
+For iterating on changes, run a single prompt × single config (fastest):
+
+```bash
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config baseline/claude-opus-4.6 --log-level debug
+```
+
+Python prompts finish quickest (5-10 minutes). After each run, clean up:
+
+```bash
+go run ./hyoka clean
+```
+
+### Check Logs
+
+```bash
+# View the debug log
+cat hyoka-debug.log
+
+# Search for role-prefixed output
+grep "role=" hyoka-debug.log | head -20
+```
+
+### Browse Results
+
+```bash
+go run ./hyoka serve
+# Open http://localhost:8080
+```
+
+## Common Development Tasks
+
+### Adding a New Grader Type
+
+1. **Create the grader:** `hyoka/internal/graders/my_grader.go`
+2. **Implement the interface:**
+   ```go
+   type MyGrader struct { /* fields */ }
+   func (g *MyGrader) Kind() string { return "my" }
+   func (g *MyGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) { /* ... */ }
+   ```
+3. **Register in factory:** `hyoka/internal/graders/registry.go`
+4. **Write tests:** `hyoka/internal/graders/my_grader_test.go`
+5. **Update config examples:** `configs/*.yaml`
+
+### Adding a New CLI Command
+
+1. **Create command file:** `hyoka/cmd/mycommand.go`
+2. **Implement Cobra command:**
+   ```go
+   var myCmd = &cobra.Command{
+       Use: "mycommand",
+       RunE: func(cmd *cobra.Command, args []string) error { /* ... */ },
+   }
+   func init() { rootCmd.AddCommand(myCmd) }
+   ```
+3. **Document in help text**
+4. **Write tests:** `hyoka/cmd/mycommand_test.go`
+
+### Updating Documentation
+
+- **Architecture docs:** `docs/architecture.md`
+- **CLI reference:** `docs/cli-reference.md`
+- **Contributing guide:** `docs/contributing.md`
+- **README:** `hyoka/README.md`
+
+## Code Review Process
+
+1. **Submit PR** with `Closes #{issue}` in description
+2. **Address review comments** in follow-up commits
+3. **Ensure tests pass** (CI runs on PR)
+4. **Squash if requested** for history cleanliness
+5. **Merge to dev** (maintainer handles merge)
+
+## Release Workflow
+
+(Handled by maintainers)
+
+1. Tag release on `main` branch
+2. Create GitHub Release with changelog
+3. Upload binary artifacts
+
+## Resources
+
+- **Go stdlib docs:** https://pkg.go.dev/std
+- **Cobra docs:** https://cobra.dev
+- **slog guide:** https://pkg.go.dev/log/slog
+- **GitHub Copilot CLI docs:** https://github.com/cli/cli/wiki/GitHub-Copilot-CLI
+
+## Anti-Patterns
+
+- Working directly on `main` branch (use feature branches)
+- Committing without running `go test -race`
+- Leaving orphaned Copilot sessions (always run `hyoka clean`)
+- Skipping tests to speed up iteration (tests catch regressions)
+- Hardcoding paths or config names in code

--- a/skills/hyoka/copilot-sdk-integration/SKILL.md
+++ b/skills/hyoka/copilot-sdk-integration/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: "copilot-sdk-integration"
+description: "How hyoka uses the Copilot SDK"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/copilot.go"
+---
+
+## Context
+
+Hyoka integrates with the Copilot SDK to launch agent sessions (both for code generation and code review). The SDK provides session lifecycle management, tool invocation, and action history capture.
+
+## Session Lifecycle
+
+### Creation
+```go
+sess, err := SDK.NewSession(ctx, &SessionOptions{
+    Model: "claude-opus-4.6",
+    SystemPrompt: "You are an Azure SDK code generator...",
+    Tools: toolSet,
+    Skills: skillPaths,
+    MCPServers: mcpConfigs,
+    MaxTurns: 25,
+    MaxFiles: 50,
+    MaxOutputSize: 1MB,
+})
+```
+
+### Agent Turn Loop
+```go
+// Send initial prompt
+resp, err := sess.SendMessage(ctx, prompt)
+
+// Agent responds with actions (tool calls, file operations, etc)
+for action := range resp.Actions {
+    // Hyoka captures action metadata for timeline
+    timeline.Append(action)
+    
+    // Let SDK handle tool execution
+    result, err := sess.ExecuteAction(ctx, action)
+}
+
+// Repeat until agent stops or max turns reached
+```
+
+### Cleanup
+```go
+sess.Close()  // Kills Copilot process, cleans workspace
+```
+
+## Action Capture
+
+The SDK returns **SessionEventRecord** for each agent action:
+- Type: `tool_call`, `tool_result`, `file_read`, `file_write`, `bash_command`
+- Tool name, arguments, output
+- Duration, success/failure status
+- Turn number
+
+Hyoka maps these into **ActionEvent** for graders and reports.
+
+## Skills Integration
+
+Skills are **SKILL.md files** injected into the SDK session. They provide domain knowledge (e.g., Azure SDK patterns, Python conventions) without needing direct prompt modification.
+
+```yaml
+generator:
+  skills:
+    - type: local
+      path: ./skills/generator/**/*.md
+```
+
+The SDK concatenates skills into the system prompt at session creation.
+
+## MCP Server Integration
+
+MCP (Model Context Protocol) servers extend tool availability beyond built-in SDK tools.
+
+```yaml
+generator:
+  mcp_servers:
+    azure-cli:
+      type: command
+      command: /usr/bin/az
+      args: ["mcp", "run"]
+      tools: ["azure_resource_list"]
+```
+
+The SDK spawns the MCP server process and routes tool calls to it.
+
+## Timeout and Resource Monitoring
+
+- **Session timeout:** If agent doesn't respond within `--gen-timeout` (default 600s), SDK terminates
+- **Resource monitoring:** Optional per-config (via `--monitor-resources`), tracks CPU/memory per session
+- **Process tracking:** Hyoka tracks child PIDs for cleanup on interruption
+
+## Tool Result Feedback Loop
+
+After each tool execution:
+1. SDK captures result (stdout, stderr, exit code)
+2. Hyoka records in action timeline
+3. Result fed back to agent in next turn
+4. Agent continues or stops
+
+## Error Handling
+
+- **Tool not found:** Agent sees error, can adjust
+- **Tool timeout:** Reported to agent, can retry
+- **SDK session crash:** Entire eval marked as failed, workspace preserved for debugging
+
+## Code Locations
+
+- **Copilot SDK session management:** `hyoka/internal/eval/copilot.go`
+- **Action capture and timeline:** `hyoka/internal/eval/action.go`
+- **Engine integration:** `hyoka/internal/eval/engine.go` (orchestrates SDK calls)
+
+## Anti-Patterns
+
+- Modifying agent response mid-turn (let SDK handle tool execution)
+- Killing process without calling `sess.Close()` (orphans may remain)
+- Assuming all tools are available (check config tool filters)
+- Not capturing action timeline (required for graders and debugging)

--- a/skills/hyoka/error-handling/SKILL.md
+++ b/skills/hyoka/error-handling/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "error-handling"
+description: "Return errors up, no log-and-return, %w wrapping"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/eval/engine.go, hyoka/internal/config/config.go patterns"
+---
+
+## Context
+
+Hyoka follows Go's idiomatic error handling pattern: errors bubble up the call stack, and are logged at the top level (in CLI commands). This separation of concerns makes the codebase testable and keeps error flows explicit.
+
+## Patterns
+
+### Return Errors Up (No Log-and-Return)
+
+**✓ Correct:**
+```go
+// In internal function
+func loadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config: %w", err)  // Wrap and return
+    }
+    // ...
+}
+
+// In CLI command (top level)
+func Execute() error {
+    cfg, err := loadConfig(cfgPath)
+    if err != nil {
+        slog.Error("Failed to load config", "error", err)  // Log once at top
+        return err
+    }
+    // ...
+}
+```
+
+**✗ Incorrect:**
+```go
+// Internal function logs AND returns
+func loadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        slog.Error("Failed to read config", "error", err)  // Wrong: logging here
+        return nil, err
+    }
+}
+```
+
+### Error Wrapping with `%w`
+
+Always wrap lower-level errors with `%w` to preserve the error chain. This enables `errors.Is()` and `errors.As()` in caller code.
+
+**✓ Correct:**
+```go
+if err != nil {
+    return fmt.Errorf("failed to build project: %w", err)
+}
+
+// Caller can inspect the chain
+if errors.Is(err, os.ErrNotExist) {
+    // Handle missing file
+}
+```
+
+**✗ Incorrect:**
+```go
+if err != nil {
+    return fmt.Errorf("failed to build project: %v", err)  // Loses error chain
+}
+```
+
+### Context in Error Messages
+
+Provide actionable context at the point where error is wrapped, not repeated at logging.
+
+**✓ Correct:**
+```go
+// In eval engine
+if err := runGrader(ctx, grader); err != nil {
+    return fmt.Errorf("grade with %q: %w", grader.Name(), err)
+}
+
+// In CLI command
+if err != nil {
+    slog.Error("Evaluation failed", "error", err)  // Message says what failed, details in error chain
+}
+```
+
+## Anti-Patterns
+
+- Logging at multiple levels (log once at top-level CLI)
+- Using `%v` instead of `%w` for error wrapping
+- Ignoring errors silently with `_ = someFunc()`
+- Returning `nil` error when error occurred
+- Logging and then returning without wrapping
+
+## Related Code Locations
+
+- **Error wrapping examples:** `hyoka/internal/eval/engine.go`
+- **CLI error handling:** `hyoka/cmd/*.go`
+- **Logging configuration:** `hyoka/internal/logging/`

--- a/skills/hyoka/eval-pipeline/SKILL.md
+++ b/skills/hyoka/eval-pipeline/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: "eval-pipeline"
+description: "How the eval engine works: generate → grade → report"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/engine.go, architecture.md"
+---
+
+## Context
+
+The evaluation pipeline is the core workflow of hyoka. It orchestrates AI agent code generation, multi-model grading, and report generation. Understanding the pipeline is essential for debugging eval failures and extending the engine.
+
+## Pipeline Phases
+
+### 1. Generation Phase
+- **Input:** Prompt (with service, language, plane metadata)
+- **Process:** 
+  - Creates a workspace (temporary directory)
+  - Launches Copilot SDK session with generator model
+  - Injects skills and MCP servers from config
+  - Runs max 25 turns (configurable via `--max-session-actions`)
+  - Captures all tool calls, file reads/writes, and stdout
+- **Output:** Generated code + action timeline
+
+### 2. Build Verification Phase (optional)
+- **Input:** Generated code
+- **Process:**
+  - Runs language-specific build command (e.g., `cargo build` for Rust)
+  - Collects stderr/stdout for report
+  - Marks success/failure
+- **Output:** Build status + logs
+
+### 3. Grading Phase
+- **Input:** Generated code + action timeline + config
+- **Process:**
+  - Runs 6 pluggable grader types independently
+  - Each grader inspects code/timeline and scores against criteria
+  - Collects all grader results
+- **Output:** Grader scores (pass/fail + numeric score per grader)
+
+### 4. Review Panel Phase
+- **Input:** Generated code + build status
+- **Process:**
+  - Launches N reviewer sessions (one per reviewer model in config)
+  - Sends code + rubric to each reviewer independently
+  - Each reviewer scores against semantic criteria (e.g., "Handles errors correctly")
+  - Consolidator model merges individual reviews → consensus score
+- **Output:** Panel scores + individual reviewer insights
+
+### 5. Report Generation Phase
+- **Input:** All phase outputs + metadata
+- **Process:**
+  - Renders JSON report with full timeline
+  - Renders HTML/Markdown from JSON
+  - Saves to `reports/{run_id}/`
+- **Output:** Multi-format reports
+
+## Key Patterns
+
+**Workspace Isolation:**
+- Each eval run gets its own temp directory (`/tmp/hyoka-{run_id}`)
+- Ensures no state leakage between runs
+
+**Action Timeline Capture:**
+- Every tool call, file operation, bash command is recorded with duration
+- Used by graders to verify required/forbidden tool usage
+- Enables post-hoc analysis of agent behavior
+
+**Async/Parallel Processing:**
+- Multiple prompts can run in parallel (via `--workers` flag)
+- Generator and review phases are sequential per prompt (generation must complete before review)
+
+**Error Handling:**
+- Generation timeout → captured as error in report, review skipped
+- Build failure → reported but review proceeds
+- Grader timeout → grader marked as timeout, engine continues
+- Single reviewer timeout → other reviewers still score
+
+## Code Locations
+
+- **Engine orchestration:** `hyoka/internal/eval/engine.go`
+- **Copilot session management:** `hyoka/internal/eval/copilot.go`
+- **Action timeline:** `hyoka/internal/eval/action.go`
+- **Workspace creation:** `hyoka/internal/eval/workspace.go`
+- **Process tracking:** `hyoka/internal/eval/proctracker.go`
+
+## Anti-Patterns
+
+- Don't call `log.Fatal` in pipeline steps — return errors
+- Don't skip phases silently; report skipped phases in output
+- Don't assume workspace directory persists after eval (it's cleaned up)
+- Don't hardcode turn/file/output limits in engine (use SessionLimits)

--- a/skills/hyoka/grader-system/SKILL.md
+++ b/skills/hyoka/grader-system/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: "grader-system"
+description: "Pluggable grader architecture (6 types, gate semantics)"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/graders/grader.go, hyoka/internal/graders/registry.go"
+---
+
+## Context
+
+Hyoka's grading system is pluggable and multi-layered. Six independent grader types inspect generated code and action timelines from different angles, then consolidate into a holistic assessment. Graders are **advisory** — they report findings, they don't gate evaluation completion.
+
+## Grader Architecture
+
+All graders implement:
+```go
+type Grader interface {
+    Kind() string
+    Name() string
+    Grade(ctx context.Context, input GraderInput) (GraderResult, error)
+}
+```
+
+### GraderInput
+```go
+type GraderInput struct {
+    Code           string          // Generated code
+    Language       string          // e.g., "python"
+    ActionLog      []ActionEvent   // Timeline of agent actions
+    BuildStatus    string          // "success", "failed", "skipped"
+    BuildOutput    string          // Compiler/interpreter output
+}
+```
+
+### GraderResult
+```go
+type GraderResult struct {
+    Kind    string                  // e.g., "behavior", "lint"
+    Name    string                  // Grader instance name
+    Pass    bool                    // Critical gate (true = safe to deploy)
+    Score   float64                 // 0.0-1.0 numeric score
+    Message string                  // Human-readable summary
+    Details interface{}             // Type-specific details
+}
+```
+
+## Six Grader Types
+
+### 1. Behavior Grader
+Inspects action timeline for required/forbidden tool usage and turn limits.
+
+```yaml
+graders:
+  - kind: behavior
+    name: tool_compliance
+    required_tools: [file_write, read_file]
+    forbidden_tools: [rm, sudo]
+    max_turns: 25
+```
+
+**Details:** `BehaviorGraderDetails` with ToolsUsed, MaxTurns, Violations
+
+### 2. Lint Grader
+Runs language-specific linters on generated code.
+
+```yaml
+graders:
+  - kind: lint
+    name: python_lint
+    linters: [pylint, black, mypy]
+    threshold: 0.8  # Must pass 80% of linters
+```
+
+**Details:** `LintGraderDetails` with per-linter pass/fail, warnings
+
+### 3. Build Grader
+Verifies code builds (or interprets) without errors.
+
+```yaml
+graders:
+  - kind: build
+    name: cargo_build
+```
+
+**Details:** `BuildGraderDetails` with exit code, stderr excerpt
+
+### 4. File Grader
+Checks generated file structure (count, naming, organization).
+
+```yaml
+graders:
+  - kind: file
+    name: file_structure
+    min_files: 2
+    max_files: 50
+    required_files: [main.py, tests.py]
+```
+
+**Details:** `FileGraderDetails` with file list, violations
+
+### 5. Program Grader
+Runs generated code and checks output against expected results.
+
+```yaml
+graders:
+  - kind: program
+    name: integration_test
+    test_command: python tests.py
+    expected_output: "All tests passed"
+```
+
+**Details:** `ProgramGraderDetails` with actual vs. expected output
+
+### 6. Prompt Grader
+Uses an LLM to score code against semantic criteria (a.k.a. "LLM-as-judge").
+
+```yaml
+graders:
+  - kind: prompt
+    name: semantic_correctness
+    rubric: "Does the code correctly implement the requested feature?"
+    model: claude-opus-4.6
+```
+
+**Details:** `PromptGraderDetails` with rubric reasoning, score breakdown
+
+## Gate Semantics
+
+**Soft gates (reporting):**
+- Graders run independently in parallel
+- Timeout on one grader doesn't block others
+- Failure on one grader doesn't prevent report generation
+
+**Hard gates (evaluation completion):**
+- If generation or review phases **hard-fail** (e.g., timeout, SDK crash), eval stops
+- Grader failures do NOT stop evaluation (graders are advisory)
+
+## Pluggable Registry
+
+Graders are registered via factory functions:
+
+```go
+type GraderFactory func(name string, cfg map[string]any) (Grader, error)
+
+var registry = map[string]GraderFactory{
+    "behavior": NewBehaviorGrader,
+    "lint":     NewLintGrader,
+    "build":    NewBuildGrader,
+    "file":     NewFileGrader,
+    "program":  NewProgramGrader,
+    "prompt":   NewPromptGrader,
+}
+
+// New grader types can be added by updating registry
+```
+
+## Configuration
+
+Graders are defined in config YAML:
+
+```yaml
+graders:
+  - kind: behavior
+    name: required_tools
+    required_tools: [file_write, bash]
+  
+  - kind: lint
+    name: python_style
+    linters: [pylint]
+    threshold: 0.9
+
+  - kind: prompt
+    name: correctness
+    model: gpt-5.4
+```
+
+## Error Handling
+
+Each grader catches its own errors:
+
+```go
+func (g *LintGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) {
+    // Run linter
+    cmd := exec.CommandContext(ctx, "pylint", ...)
+    
+    // Timeout?
+    if ctx.Err() != nil {
+        return GraderResult{
+            Pass: false,
+            Message: "Linter timeout",
+        }, nil  // Return error object, not error value
+    }
+}
+```
+
+Grader errors are **not** fatal — they're reported in the grader result.
+
+## Code Locations
+
+- **Grader interface and registry:** `hyoka/internal/graders/grader.go`
+- **Individual grader implementations:** `hyoka/internal/graders/{kind}_grader.go`
+- **Example grader tests:** `hyoka/internal/graders/*_test.go`
+
+## Anti-Patterns
+
+- Using grader failures as eval blockers (they're advisory only)
+- Hardcoding grader lists in engine (add via config)
+- Ignoring grader timeout errors (report them)
+- Assuming all graders finish synchronously (they may timeout)

--- a/skills/hyoka/logging-conventions/SKILL.md
+++ b/skills/hyoka/logging-conventions/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: "logging-conventions"
+description: "slog usage, no third-party logging"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/logging/logging.go, all internal packages"
+---
+
+## Context
+
+Hyoka uses Go's standard `log/slog` package (available since Go 1.21). No third-party logging libraries are used. Logging follows a simple hierarchy: diagnostic logs go to slog, user-facing output goes to stdout/stderr.
+
+## slog Basics
+
+```go
+import "log/slog"
+
+// Debug: development/troubleshooting info
+slog.Debug("Session started", "session_id", sessID, "model", model)
+
+// Info: important events users might care about
+slog.Info("Evaluation complete", "prompt_id", id, "duration_s", elapsed)
+
+// Warn: recoverable issues (grader timeout, build skipped)
+slog.Warn("Grader timeout", "grader_name", name, "duration_s", 30)
+
+// Error: problems that don't stop evaluation (reviewer model unavailable)
+slog.Error("Failed to load skill", "path", p, "error", err)
+```
+
+## Initialization
+
+slog is typically initialized in `main()` or in the logging package:
+
+```go
+// main.go or logging.go
+package main
+
+import (
+    "log/slog"
+    "os"
+)
+
+func init() {
+    // Default: JSON output to stderr
+    handler := slog.NewJSONHandler(os.Stderr, nil)
+    slog.SetDefault(slog.New(handler))
+}
+```
+
+## Log Levels
+
+Control verbosity with `--log-level` flag:
+
+```bash
+go run ./hyoka run --prompt-id ... --log-level debug    # Very verbose
+go run ./hyoka run --prompt-id ... --log-level info     # Important events
+go run ./hyoka run --prompt-id ... --log-level warn     # Warnings only
+```
+
+Mapping (from least to most verbose):
+1. **ERROR** — Errors only
+2. **WARN** — Warnings + errors
+3. **INFO** — Important events + warnings + errors
+4. **DEBUG** — Development diagnostics + everything else
+
+## Structured Attributes
+
+Always use key-value pairs, not formatted strings:
+
+**✓ Correct:**
+```go
+slog.Info("Evaluation started",
+    "prompt_id", promptID,
+    "config", configName,
+    "model", model,
+)
+```
+
+**✗ Incorrect:**
+```go
+slog.Info(fmt.Sprintf("Evaluation %s with config %s using model %s",
+    promptID, configName, model))
+```
+
+Structured attributes enable filtering and aggregation in log analysis tools.
+
+## Logging Pattern: Errors
+
+Always log at the point where you can provide context:
+
+```go
+// Load config
+cfg, err := loadConfig(cfgPath)
+if err != nil {
+    // Log with context
+    slog.Error("Failed to load config",
+        "path", cfgPath,
+        "error", err,
+    )
+    return err
+}
+
+// Process config (no logging here — error means we already logged above)
+if err := processConfig(cfg); err != nil {
+    slog.Error("Failed to process config",
+        "config_name", cfg.Name,
+        "error", err,
+    )
+    return err
+}
+```
+
+## Logging Pattern: Lifecycle Events
+
+Use **Info** for important milestones:
+
+```go
+func (e *Engine) Run(ctx context.Context, prompt *Prompt, cfg *Config) (*Result, error) {
+    slog.Info("Evaluation starting",
+        "prompt_id", prompt.ID,
+        "config", cfg.Name,
+    )
+    defer func(start time.Time) {
+        duration := time.Since(start)
+        slog.Info("Evaluation complete",
+            "prompt_id", prompt.ID,
+            "duration_s", duration.Seconds(),
+        )
+    }(time.Now())
+    
+    // ... evaluation logic
+}
+```
+
+## Logging Pattern: Debug Traces
+
+Use **Debug** for developer troubleshooting:
+
+```go
+// generation phase
+slog.Debug("Copilot session created",
+    "session_id", sess.ID(),
+    "model", cfg.Generator.Model,
+)
+
+slog.Debug("Action captured",
+    "type", action.Type,
+    "tool", action.Tool,
+    "duration_ms", action.DurationMs,
+)
+
+// review phase
+slog.Debug("Review panel score",
+    "reviewer_model", model,
+    "score", score,
+)
+```
+
+## Log File Output
+
+When `--log-file` is specified, slog output is both written to the file and echoed to stderr:
+
+```bash
+go run ./hyoka run ... --log-file hyoka-debug.log
+```
+
+The file captures full debug output; users see warnings and errors in console.
+
+## slog Configuration (if needed)
+
+For custom output formatting:
+
+```go
+import (
+    "log/slog"
+    "os"
+)
+
+// Text format (instead of JSON)
+handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+    Level: slog.LevelDebug,
+})
+slog.SetDefault(slog.New(handler))
+
+// Or with pretty-printing
+handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+    Level:     slog.LevelDebug,
+    AddSource: true,  // Include file:line
+})
+```
+
+## Anti-Patterns
+
+- Logging errors AND returning them with same context (return once, log once)
+- Using `log.Printf` or `fmt.Printf` for diagnostic output (use slog)
+- Logging user output (progress, results) — write to stdout directly
+- String formatting in log arguments (use structured attributes)
+- Logging secrets or sensitive data
+- `slog.Error()` for non-critical issues (use `slog.Warn()`)
+
+## Related Code Locations
+
+- **slog setup:** `hyoka/internal/logging/logging.go`
+- **CLI log-level flag:** `hyoka/cmd/root.go`
+- **Example logging patterns:** `hyoka/internal/eval/engine.go`

--- a/skills/hyoka/process-lifecycle/SKILL.md
+++ b/skills/hyoka/process-lifecycle/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: "process-lifecycle"
+description: "Session creation, workspace isolation, cleanup"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/workspace.go, hyoka/internal/eval/copilot.go, hyoka/internal/clean/"
+---
+
+## Context
+
+Each hyoka evaluation runs in an isolated workspace with its own session. Understanding process lifecycle is critical for debugging eval failures, preventing resource leaks, and writing tests.
+
+## Workspace Lifecycle
+
+### Creation
+
+When an evaluation starts:
+
+```go
+// Create workspace directory
+ws, err := NewWorkspace(ctx, "eval-run-123")
+if err != nil {
+    return fmt.Errorf("create workspace: %w", err)
+}
+defer ws.Close()  // Cleanup deferred
+
+// Start Copilot session in workspace
+sess, err := copilot.NewSession(ctx, &SessionOptions{
+    WorkingDir: ws.Path(),
+    Model:      "claude-opus-4.6",
+    // ...
+})
+```
+
+Workspace is created as a temporary directory:
+- **Linux/Mac:** `/tmp/hyoka-{run_id}-XXXXXX`
+- **Windows:** `%TEMP%\hyoka-{run_id}-XXXXXX`
+- Contains all generated files, logs, and session metadata
+
+### Session Initialization
+
+Copilot SDK launches the agent process:
+
+```
+┌─────────────────────────────────────┐
+│ hyoka (CLI process, PID 1234)       │
+└──────────────┬──────────────────────┘
+               │
+               ├─→ Workspace: /tmp/hyoka-eval-1
+               │
+               └─→ Copilot process (PID 1235) [child]
+                   ├─→ MCP server (PID 1236) [grandchild]
+                   └─→ Tool subprocess (PID 1237) [grandchild]
+```
+
+The CLI tracks all child PIDs for cleanup on signal.
+
+### File Operations
+
+Agent writes generated code to workspace:
+
+```
+/tmp/hyoka-eval-1/
+  main.py           # Generated code
+  test_main.py      # Generated tests
+  Copilot.log       # Session log
+  action_timeline.json  # Captured actions
+```
+
+The CLI captures all file operations in the action timeline.
+
+### Cleanup Phase
+
+When evaluation completes (success or failure):
+
+```go
+// Workspace cleanup
+if err := ws.Close(); err != nil {
+    slog.Warn("Workspace cleanup failed", "path", ws.Path(), "error", err)
+}
+
+// Copilot session cleanup
+if err := sess.Close(); err != nil {
+    slog.Warn("Session cleanup failed", "error", err)
+}
+
+// Orphaned process cleanup (if signal received)
+// kill all child PIDs
+```
+
+Cleanup removes:
+- Workspace directory + all files
+- Copilot process + child processes
+- Temporary MCP servers
+
+## Process Tracking
+
+Hyoka tracks child processes to ensure cleanup on interruption:
+
+```go
+// hyoka/internal/eval/proctracker.go
+tracker := NewProcessTracker()
+
+// Register Copilot process
+tracker.Add(sess.PID())
+
+// On SIGINT, cleanup
+<-sigChan
+tracker.KillAll()  // Kills all tracked processes
+```
+
+### PID Files
+
+For long-running evaluations, PIDs are written to files:
+
+```
+reports/{run_id}/
+  pids.txt     # List of tracked PIDs
+```
+
+If eval crashes, `hyoka clean` reads these files and kills orphaned processes.
+
+## Session State
+
+### Before Generation
+```
+Created ✓
+Tools loaded ✓
+MCP servers started ✓
+Skills injected ✓
+Ready for agent ✓
+```
+
+### During Generation
+```
+Agent running...
+Tool calls executed...
+Files written...
+Actions captured...
+```
+
+### After Generation
+```
+Agent stopped ✓
+Build phase (optional)
+Review phase (if enabled)
+Workspace preserved (for debugging)
+```
+
+### Cleanup
+```
+Workspace deleted ✓
+Session closed ✓
+Processes killed ✓
+```
+
+## Workspace Isolation
+
+Each eval is isolated to prevent:
+- **State leakage:** Code from eval 1 not visible to eval 2
+- **File conflicts:** Two evals writing to same file
+- **Process conflicts:** Child processes from eval 1 interfering with eval 2
+
+This is achieved by:
+- Unique workspace directories (per run ID)
+- Separate Copilot sessions (each with own process tree)
+- Deferred cleanup (filesystem cleanup guaranteed even on panic)
+
+## Cleanup Command
+
+```bash
+go run ./hyoka clean
+```
+
+This command:
+1. Finds all abandoned sessions (workspace dirs left on disk)
+2. Reads PIDs from `reports/{run_id}/pids.txt`
+3. Kills orphaned processes
+4. Removes workspace directories
+5. Reports cleaned sessions
+
+Useful after:
+- Interrupted eval runs
+- Process crashes
+- Development/testing (always run before committing)
+
+## Session Limits
+
+Per-evaluation guardrails prevent runaway sessions:
+
+```yaml
+limits:
+  max_turns: 25                    # Max agent turns
+  max_files: 50                    # Max files created
+  max_output_size: 1048576         # Max output (1 MB)
+  max_session_actions: 50          # Max tool calls
+```
+
+When limit exceeded:
+```
+Generation phase stops → Session killed → Error reported
+```
+
+## Testing with Temporary Workspaces
+
+In tests, use stub workspaces:
+
+```go
+// Stub workspace that doesn't create disk files
+type stubWorkspace struct {
+    files map[string]string  // In-memory files
+}
+
+func (sw *stubWorkspace) WriteFile(path, content string) error {
+    sw.files[path] = content
+    return nil
+}
+```
+
+Never create real workspaces in tests (use stubs or temp directories).
+
+## Code Locations
+
+- **Workspace management:** `hyoka/internal/eval/workspace.go`
+- **Process tracking:** `hyoka/internal/eval/proctracker.go`
+- **Cleanup command:** `hyoka/cmd/clean.go`
+- **Session lifecycle:** `hyoka/internal/eval/copilot.go`
+
+## Anti-Patterns
+
+- Not deferring workspace cleanup (may leak on early return)
+- Hardcoding workspace paths (use WorkingDir option)
+- Not tracking child processes (orphans may remain)
+- Assuming workspace persists after eval (it's deleted)
+- Ignoring cleanup errors in tests (cleanup failures indicate leaks)

--- a/skills/hyoka/prompt-conventions/SKILL.md
+++ b/skills/hyoka/prompt-conventions/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: "prompt-conventions"
+description: "Prompt frontmatter format, properties, migration"
+domain: "content"
+confidence: "high"
+source: "hyoka/internal/prompt/prompt.go, prompts/*.md files"
+---
+
+## Context
+
+Hyoka prompts are Markdown files with YAML frontmatter. The frontmatter defines metadata (service, language, category, difficulty) that's used for filtering, tool selection, and grading. Prompts are organized by language/service and must follow a consistent structure.
+
+## Prompt File Structure
+
+```markdown
+---
+id: identity-dp-python-default-credential
+service: identity
+language: python
+plane: data-plane
+category: auth
+difficulty: beginner
+tags: [authentication, patterns]
+---
+
+# Prompt Title
+
+Your task is to generate Python code that uses the Azure Identity library...
+
+## Requirements
+
+- Code should handle authentication
+- Include error handling
+- Add type hints
+
+## Expected Output
+
+A Python script that demonstrates the DefaultAzureCredential pattern.
+```
+
+## Frontmatter Fields
+
+### Required Fields
+
+- **id:** Unique identifier (pattern: `{service}-{plane}-{language}-{short-name}`)
+  - Examples: `identity-dp-python-default-credential`, `key-vault-mp-dotnet-crud`
+  - Must be unique across all prompts
+  - Snake_case, lowercase
+
+- **service:** Azure service name
+  - Values: `identity`, `key-vault`, `storage`, `cosmos-db`, etc.
+  - Used for `--service` filtering
+
+- **language:** Programming language
+  - Values: `python`, `dotnet`, `java`, `js-ts`, `go`, `rust`, `cpp`
+  - Used for `--language` filtering and tool selection
+
+- **plane:** Deployment plane
+  - Values: `data-plane` or `management-plane`
+  - Used for `--plane` filtering
+
+### Optional Fields
+
+- **category:** Use-case category
+  - Examples: `auth`, `crud`, `pagination`, `streaming`
+  - Used for `--category` filtering
+
+- **difficulty:** Skill level for generated code
+  - Values: `beginner`, `intermediate`, `advanced`
+  - Informational for report context
+
+- **tags:** Additional keyword filters (array)
+  - Examples: `[authentication, error-handling, async]`
+  - Used for `--tags` filtering
+
+## File Organization
+
+Prompts are stored in `prompts/` organized by service/language:
+
+```
+prompts/
+  identity/
+    python/
+      default-credential.md
+      managed-identity.md
+    dotnet/
+      default-credential.md
+  key-vault/
+    python/
+      crud-secrets.md
+    go/
+      get-secret.md
+```
+
+## Prompt ID Naming Convention
+
+Pattern: `{service}-{plane-abbrev}-{language}-{short-name}`
+
+- **service:** Service name (identity, key-vault, storage, etc.)
+- **plane-abbrev:** `dp` (data-plane) or `mp` (management-plane)
+- **language:** `python`, `dotnet`, `java`, `js-ts`, `go`, `rust`, `cpp`
+- **short-name:** Hyphenated description (max 4 words)
+
+Examples:
+- ✓ `identity-dp-python-default-credential`
+- ✓ `key-vault-dp-dotnet-crud-secrets`
+- ✓ `storage-mp-java-list-containers`
+- ✗ `DefaultCredentialPython` (wrong case, no plane/service prefix)
+- ✗ `identity-python-auth-with-logging-and-retry` (too long)
+
+## Prompt Content Guidelines
+
+### Header
+Brief, actionable description of the task.
+
+### Requirements Section
+List concrete requirements for generated code:
+- Functionality (what should the code do?)
+- Error handling expectations
+- Language-specific conventions (e.g., type hints for Python)
+- API patterns to follow
+
+### Expected Output
+Describe the form of generated code (script vs. module, entry point, etc.)
+
+### Example (optional)
+Show a snippet of expected behavior or output format.
+
+## Properties for Tool Selection
+
+Properties in tool config filters match prompt metadata:
+
+```yaml
+# Config
+tools:
+  - name: python_test_runner
+    properties:
+      language: python    # Matches prompt.language
+      service: key-vault  # Matches prompt.service
+```
+
+Prompt metadata is compared against tool properties — tools only appear if all properties match.
+
+## Prompt Validation
+
+Validate prompts before running:
+
+```bash
+go run ./hyoka validate --prompt-id identity-dp-python-default-credential
+
+# Or validate all prompts
+go run ./hyoka validate
+```
+
+The validator checks:
+- Required frontmatter fields present
+- ID uniqueness
+- Language/service/plane values valid
+- Prompt file exists and is readable
+
+## Property Migration (Advanced)
+
+For changes to property schema or tool filtering logic:
+
+1. **Update prompt frontmatter** in batch:
+   ```bash
+   # Script to add/rename fields across all prompts
+   for f in prompts/*/*.md; do
+     # Add new field or rename existing
+     sed -i 's/old_field:/new_field:/' "$f"
+   done
+   ```
+
+2. **Update tool filters** in config:
+   ```yaml
+   # Before
+   properties:
+     lang: python
+   
+   # After (new property name)
+   properties:
+     language: python
+   ```
+
+3. **Test with dry-run:**
+   ```bash
+   go run ./hyoka run --service identity --language python --dry-run
+   ```
+
+## Listing and Filtering Prompts
+
+```bash
+# List all prompts
+go run ./hyoka list
+
+# Filter by service
+go run ./hyoka list --service key-vault
+
+# Filter by language + service
+go run ./hyoka list --service identity --language python
+
+# Filter by tags
+go run ./hyoka list --tags "auth,crud"
+```
+
+## Anti-Patterns
+
+- IDs with uppercase or special characters (use snake_case)
+- Inconsistent plane values (`data_plane` vs `data-plane`)
+- Missing required frontmatter fields
+- Prompts with same ID in different directories (validator should catch)
+- Tool properties that don't match any prompt metadata
+- Overly specific prompts (too narrow to be useful across models)
+
+## Related Code Locations
+
+- **Prompt structure:** `hyoka/internal/prompt/prompt.go`
+- **Validation logic:** `hyoka/internal/validate/validate.go`
+- **Example prompts:** `hyoka/prompts/*/`
+- **List command:** `hyoka/cmd/list.go`

--- a/skills/hyoka/property-migration/SKILL.md
+++ b/skills/hyoka/property-migration/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: "property-migration"
+description: "How properties map works, snake_case convention"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/config/tools.go, hyoka/internal/prompt/prompt.go"
+---
+
+## Context
+
+Hyoka uses property-based tool filtering to dynamically match tools to prompts based on metadata (language, service, plane). This allows a single config to work across multiple prompts without hardcoding tool lists. Property migration is the process of updating the property schema when business logic or tool definitions change.
+
+## Property System Overview
+
+### How It Works
+
+1. **Prompt declares properties:**
+   ```yaml
+   id: key-vault-dp-python-crud
+   language: python
+   service: key-vault
+   plane: data-plane
+   ```
+
+2. **Tool defines property filters:**
+   ```yaml
+   # config.yaml
+   tools:
+     - name: python_key_vault_sdk
+       include: true
+       properties:
+         language: python
+         service: key-vault
+   ```
+
+3. **Engine matches at runtime:**
+   ```
+   Does prompt.language (python) match tool.properties.language (python)? ✓
+   Does prompt.service (key-vault) match tool.properties.service (key-vault)? ✓
+   → Tool included in session
+   ```
+
+4. **No match excludes tool:**
+   ```
+   Does prompt.language (dotnet) match tool.properties.language (python)? ✗
+   → Tool hidden from session
+   ```
+
+## Property Convention: snake_case
+
+All property names and values use **snake_case** (not camelCase or kebab-case):
+
+**✓ Correct:**
+```yaml
+properties:
+  language: python            # not "Language" or "PYTHON"
+  service: key_vault          # not "keyVault" or "Key-Vault"
+  deployment_plane: data_plane  # not "deploymentPlane"
+```
+
+**✗ Incorrect:**
+```yaml
+properties:
+  Language: python            # CamelCase in key
+  language: Python            # CamelCase in value
+  service: Key-Vault          # Kebab-case
+```
+
+## Valid Property Names
+
+- **language:** Python, dotnet, java, js_ts, go, rust, cpp
+- **service:** identity, key_vault, storage, cosmos_db, app_config, etc.
+- **plane:** data_plane, management_plane
+- **category:** auth, crud, pagination, streaming, etc.
+- **difficulty:** beginner, intermediate, advanced (optional)
+
+## Migration Scenarios
+
+### Scenario 1: Adding a New Property
+
+When you want to filter tools by a new dimension:
+
+1. **Define in prompt frontmatter:**
+   ```yaml
+   # prompts/storage/python/blob-upload.md
+   tier: premium  # New property
+   ```
+
+2. **Add to tool filter (optional):**
+   ```yaml
+   # config.yaml
+   tools:
+     - name: storage_premium_tools
+       properties:
+         language: python
+         service: storage
+         tier: premium  # Now filtered
+   ```
+
+3. **Verify tool visibility:**
+   ```bash
+   go run ./hyoka run --prompt-id storage-dp-python-blob-upload --dry-run
+   # Shows: storage_premium_tools included
+   
+   go run ./hyoka run --prompt-id storage-dp-python-blob-list --dry-run
+   # Shows: storage_premium_tools NOT included (no tier=premium)
+   ```
+
+### Scenario 2: Renaming a Property
+
+If you rename `service` to `azure_service`:
+
+1. **Update all prompts** (batch script):
+   ```bash
+   for f in prompts/**/*.md; do
+     sed -i 's/^service:/azure_service:/' "$f"
+   done
+   ```
+
+2. **Update all configs:**
+   ```yaml
+   # Before
+   properties:
+     service: key_vault
+   
+   # After
+   properties:
+     azure_service: key_vault
+   ```
+
+3. **Validate no orphaned properties:**
+   ```bash
+   grep -r "service:" prompts/  # Should be empty (all renamed)
+   grep -r "service:" configs/  # Should be empty
+   ```
+
+### Scenario 3: Changing Property Values
+
+If `plane` values change from `data-plane` to `data_plane`:
+
+1. **Update all prompts:**
+   ```bash
+   for f in prompts/**/*.md; do
+     sed -i 's/plane: data-plane/plane: data_plane/' "$f"
+     sed -i 's/plane: management-plane/plane: management_plane/' "$f"
+   done
+   ```
+
+2. **Update all configs:**
+   ```yaml
+   # Before
+   properties:
+     plane: data-plane
+   
+   # After
+   properties:
+     plane: data_plane
+   ```
+
+3. **Test property matching:**
+   ```bash
+   go run ./hyoka list --plane data_plane
+   # Verify correct prompts listed
+   ```
+
+## Property Matching Logic
+
+```go
+// hyoka/internal/config/tools.go
+func matchesProperties(prompt *Prompt, toolProps map[string]string) bool {
+    for key, expectedValue := range toolProps {
+        actualValue := prompt.GetProperty(key)
+        if actualValue != expectedValue {
+            return false  // Property mismatch → tool not included
+        }
+    }
+    return true  // All properties match → tool included
+}
+```
+
+## Best Practices
+
+1. **Use properties consistently:** If a property exists, use it in ALL relevant places (prompts + tools)
+2. **Document property semantics:** List valid values in architecture docs or code comments
+3. **Test after migration:** Run `go run ./hyoka list` to verify filtering still works
+4. **Batch migrations:** Update prompts and configs in the same commit
+5. **Avoid redundant properties:** Don't encode info that's already in prompt ID
+
+## Testing Property Matches
+
+Create a test to verify property matching:
+
+```go
+func TestPropertyMatching(t *testing.T) {
+    tests := []struct {
+        prompt   *Prompt
+        toolProp map[string]string
+        expect   bool
+    }{
+        {
+            prompt: &Prompt{Language: "python", Service: "key_vault"},
+            toolProp: map[string]string{
+                "language": "python",
+                "service": "key_vault",
+            },
+            expect: true,
+        },
+        {
+            prompt: &Prompt{Language: "dotnet", Service: "key_vault"},
+            toolProp: map[string]string{
+                "language": "python",  // Mismatch
+                "service": "key_vault",
+            },
+            expect: false,
+        },
+    }
+    
+    for _, tt := range tests {
+        if matchesProperties(tt.prompt, tt.toolProp) != tt.expect {
+            t.Fail()
+        }
+    }
+}
+```
+
+## Code Locations
+
+- **Property matching logic:** `hyoka/internal/config/tools.go`
+- **Prompt property parsing:** `hyoka/internal/prompt/prompt.go`
+- **Tool configuration:** `hyoka/internal/config/config.go`
+- **Example prompts:** `hyoka/prompts/**/*.md`
+
+## Anti-Patterns
+
+- Using camelCase or kebab-case for property names (use snake_case)
+- Hardcoding tool names instead of using property filters
+- Property values that don't match prompt metadata
+- Leaving orphaned properties in configs after migration
+- Not testing property matching after schema changes

--- a/skills/hyoka/report-generation/SKILL.md
+++ b/skills/hyoka/report-generation/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: "report-generation"
+description: "JSON/HTML/Markdown reports, template system"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/report/*.go"
+---
+
+## Context
+
+Hyoka generates multi-format evaluation reports (JSON, HTML, Markdown) from a unified internal representation. Reports capture the entire evaluation timeline: generation, build, grading, and review phases.
+
+## Report Formats
+
+### JSON Report
+
+The canonical format — contains all raw data and is used to generate other formats:
+
+```json
+{
+  "metadata": {
+    "run_id": "eval-2024-04-06-123456",
+    "timestamp": "2024-04-06T12:34:56Z",
+    "prompt": {
+      "id": "identity-dp-python-default-credential",
+      "service": "identity",
+      "language": "python"
+    },
+    "config": {
+      "name": "baseline/claude-opus-4.6"
+    }
+  },
+  "generation": {
+    "status": "success",
+    "duration_ms": 45000,
+    "code": "# Generated Python code...",
+    "action_timeline": {
+      "events": [...],
+      "summary": {...}
+    }
+  },
+  "build": {
+    "status": "success",
+    "duration_ms": 5000,
+    "stdout": "Compilation successful",
+    "stderr": ""
+  },
+  "graders": [
+    {
+      "kind": "behavior",
+      "name": "tool_compliance",
+      "pass": true,
+      "score": 1.0,
+      "message": "All required tools used"
+    }
+  ],
+  "review": {
+    "status": "success",
+    "reviewers": [
+      {
+        "model": "claude-opus-4.6",
+        "score": 0.9,
+        "findings": "Code is mostly correct..."
+      }
+    ],
+    "consensus_score": 0.85
+  }
+}
+```
+
+### HTML Report
+
+Browser-viewable report with interactive elements:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Evaluation Report: identity-dp-python</title>
+  <style>...</style>
+</head>
+<body>
+  <div class="report-container">
+    <h1>Evaluation Report</h1>
+    <section class="generation">
+      <h2>Generation Phase</h2>
+      <code>{{ .Code }}</code>
+      <div class="timeline">...</div>
+    </section>
+    <section class="graders">
+      <h2>Grading Results</h2>
+      ...
+    </section>
+  </div>
+  <script>
+    // Interactive features (expand/collapse, filtering)
+  </script>
+</body>
+</html>
+```
+
+### Markdown Report
+
+Human-readable text format for documentation and sharing:
+
+```markdown
+# Evaluation Report: identity-dp-python
+
+## Generation
+- Status: Success
+- Duration: 45s
+
+## Code
+\`\`\`python
+# Generated code...
+\`\`\`
+
+## Graders
+| Grader | Status | Score | Message |
+|--------|--------|-------|---------|
+| behavior | Pass | 1.0 | All required tools used |
+| lint | Pass | 0.95 | 1 warning |
+
+## Review Panel
+- Claude Opus 4.6: 0.9
+- GPT-5.4: 0.85
+- Consensus: 0.875
+```
+
+## Report Generation Pipeline
+
+1. **Evaluation Completion:** Engine returns `EvaluationResult` with all phase outputs
+2. **JSON Marshaling:** Convert result to JSON bytes
+3. **File Write:** Save JSON to `reports/{run_id}/report.json`
+4. **Template Rendering:** Apply HTML/Markdown templates to JSON
+5. **Asset Linking:** Copy static assets (CSS, JS) to report directory
+
+## Template System
+
+Reports use Go's `text/template` package:
+
+```go
+// report.go
+type ReportTemplate struct {
+    HTML      *template.Template
+    Markdown  *template.Template
+}
+
+func (rt *ReportTemplate) RenderHTML(data EvaluationResult) (string, error) {
+    var buf bytes.Buffer
+    if err := rt.HTML.Execute(&buf, data); err != nil {
+        return "", err
+    }
+    return buf.String(), nil
+}
+```
+
+### Template Variables
+
+Templates can access all fields from `EvaluationResult`:
+
+```handlebars
+{{- .Metadata.RunID }}
+{{- .Generation.Status }}
+{{- range .Graders }}
+  {{- .Kind }}: {{- .Score }}
+{{- end }}
+```
+
+## Report Storage
+
+Reports are written to:
+```
+reports/
+  {run_id}/
+    report.json           # Canonical data
+    report.html           # Browser view
+    report.md             # Text format
+    assets/
+      style.css
+      script.js
+```
+
+## Multi-Report Aggregation
+
+For batch runs (multiple prompts × configs):
+
+```json
+{
+  "batch_metadata": {
+    "run_date": "2024-04-06",
+    "prompts": 5,
+    "configs": 2,
+    "total_evals": 10
+  },
+  "summary": {
+    "avg_score": 0.82,
+    "pass_count": 8,
+    "fail_count": 2
+  },
+  "reports": [
+    { "prompt_id": "...", "config": "...", "result": {...} }
+  ]
+}
+```
+
+## Re-rendering from JSON
+
+The `rerender` command regenerates HTML/Markdown from saved JSON:
+
+```bash
+go run ./hyoka rerender --report-id eval-2024-04-06-123456 --format html
+```
+
+This allows updating templates without re-running evaluations.
+
+## Code Locations
+
+- **Report structure:** `hyoka/internal/report/report.go`
+- **JSON marshaling:** `hyoka/internal/report/json.go`
+- **HTML/Markdown rendering:** `hyoka/internal/report/render.go`
+- **Templates:** `hyoka/templates/`
+
+## Anti-Patterns
+
+- Hardcoding paths in templates (use config for asset paths)
+- Not including action timeline in JSON (required for reproducibility)
+- Rendering HTML/Markdown before generation completes (wait for all phases)
+- Losing build/grader details in summary format (preserve full data in JSON)
+- Assuming report directory exists (create it before writing)

--- a/skills/hyoka/serve-patterns/SKILL.md
+++ b/skills/hyoka/serve-patterns/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: "serve-patterns"
+description: "API endpoints, SPA dashboard, path traversal protection"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/serve/serve.go"
+---
+
+## Context
+
+The `hyoka serve` command launches a local web server for browsing evaluation reports. The server provides RESTful endpoints for retrieving reports and serves a single-page application (SPA) dashboard. Security focuses on path traversal protection and sandboxing report access.
+
+## Server Architecture
+
+```
+┌─────────────────────┐
+│  SPA Dashboard      │
+│  (React/JS)         │
+└──────────┬──────────┘
+           │ HTTP requests
+           ↓
+┌─────────────────────────────────────┐
+│  REST API (hyoka serve)             │
+│  :8080                              │
+│  ├─ GET /api/reports                │
+│  ├─ GET /api/reports/{id}           │
+│  ├─ GET /api/reports/{id}/json      │
+│  └─ GET /static/*                   │
+└──────────┬──────────────────────────┘
+           │
+           ↓
+      reports/
+      ├─ {run_id1}/
+      │  ├─ report.json
+      │  └─ report.html
+      └─ {run_id2}/
+         ├─ report.json
+         └─ report.html
+```
+
+## API Endpoints
+
+### List Reports
+```
+GET /api/reports
+
+Response:
+{
+  "reports": [
+    {
+      "id": "eval-2024-04-06-123456",
+      "prompt": "identity-dp-python-default-credential",
+      "config": "baseline/claude-opus-4.6",
+      "timestamp": "2024-04-06T12:34:56Z",
+      "status": "success"
+    }
+  ]
+}
+```
+
+### Get Report Metadata
+```
+GET /api/reports/{id}
+
+Response:
+{
+  "id": "eval-2024-04-06-123456",
+  "prompt": {...},
+  "config": {...},
+  "generation": { "status": "success", "duration_ms": 45000 },
+  "build": { "status": "success" },
+  "graders": [...],
+  "review": {...}
+}
+```
+
+### Get Full Report JSON
+```
+GET /api/reports/{id}/json
+
+Response:
+(Full report.json from disk)
+```
+
+### Serve Static Files
+```
+GET /static/{path}
+
+Serves from reports/{id}/assets/ with path traversal protection
+```
+
+## Path Traversal Protection
+
+Critical security feature: prevent access to files outside `reports/` directory.
+
+**Vulnerable pattern:**
+```go
+// ✗ WRONG: Directly concatenates user input
+filePath := filepath.Join(reportDir, userInput)
+// If userInput = "../../etc/passwd", could read arbitrary files!
+```
+
+**Safe pattern:**
+```go
+// ✓ CORRECT: Validate path is within sandbox
+filePath := filepath.Join(reportDir, filepath.Clean(userInput))
+if !strings.HasPrefix(filePath, reportDir) {
+    return fmt.Errorf("path traversal attempt")
+}
+// Read file safely
+```
+
+### Implementation
+
+```go
+// hyoka/internal/serve/serve.go
+func (s *Server) serveReport(w http.ResponseWriter, r *http.Request) {
+    reportID := chi.URLParam(r, "id")
+    
+    // Validate report ID format
+    if !isValidRunID(reportID) {
+        http.Error(w, "Invalid report ID", http.StatusBadRequest)
+        return
+    }
+    
+    // Construct safe path
+    reportPath := filepath.Join(s.reportDir, reportID, "report.json")
+    
+    // Verify path is within sandbox
+    absReportPath, _ := filepath.Abs(reportPath)
+    absSandbox, _ := filepath.Abs(s.reportDir)
+    if !strings.HasPrefix(absReportPath, absSandbox) {
+        http.Error(w, "Forbidden", http.StatusForbidden)
+        return
+    }
+    
+    // Read and serve
+    data, err := os.ReadFile(reportPath)
+    // ...
+}
+```
+
+## Routing
+
+Use a router (e.g., chi) for clean, type-safe route handling:
+
+```go
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) setupRoutes() *chi.Mux {
+    r := chi.NewRouter()
+    
+    // API routes
+    r.Get("/api/reports", s.listReports)
+    r.Get("/api/reports/{id}", s.getReport)
+    r.Get("/api/reports/{id}/json", s.getReportJSON)
+    
+    // Static files (SPA assets)
+    r.Get("/static/*", s.serveStatic)
+    
+    // SPA fallback (serve index.html for unmatched routes)
+    r.NotFound(s.serveSPA)
+    
+    return r
+}
+```
+
+## SPA (Single-Page Application) Serving
+
+The dashboard is a static SPA (HTML + JS) that:
+1. Loads list of reports via `/api/reports`
+2. Fetches detailed report via `/api/reports/{id}`
+3. Renders interactive UI in browser
+
+```go
+// Serve index.html for all non-API routes
+func (s *Server) serveSPA(w http.ResponseWriter, r *http.Request) {
+    if r.RequestURI == "/" {
+        // Home page
+        http.ServeFile(w, r, filepath.Join(s.staticDir, "index.html"))
+        return
+    }
+    
+    // Route not found
+    http.NotFound(w, r)
+}
+```
+
+## CORS (Cross-Origin Resource Sharing)
+
+If SPA is on different domain than API:
+
+```go
+func (s *Server) setupCORS() func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Access-Control-Allow-Origin", "*")
+            w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+            w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+            next.ServeHTTP(w, r)
+        })
+    }
+}
+```
+
+## Error Handling
+
+```go
+func (s *Server) getReport(w http.ResponseWriter, r *http.Request) {
+    reportID := chi.URLParam(r, "id")
+    
+    // Validate ID
+    if reportID == "" {
+        http.Error(w, "Report ID required", http.StatusBadRequest)
+        return
+    }
+    
+    // Read report
+    data, err := s.readReport(reportID)
+    if err != nil {
+        if os.IsNotExist(err) {
+            http.Error(w, "Report not found", http.StatusNotFound)
+            return
+        }
+        http.Error(w, "Internal server error", http.StatusInternalServerError)
+        slog.Error("Failed to read report", "id", reportID, "error", err)
+        return
+    }
+    
+    // Serve
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(data)
+}
+```
+
+## Server Startup
+
+```bash
+# Default (localhost:8080)
+go run ./hyoka serve
+
+# Custom port
+go run ./hyoka serve --port 9000
+
+# Custom report directory
+go run ./hyoka serve --report-dir ./my-reports
+```
+
+Implementation:
+
+```go
+var serveCmd = &cobra.Command{
+    Use:   "serve",
+    Short: "Start local web server for browsing reports",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        port, _ := cmd.Flags().GetInt("port")
+        reportDir, _ := cmd.Flags().GetString("report-dir")
+        
+        server, err := NewServer(reportDir, port)
+        if err != nil {
+            return err
+        }
+        
+        slog.Info("Server starting", "url", fmt.Sprintf("http://localhost:%d", port))
+        return server.Start()
+    },
+}
+```
+
+## Testing
+
+```go
+func TestPathTraversal(t *testing.T) {
+    server := NewServer("./reports", 8080)
+    
+    tests := []struct {
+        reportID string
+        expect   int  // HTTP status
+    }{
+        {"eval-valid-123", 200},
+        {"../../etc/passwd", 400},  // Bad format
+        {"./../secret", 400},       // Path traversal attempt
+    }
+    
+    for _, tt := range tests {
+        req := httptest.NewRequest("GET", fmt.Sprintf("/api/reports/%s", tt.reportID), nil)
+        w := httptest.NewRecorder()
+        server.getReport(w, req)
+        
+        if w.Code != tt.expect {
+            t.Errorf("reportID %q: expected %d, got %d", tt.reportID, tt.expect, w.Code)
+        }
+    }
+}
+```
+
+## Code Locations
+
+- **Server implementation:** `hyoka/internal/serve/serve.go`
+- **API handlers:** `hyoka/internal/serve/handlers.go` (if split)
+- **Serve command:** `hyoka/cmd/serve.go`
+- **Static assets:** `hyoka/site/` or `hyoka/templates/`
+
+## Anti-Patterns
+
+- Not validating report IDs (enables directory traversal)
+- Serving files outside `reports/` directory
+- Not escaping HTML in JSON responses (XSS risk)
+- Hardcoding port in code (use flags)
+- Not logging API errors (makes debugging hard)
+- Assuming localhost is secure (anyone with network access can reach port 8080)

--- a/skills/hyoka/testing-patterns/SKILL.md
+++ b/skills/hyoka/testing-patterns/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "testing-patterns"
+description: "Table-driven tests, -race flag, stub patterns"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/*_test.go files"
+---
+
+## Context
+
+Hyoka test suite follows Go idioms: table-driven tests for comprehensive coverage, `-race` flag for detecting concurrency issues, and stub patterns for mocking external dependencies (Copilot SDK, file system).
+
+## Table-Driven Tests
+
+Use table-driven tests to test multiple scenarios with the same logic:
+
+**✓ Correct:**
+```go
+func TestBehaviorGrader_ConstraintValidation(t *testing.T) {
+    tests := []struct {
+        name      string
+        config    map[string]any
+        actionLog []ActionEvent
+        expect    bool
+        wantErr   string
+    }{
+        {
+            name: "required tools present",
+            config: map[string]any{
+                "required_tools": []any{"read_file", "edit_file"},
+            },
+            actionLog: []ActionEvent{
+                {Tool: "read_file", TurnNumber: 1},
+                {Tool: "edit_file", TurnNumber: 2},
+            },
+            expect: true,
+        },
+        {
+            name: "required tool missing",
+            config: map[string]any{
+                "required_tools": []any{"read_file"},
+            },
+            actionLog: []ActionEvent{
+                {Tool: "bash", TurnNumber: 1},
+            },
+            expect: false,
+            wantErr: "required tool not found",
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            g, _ := NewBehaviorGrader("test", tt.config)
+            result, err := g.Grade(context.Background(), GraderInput{
+                ActionLog: tt.actionLog,
+            })
+            if (err != nil) != (tt.wantErr != "") {
+                t.Fatalf("unexpected error: %v", err)
+            }
+            if result.Pass != tt.expect {
+                t.Errorf("expected Pass=%v, got %v", tt.expect, result.Pass)
+            }
+        })
+    }
+}
+```
+
+## Race Condition Detection
+
+Always run tests with `-race` flag:
+
+```bash
+go test -race ./hyoka/...
+```
+
+The `-race` detector catches unsynchronized access to shared memory in concurrent code. This is critical for:
+- Parallel grader execution
+- Multi-worker prompt evaluation
+- Action timeline appends
+
+## Stub Patterns for External Dependencies
+
+### Grader Stubs
+
+When testing engine behavior without real graders:
+
+```go
+type StubGrader struct {
+    gradeFn func(context.Context, GraderInput) (GraderResult, error)
+}
+
+func (sg *StubGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) {
+    return sg.gradeFn(ctx, input)
+}
+
+// Usage in test
+stubGrader := &StubGrader{
+    gradeFn: func(_ context.Context, _ GraderInput) (GraderResult, error) {
+        return GraderResult{Pass: true, Score: 1.0}, nil
+    },
+}
+```
+
+### File System Stubs
+
+Mock file operations without touching disk:
+
+```go
+type stubFileReader struct {
+    readFn func(path string) (string, error)
+}
+
+func (s *stubFileReader) Read(path string) (string, error) {
+    return s.readFn(path)
+}
+
+// Usage
+stubFS := &stubFileReader{
+    readFn: func(path string) (string, error) {
+        if path == "/test/main.py" {
+            return "# Generated code", nil
+        }
+        return "", os.ErrNotExist
+    },
+}
+```
+
+## Test Organization
+
+- **Unit tests:** Test single function/method (`*_test.go` in same package)
+- **Integration tests:** Test multi-package workflows (`*_integration_test.go`)
+- **Fixtures:** Use `testdata/` directory for test files
+
+## Running Tests
+
+```bash
+# All tests
+go test ./hyoka/...
+
+# With race detector
+go test -race ./hyoka/...
+
+# Specific test
+go test -run TestBehaviorGrader ./hyoka/internal/graders
+
+# Verbose with coverage
+go test -v -cover ./hyoka/...
+```
+
+## Anti-Patterns
+
+- Not using table-driven tests for multiple scenarios
+- Ignoring `-race` failures (concurrency bugs are subtle)
+- Mocking internal types instead of using interfaces
+- Test files that modify package state between runs
+- Hardcoding file paths (use testdata or stubs)
+
+## Related Code Locations
+
+- **Example table-driven tests:** `hyoka/internal/graders/*_test.go`
+- **Stub patterns:** `hyoka/internal/eval/*_test.go`
+- **Test fixtures:** `hyoka/testdata/`


### PR DESCRIPTION
Create comprehensive skill documentation for hyoka's architecture, patterns, and domain knowledge.

**Skills created (14 total):**

Core Architecture (5):
- eval-pipeline: How the eval engine works (generate → grade → report)
- error-handling: Return errors up, no log-and-return, %w wrapping
- config-system: Generator/Reviewer sub-structs, property-based tool filters
- copilot-sdk-integration: How hyoka uses the Copilot SDK
- grader-system: Pluggable grader architecture (6 types, gate semantics)

Working Patterns (4):
- testing-patterns: Table-driven tests, -race flag, stub patterns
- cli-patterns: Cobra commands in cmd/ package, flag conventions
- report-generation: JSON/HTML/Markdown reports, template system
- logging-conventions: slog usage, no third-party logging

Human Developer (2):
- contributor-guide: How to contribute, build, test
- prompt-conventions: Prompt frontmatter format, properties, migration

Evolution Support (3):
- property-migration: How properties map works, snake_case convention
- process-lifecycle: Session creation, workspace isolation, cleanup
- serve-patterns: API endpoints, SPA dashboard, path traversal protection

Closes #162