### PR TITLE
feat: move skills/hyoka/ to .agents/skills/ for Copilot CLI discovery

### DIFF
--- a/.agents/skills/agent-collaboration/SKILL.md
+++ b/.agents/skills/agent-collaboration/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "agent-collaboration"
+description: "Standard collaboration patterns for all squad agents — worktree awareness, decisions, cross-agent communication"
+domain: "team-workflow"
+confidence: "high"
+source: "extracted from charter boilerplate — identical content in 18+ agent charters"
+---
+
+## Context
+
+Every agent on the team follows identical collaboration patterns for worktree awareness, decision recording, and cross-agent communication. These were previously duplicated in every charter's Collaboration section (~300 bytes × 18 agents = ~5.4KB of redundant context). Now centralized here.
+
+The coordinator's spawn prompt already instructs agents to read decisions.md and their history.md. This skill adds the patterns for WRITING decisions and requesting help.
+
+## Patterns
+
+### Worktree Awareness
+Use the `TEAM ROOT` path provided in your spawn prompt. All `.squad/` paths are relative to this root. If TEAM ROOT is not provided (rare), run `git rev-parse --show-toplevel` as fallback. Never assume CWD is the repo root.
+
+### Decision Recording
+After making a decision that affects other team members, write it to:
+`.squad/decisions/inbox/{your-name}-{brief-slug}.md`
+
+Format:
+```
+### {date}: {decision title}
+**By:** {Your Name}
+**What:** {the decision}
+**Why:** {rationale}
+```
+
+### Cross-Agent Communication
+If you need another team member's input, say so in your response. The coordinator will bring them in. Don't try to do work outside your domain.
+
+### Reviewer Protocol
+If you have reviewer authority and reject work: the original author is locked out from revising that artifact. A different agent must own the revision. State who should revise in your rejection response.
+
+## Anti-Patterns
+- Don't read all agent charters — you only need your own context + decisions.md
+- Don't write directly to `.squad/decisions.md` — always use the inbox drop-box
+- Don't modify other agents' history.md files — that's Scribe's job
+- Don't assume CWD is the repo root — always use TEAM ROOT

--- a/.agents/skills/agent-conduct/SKILL.md
+++ b/.agents/skills/agent-conduct/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: "agent-conduct"
+description: "Shared hard rules enforced across all squad agents"
+domain: "team-governance"
+confidence: "high"
+source: "reskill extraction — Product Isolation Rule and Peer Quality Check appeared in all 20 agent charters"
+---
+
+## Context
+
+Every squad agent must follow these two hard rules. They were previously duplicated in every charter. Now they live here as a shared skill, loaded once.
+
+## Patterns
+
+### Product Isolation Rule (hard rule)
+Tests, CI workflows, and product code must NEVER depend on specific agent names from any particular squad. "Our squad" must not impact "the squad." No hardcoded references to agent names (Flight, EECOM, FIDO, etc.) in test assertions, CI configs, or product logic. Use generic/parameterized values. If a test needs agent names, use obviously-fake test fixtures (e.g., "test-agent-1", "TestBot").
+
+### Peer Quality Check (hard rule)
+Before finishing work, verify your changes don't break existing tests. Run the test suite for files you touched. If CI has been failing, check your changes aren't contributing to the problem. When you learn from mistakes, update your history.md.
+
+## Anti-Patterns
+- Don't hardcode dev team agent names in product code or tests
+- Don't skip test verification before declaring work done
+- Don't ignore pre-existing CI failures that your changes may worsen

--- a/.agents/skills/architectural-proposals/SKILL.md
+++ b/.agents/skills/architectural-proposals/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: "architectural-proposals"
+description: "How to write comprehensive architectural proposals that drive alignment before code is written"
+domain: "architecture, product-direction"
+confidence: "high"
+source: "earned (2026-02-21 interactive shell proposal)"
+tools:
+  - name: "view"
+    description: "Read existing codebase, prior decisions, and team context before proposing changes"
+    when: "Always read .squad/decisions.md, relevant PRDs, and current architecture docs before writing proposal"
+  - name: "create"
+    description: "Create proposal in docs/proposals/ with structured format"
+    when: "After gathering context, before any implementation work begins"
+---
+
+## Context
+
+Proposals create alignment before code is written. Cheaper to change a doc than refactor code. Use this pattern when:
+- Architecture shifts invalidate existing assumptions
+- Product direction changes require new foundation
+- Multiple waves/milestones will be affected by a decision
+- External dependencies (Copilot CLI, SDK APIs) change
+
+## Patterns
+
+### Proposal Structure (docs/proposals/)
+
+**Required sections:**
+1. **Problem Statement** — Why current state is broken (specific, measurable evidence)
+2. **Proposed Architecture** — Solution with technical specifics (not hand-waving)
+3. **What Changes** — Impact on existing work (waves, milestones, modules)
+4. **What Stays the Same** — Preserve existing functionality (no regression)
+5. **Key Decisions Needed** — Explicit choices with recommendations
+6. **Risks and Mitigations** — Likelihood + impact + mitigation strategy
+7. **Scope** — What's in v1, what's deferred (timeline clarity)
+
+**Optional sections:**
+- Implementation Plan (high-level milestones)
+- Success Criteria (measurable outcomes)
+- Open Questions (unresolved items)
+- Appendix (prior art, alternatives considered)
+
+### Tone Ceiling Enforcement
+
+**Always:**
+- Cite specific evidence (user reports, performance data, failure modes)
+- Justify recommendations with technical rationale
+- Acknowledge trade-offs (no perfect solutions)
+- Be specific about APIs, libraries, file paths
+
+**Never:**
+- Hype ("revolutionary", "game-changing")
+- Hand-waving ("we'll figure it out later")
+- Unsubstantiated claims ("users will love this")
+- Vague timelines ("soon", "eventually")
+
+### Wave Restructuring Pattern
+
+When a proposal invalidates existing wave structure:
+1. **Acknowledge the shift:** "This becomes Wave 0 (Foundation)"
+2. **Cascade impacts:** Adjust downstream waves (Wave 1, Wave 2, Wave 3)
+3. **Preserve non-blocking work:** Identify what can proceed in parallel
+4. **Update dependencies:** Document new blocking relationships
+
+**Example (Interactive Shell):**
+- Wave 0 (NEW): Interactive Shell — blocks all other waves
+- Wave 1 (ADJUSTED): npm Distribution — shell bundled in cli.js
+- Wave 2 (DEFERRED): SquadUI — waits for shell foundation
+- Wave 3 (ADJUSTED): Public Docs — now documents shell as primary interface
+
+### Decision Framing
+
+**Format:** "Recommendation: X (recommended) or alternatives?"
+
+**Components:**
+- Recommendation (pick one, justify)
+- Alternatives (what else was considered)
+- Decision rationale (why recommended option wins)
+- Needs sign-off from (which agents/roles must approve)
+
+**Example:**
+```
+### 1. Terminal UI Library: `ink` (recommended) or alternatives?
+
+**Recommendation:** `ink`  
+**Alternatives:** `blessed`, raw readline  
+**Decision rationale:** Component model enables testable UI. Battle-tested ecosystem.
+
+**Needs sign-off from:** Brady (product direction), Fortier (runtime performance)
+```
+
+### Risk Documentation
+
+**Format per risk:**
+- **Risk:** Specific failure mode
+- **Likelihood:** Low / Medium / High (not percentages)
+- **Impact:** Low / Medium / High
+- **Mitigation:** Concrete actions (measurable)
+
+**Example:**
+```
+### Risk 2: SDK Streaming Reliability
+
+**Risk:** SDK streaming events might drop messages or arrive out of order.  
+**Likelihood:** Low (SDK is production-grade).  
+**Impact:** High — broken streaming makes shell unusable.
+
+**Mitigation:**
+- Add integration test: Send 1000-message stream, verify all deltas arrive in order
+- Implement fallback: If streaming fails, fall back to polling session state
+- Log all SDK events to `.squad/orchestration-log/sdk-events.jsonl` for debugging
+```
+
+## Examples
+
+**File references from interactive shell proposal:**
+- Full proposal: `docs/proposals/squad-interactive-shell.md`
+- User directive: `.squad/decisions/inbox/copilot-directive-2026-02-21T202535Z.md`
+- Team decisions: `.squad/decisions.md`
+- Current architecture: `docs/architecture/module-map.md`, `docs/prd-23-release-readiness.md`
+
+**Key patterns demonstrated:**
+1. Read user directive first (understand the "why")
+2. Survey current architecture (module map, existing waves)
+3. Research SDK APIs (exploration task to validate feasibility)
+4. Document problem with specific evidence (unreliable handoffs, zero visibility, UX mismatch)
+5. Propose solution with technical specifics (ink components, SDK session management, spawn.ts module)
+6. Restructure waves when foundation shifts (Wave 0 becomes blocker)
+7. Preserve backward compatibility (squad.agent.md still works, VS Code mode unchanged)
+8. Frame decisions explicitly (5 key decisions with recommendations)
+9. Document risks with mitigations (5 risks, each with concrete actions)
+10. Define scope (what's in v1 vs. deferred)
+
+## Anti-Patterns
+
+**Avoid:**
+- ❌ Proposals without problem statements (solution-first thinking)
+- ❌ Vague architecture ("we'll use a shell") — be specific (ink components, session registry, spawn.ts)
+- ❌ Ignoring existing work — always document impact on waves/milestones
+- ❌ No risk analysis — every architecture has risks, document them
+- ❌ Unbounded scope — draw the v1 line explicitly
+- ❌ Missing decision ownership — always say "needs sign-off from X"
+- ❌ No backward compatibility plan — users don't care about your replatform
+- ❌ Hand-waving timelines ("a few weeks") — be specific (2-3 weeks, 1 engineer full-time)
+
+**Red flags in proposal reviews:**
+- "Users will love this" (citation needed)
+- "We'll figure out X later" (scope creep incoming)
+- "This is revolutionary" (tone ceiling violation)
+- No section on "What Stays the Same" (regression risk)
+- No risks documented (wishful thinking)

--- a/.agents/skills/ci-validation-gates/SKILL.md
+++ b/.agents/skills/ci-validation-gates/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: "ci-validation-gates"
+description: "Defensive CI/CD patterns: semver validation, token checks, retry logic, draft detection — earned from v0.8.22"
+domain: "ci-cd"
+confidence: "high"
+source: "extracted from Drucker and Trejo charters — earned knowledge from v0.8.22 release incident"
+---
+
+## Context
+
+CI workflows must be defensive. These patterns were learned from the v0.8.22 release disaster where invalid semver, wrong token types, missing retry logic, and draft releases caused a multi-hour outage. Both Drucker (CI/CD) and Trejo (Release Manager) carried this knowledge in their charters — now centralized here.
+
+## Patterns
+
+### Semver Validation Gate
+Every publish workflow MUST validate version format before `npm publish`. 4-part versions (e.g., 0.8.21.4) are NOT valid semver — npm mangles them.
+
+```yaml
+- name: Validate semver
+  run: |
+    VERSION="${{ github.event.release.tag_name }}"
+    VERSION="${VERSION#v}"
+    if ! npx semver "$VERSION" > /dev/null 2>&1; then
+      echo "❌ Invalid semver: $VERSION"
+      echo "Only 3-part versions (X.Y.Z) or prerelease (X.Y.Z-tag.N) are valid."
+      exit 1
+    fi
+    echo "✅ Valid semver: $VERSION"
+```
+
+### NPM Token Type Verification
+NPM_TOKEN MUST be an Automation token, not a User token with 2FA:
+- User tokens require OTP — CI can't provide it → EOTP error
+- Create Automation tokens at npmjs.com → Settings → Access Tokens → Automation
+- Verify before first publish in any workflow
+
+### Retry Logic for npm Registry Propagation
+npm registry uses eventual consistency. After `npm publish` succeeds, the package may not be immediately queryable.
+- Propagation: typically 5-30s, up to 2min in rare cases
+- All verify steps: 5 attempts, 15-second intervals
+- Log each attempt: "Attempt 1/5: Checking package..."
+- Exit loop on success, fail after max attempts
+
+```yaml
+- name: Verify package (with retry)
+  run: |
+    MAX_ATTEMPTS=5
+    WAIT_SECONDS=15
+    for attempt in $(seq 1 $MAX_ATTEMPTS); do
+      echo "Attempt $attempt/$MAX_ATTEMPTS: Checking $PACKAGE@$VERSION..."
+      if npm view "$PACKAGE@$VERSION" version > /dev/null 2>&1; then
+        echo "✅ Package verified"
+        exit 0
+      fi
+      [ $attempt -lt $MAX_ATTEMPTS ] && sleep $WAIT_SECONDS
+    done
+    echo "❌ Failed to verify after $MAX_ATTEMPTS attempts"
+    exit 1
+```
+
+### Draft Release Detection
+Draft releases don't emit `release: published` event. Workflows MUST:
+- Trigger on `release: published` (NOT `created`)
+- If using workflow_dispatch: verify release is published via GitHub API before proceeding
+
+### Build Script Protection
+Set `SKIP_BUILD_BUMP=1` (or `$env:SKIP_BUILD_BUMP = "1"` on Windows) before ANY release build. bump-build.mjs is for dev builds ONLY — it silently mutates versions.
+
+## Known Failure Modes (v0.8.22 Incident)
+
+| # | What Happened | Root Cause | Prevention |
+|---|---------------|-----------|------------|
+| 1 | 4-part version published, npm mangled it | No semver validation gate | `npx semver` check before every publish |
+| 2 | CI failed 5+ times with EOTP | User token with 2FA | Automation token only |
+| 3 | Verify returned false 404 | No retry logic for propagation | 5 attempts, 15s intervals |
+| 4 | Workflow never triggered | Draft release doesn't emit event | Never create draft releases |
+| 5 | Version mutated during release | bump-build.mjs ran in release | SKIP_BUILD_BUMP=1 |
+
+## Anti-Patterns
+- ❌ Publishing without semver validation gate
+- ❌ Single-shot verification without retry
+- ❌ Hard-coded secrets in workflows
+- ❌ Silent CI failures — every error needs actionable output with remediation
+- ❌ Assuming npm publish is instantly queryable

--- a/.agents/skills/cli-patterns/SKILL.md
+++ b/.agents/skills/cli-patterns/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: "cli-patterns"
+description: "Cobra commands in cmd/ package, flag conventions"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/cmd/*.go"
+---
+
+## Context
+
+Hyoka's CLI is built with Cobra, a popular Go CLI framework. Commands are organized in the `cmd/` package with consistent flag naming and help text patterns.
+
+## Command Structure
+
+Each command is a Cobra command object:
+
+```go
+// cmd/run.go
+var runCmd = &cobra.Command{
+    Use:   "run",
+    Short: "Run evaluation",
+    Long:  "Run an evaluation with prompts and configs.",
+    
+    Args: cobra.NoArgs,  // Positional arguments check
+    
+    RunE: func(cmd *cobra.Command, args []string) error {
+        // Retrieve flags
+        promptID, _ := cmd.Flags().GetString("prompt-id")
+        config, _ := cmd.Flags().GetString("config")
+        
+        // Validate
+        if promptID == "" && config == "" {
+            return fmt.Errorf("either --prompt-id or --config required")
+        }
+        
+        // Execute
+        return run(promptID, config)
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(runCmd)
+    runCmd.Flags().StringP("prompt-id", "", "", "Single prompt ID")
+    runCmd.Flags().StringP("config", "", "", "Config (comma-sep for multiple)")
+}
+```
+
+## Flag Naming Conventions
+
+- **Kebab-case:** `--log-level`, `--max-files`, `--prompt-id` (not `--logLevel`, `--maxfiles`)
+- **Short flags:** Single-letter for common flags (e.g., `-v` for `--verbose`)
+- **Suffixes:**
+  - `--*-timeout` for duration limits (e.g., `--gen-timeout`)
+  - `--skip-*` for skipping phases (e.g., `--skip-review`)
+  - `--*-file` for file paths (e.g., `--log-file`)
+
+## Flag Types and Patterns
+
+**String flags:**
+```go
+cmd.Flags().StringP("config", "", "", "Config name")
+```
+
+**Comma-separated lists:**
+```go
+cmd.Flags().String("tags", "", "Comma-separated tags (must quote: \"auth,crud\")")
+// Parsed as: strings.Split(value, ",")
+```
+
+**Boolean flags:**
+```go
+cmd.Flags().Bool("dry-run", false, "Show what would run without executing")
+```
+
+**Numeric flags:**
+```go
+cmd.Flags().Int("max-files", 50, "Max files per eval")
+cmd.Flags().Duration("gen-timeout", 600*time.Second, "Generation timeout")
+```
+
+## Help Text Guidelines
+
+Keep help text brief but actionable:
+
+```
+// Good
+--config          Config name or comma-sep list
+--prompt-id       Single prompt ID (e.g., identity-dp-python-default-credential)
+--service         Azure service (e.g., identity, key-vault)
+--dry-run         List matching prompts without executing
+
+// Bad (too verbose, no examples)
+--prompt-id       The prompt identifier
+--config          The configuration to use
+```
+
+## Command Execution Pattern
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    // 1. Get flags
+    promptID, _ := cmd.Flags().GetString("prompt-id")
+    config, _ := cmd.Flags().GetString("config")
+    
+    // 2. Validate
+    if promptID == "" {
+        return fmt.Errorf("--prompt-id required")
+    }
+    
+    // 3. Execute
+    ctx := context.Background()
+    return executeEval(ctx, promptID, config)
+}
+```
+
+## Common Commands in Hyoka
+
+- `run` — Execute evaluation
+- `list` — List available prompts
+- `validate` — Validate prompt schema
+- `check-env` — Check environment (Copilot SDK, Go version)
+- `clean` — Clean orphaned sessions
+- `serve` — Start local web server for results
+
+## Error Handling in Commands
+
+Return errors from `RunE`. Cobra catches them and prints with exit code 1:
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    result, err := runEval(...)
+    if err != nil {
+        slog.Error("Evaluation failed", "error", err)
+        return err  // Cobra handles exit
+    }
+    return nil
+}
+```
+
+## Output and Logging
+
+- **User output (results, progress):** Write to stdout
+- **Diagnostic logs:** Use slog with `--log-level` flag
+- **Errors:** Return error from `RunE`, let Cobra print
+
+## Flag Validation Example
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    config, _ := cmd.Flags().GetString("config")
+    allConfigs, _ := cmd.Flags().GetBool("all-configs")
+    
+    if config == "" && !allConfigs {
+        return fmt.Errorf("either --config or --all-configs required")
+    }
+    
+    if config != "" && allConfigs {
+        return fmt.Errorf("cannot use both --config and --all-configs")
+    }
+    
+    return runWithConfig(config, allConfigs)
+}
+```
+
+## Related Code Locations
+
+- **Root command:** `hyoka/cmd/root.go`
+- **Subcommands:** `hyoka/cmd/*.go`
+- **Flag parsing utilities:** `hyoka/cmd/common.go` (if shared parsing logic)
+
+## Anti-Patterns
+
+- CamelCase flag names
+- Positional arguments instead of flags
+- Ambiguous short flags (avoid single `-a` if context unclear)
+- Printing errors and returning them (let Cobra handle)
+- Hardcoding defaults without CLI override

--- a/.agents/skills/client-compatibility/SKILL.md
+++ b/.agents/skills/client-compatibility/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: "client-compatibility"
+description: "Platform detection and adaptive spawning for CLI vs VS Code vs other surfaces"
+domain: "orchestration"
+confidence: "high"
+source: "extracted"
+---
+
+## Context
+
+Squad runs on multiple Copilot surfaces (CLI, VS Code, JetBrains, GitHub.com). The coordinator must detect its platform and adapt spawning behavior accordingly. Different tools are available on different platforms, requiring conditional logic for agent spawning, SQL usage, and response timing.
+
+## Patterns
+
+### Platform Detection
+
+Before spawning agents, determine the platform by checking available tools:
+
+1. **CLI mode** — `task` tool is available → full spawning control. Use `task` with `agent_type`, `mode`, `model`, `description`, `prompt` parameters. Collect results via `read_agent`.
+
+2. **VS Code mode** — `runSubagent` or `agent` tool is available → conditional behavior. Use `runSubagent` with the task prompt. Drop `agent_type`, `mode`, and `model` parameters. Multiple subagents in one turn run concurrently (equivalent to background mode). Results return automatically — no `read_agent` needed.
+
+3. **Fallback mode** — neither `task` nor `runSubagent`/`agent` available → work inline. Do not apologize or explain the limitation. Execute the task directly.
+
+If both `task` and `runSubagent` are available, prefer `task` (richer parameter surface).
+
+### VS Code Spawn Adaptations
+
+When in VS Code mode, the coordinator changes behavior in these ways:
+
+- **Spawning tool:** Use `runSubagent` instead of `task`. The prompt is the only required parameter — pass the full agent prompt (charter, identity, task, hygiene, response order) exactly as you would on CLI.
+- **Parallelism:** Spawn ALL concurrent agents in a SINGLE turn. They run in parallel automatically. This replaces `mode: "background"` + `read_agent` polling.
+- **Model selection:** Accept the session model. Do NOT attempt per-spawn model selection or fallback chains — they only work on CLI. In Phase 1, all subagents use whatever model the user selected in VS Code's model picker.
+- **Scribe:** Cannot fire-and-forget. Batch Scribe as the LAST subagent in any parallel group. Scribe is light work (file ops only), so the blocking is tolerable.
+- **Launch table:** Skip it. Results arrive with the response, not separately. By the time the coordinator speaks, the work is already done.
+- **`read_agent`:** Skip entirely. Results return automatically when subagents complete.
+- **`agent_type`:** Drop it. All VS Code subagents have full tool access by default. Subagents inherit the parent's tools.
+- **`description`:** Drop it. The agent name is already in the prompt.
+- **Prompt content:** Keep ALL prompt structure — charter, identity, task, hygiene, response order blocks are surface-independent.
+
+### Feature Degradation Table
+
+| Feature | CLI | VS Code | Degradation |
+|---------|-----|---------|-------------|
+| Parallel fan-out | `mode: "background"` + `read_agent` | Multiple subagents in one turn | None — equivalent concurrency |
+| Model selection | Per-spawn `model` param (4-layer hierarchy) | Session model only (Phase 1) | Accept session model, log intent |
+| Scribe fire-and-forget | Background, never read | Sync, must wait | Batch with last parallel group |
+| Launch table UX | Show table → results later | Skip table → results with response | UX only — results are correct |
+| SQL tool | Available | Not available | Avoid SQL in cross-platform code paths |
+| Response order bug | Critical workaround | Possibly necessary (unverified) | Keep the block — harmless if unnecessary |
+
+### SQL Tool Caveat
+
+The `sql` tool is **CLI-only**. It does not exist on VS Code, JetBrains, or GitHub.com. Any coordinator logic or agent workflow that depends on SQL (todo tracking, batch processing, session state) will silently fail on non-CLI surfaces. Cross-platform code paths must not depend on SQL. Use filesystem-based state (`.squad/` files) for anything that must work everywhere.
+
+## Examples
+
+**Example 1: CLI parallel spawn**
+```typescript
+// Coordinator detects task tool available → CLI mode
+task({ agent_type: "general-purpose", mode: "background", model: "claude-sonnet-4.5", ... })
+task({ agent_type: "general-purpose", mode: "background", model: "claude-haiku-4.5", ... })
+// Later: read_agent for both
+```
+
+**Example 2: VS Code parallel spawn**
+```typescript
+// Coordinator detects runSubagent available → VS Code mode
+runSubagent({ prompt: "...Fenster charter + task..." })
+runSubagent({ prompt: "...Hockney charter + task..." })
+runSubagent({ prompt: "...Scribe charter + task..." }) // Last in group
+// Results return automatically, no read_agent
+```
+
+**Example 3: Fallback mode**
+```typescript
+// Neither task nor runSubagent available → work inline
+// Coordinator executes the task directly without spawning
+```
+
+## Anti-Patterns
+
+- ❌ Using SQL tool in cross-platform workflows (breaks on VS Code/JetBrains/GitHub.com)
+- ❌ Attempting per-spawn model selection on VS Code (Phase 1 — only session model works)
+- ❌ Fire-and-forget Scribe on VS Code (must batch as last subagent)
+- ❌ Showing launch table on VS Code (results already inline)
+- ❌ Apologizing or explaining platform limitations to the user
+- ❌ Using `task` when only `runSubagent` is available
+- ❌ Dropping prompt structure (charter/identity/task) on non-CLI platforms

--- a/.agents/skills/code-review-excellence/SKILL.md
+++ b/.agents/skills/code-review-excellence/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: code-review-excellence
+description: Master effective code review practices to provide constructive feedback, catch bugs early, and foster knowledge sharing while maintaining team morale. Use when reviewing pull requests, establishing review standards, or mentoring developers.
+---
+
+# Code Review Excellence
+
+Transform code reviews from gatekeeping to knowledge sharing through constructive feedback, systematic analysis, and collaborative improvement.
+
+## When to Use This Skill
+
+- Reviewing pull requests and code changes
+- Establishing code review standards for teams
+- Mentoring junior developers through reviews
+- Conducting architecture reviews
+- Creating review checklists and guidelines
+- Improving team collaboration
+- Reducing code review cycle time
+- Maintaining code quality standards
+
+## Core Principles
+
+### 1. The Review Mindset
+
+**Goals of Code Review:**
+
+- Catch bugs and edge cases
+- Ensure code maintainability
+- Share knowledge across team
+- Enforce coding standards
+- Improve design and architecture
+- Build team culture
+
+**Not the Goals:**
+
+- Show off knowledge
+- Nitpick formatting (use linters)
+- Block progress unnecessarily
+- Rewrite to your preference
+
+### 2. Effective Feedback
+
+**Good Feedback is:**
+
+- Specific and actionable
+- Educational, not judgmental
+- Focused on the code, not the person
+- Balanced (praise good work too)
+- Prioritized (critical vs nice-to-have)
+
+```markdown
+❌ Bad: "This is wrong."
+✅ Good: "This could cause a race condition when multiple users
+access simultaneously. Consider using a mutex here."
+
+❌ Bad: "Why didn't you use X pattern?"
+✅ Good: "Have you considered the Repository pattern? It would
+make this easier to test. Here's an example: [link]"
+
+❌ Bad: "Rename this variable."
+✅ Good: "[nit] Consider `userCount` instead of `uc` for
+clarity. Not blocking if you prefer to keep it."
+```
+
+### 3. Review Scope
+
+**What to Review:**
+
+- Logic correctness and edge cases
+- Security vulnerabilities
+- Performance implications
+- Test coverage and quality
+- Error handling
+- Documentation and comments
+- API design and naming
+- Architectural fit
+
+**What Not to Review Manually:**
+
+- Code formatting (use Prettier, Black, etc.)
+- Import organization
+- Linting violations
+- Simple typos
+
+## Review Process
+
+### Phase 1: Context Gathering (2-3 minutes)
+
+```markdown
+Before diving into code, understand:
+
+1. Read PR description and linked issue
+2. Check PR size (>400 lines? Ask to split)
+3. Review CI/CD status (tests passing?)
+4. Understand the business requirement
+5. Note any relevant architectural decisions
+```
+
+### Phase 2: High-Level Review (5-10 minutes)
+
+```markdown
+1. **Architecture & Design**
+   - Does the solution fit the problem?
+   - Are there simpler approaches?
+   - Is it consistent with existing patterns?
+   - Will it scale?
+
+2. **File Organization**
+   - Are new files in the right places?
+   - Is code grouped logically?
+   - Are there duplicate files?
+
+3. **Testing Strategy**
+   - Are there tests?
+   - Do tests cover edge cases?
+   - Are tests readable?
+```
+
+### Phase 3: Line-by-Line Review (10-20 minutes)
+
+```markdown
+For each file:
+
+1. **Logic & Correctness**
+   - Edge cases handled?
+   - Off-by-one errors?
+   - Null/undefined checks?
+   - Race conditions?
+
+2. **Security**
+   - Input validation?
+   - SQL injection risks?
+   - XSS vulnerabilities?
+   - Sensitive data exposure?
+
+3. **Performance**
+   - N+1 queries?
+   - Unnecessary loops?
+   - Memory leaks?
+   - Blocking operations?
+
+4. **Maintainability**
+   - Clear variable names?
+   - Functions doing one thing?
+   - Complex code commented?
+   - Magic numbers extracted?
+```
+
+### Phase 4: Summary & Decision (2-3 minutes)
+
+```markdown
+1. Summarize key concerns
+2. Highlight what you liked
+3. Make clear decision:
+   - ✅ Approve
+   - 💬 Comment (minor suggestions)
+   - 🔄 Request Changes (must address)
+4. Offer to pair if complex
+```
+
+## Review Techniques
+
+### Technique 1: The Checklist Method
+
+```markdown
+## Security Checklist
+
+- [ ] User input validated and sanitized
+- [ ] SQL queries use parameterization
+- [ ] Authentication/authorization checked
+- [ ] Secrets not hardcoded
+- [ ] Error messages don't leak info
+
+## Performance Checklist
+
+- [ ] No N+1 queries
+- [ ] Database queries indexed
+- [ ] Large lists paginated
+- [ ] Expensive operations cached
+- [ ] No blocking I/O in hot paths
+
+## Testing Checklist
+
+- [ ] Happy path tested
+- [ ] Edge cases covered
+- [ ] Error cases tested
+- [ ] Test names are descriptive
+- [ ] Tests are deterministic
+```
+
+### Technique 2: The Question Approach
+
+Instead of stating problems, ask questions to encourage thinking:
+
+```markdown
+❌ "This will fail if the list is empty."
+✅ "What happens if `items` is an empty array?"
+
+❌ "You need error handling here."
+✅ "How should this behave if the API call fails?"
+
+❌ "This is inefficient."
+✅ "I see this loops through all users. Have we considered
+the performance impact with 100k users?"
+```
+
+### Technique 3: Suggest, Don't Command
+
+````markdown
+## Use Collaborative Language
+
+❌ "You must change this to use async/await"
+✅ "Suggestion: async/await might make this more readable:
+`typescript
+    async function fetchUser(id: string) {
+        const user = await db.query('SELECT * FROM users WHERE id = ?', id);
+        return user;
+    }
+    `
+What do you think?"
+
+❌ "Extract this into a function"
+✅ "This logic appears in 3 places. Would it make sense to
+extract it into a shared utility function?"
+````
+
+### Technique 4: Differentiate Severity
+
+```markdown
+Use labels to indicate priority:
+
+🔴 [blocking] - Must fix before merge
+🟡 [important] - Should fix, discuss if disagree
+🟢 [nit] - Nice to have, not blocking
+💡 [suggestion] - Alternative approach to consider
+📚 [learning] - Educational comment, no action needed
+🎉 [praise] - Good work, keep it up!
+
+Example:
+"🔴 [blocking] This SQL query is vulnerable to injection.
+Please use parameterized queries."
+
+"🟢 [nit] Consider renaming `data` to `userData` for clarity."
+
+"🎉 [praise] Excellent test coverage! This will catch edge cases."
+```
+
+## Language-Specific Patterns
+
+### Python Code Review
+
+```python
+# Check for Python-specific issues
+
+# ❌ Mutable default arguments
+def add_item(item, items=[]):  # Bug! Shared across calls
+    items.append(item)
+    return items
+
+# ✅ Use None as default
+def add_item(item, items=None):
+    if items is None:
+        items = []
+    items.append(item)
+    return items
+
+# ❌ Catching too broad
+try:
+    result = risky_operation()
+except:  # Catches everything, even KeyboardInterrupt!
+    pass
+
+# ✅ Catch specific exceptions
+try:
+    result = risky_operation()
+except ValueError as e:
+    logger.error(f"Invalid value: {e}")
+    raise
+
+# ❌ Using mutable class attributes
+class User:
+    permissions = []  # Shared across all instances!
+
+# ✅ Initialize in __init__
+class User:
+    def __init__(self):
+        self.permissions = []
+```
+
+### TypeScript/JavaScript Code Review
+
+```typescript
+// Check for TypeScript-specific issues
+
+// ❌ Using any defeats type safety
+function processData(data: any) {  // Avoid any
+    return data.value;
+}
+
+// ✅ Use proper types
+interface DataPayload {
+    value: string;
+}
+function processData(data: DataPayload) {
+    return data.value;
+}
+
+// ❌ Not handling async errors
+async function fetchUser(id: string) {
+    const response = await fetch(`/api/users/${id}`);
+    return response.json();  // What if network fails?
+}
+
+// ✅ Handle errors properly
+async function fetchUser(id: string): Promise<User> {
+    try {
+        const response = await fetch(`/api/users/${id}`);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        return await response.json();
+    } catch (error) {
+        console.error('Failed to fetch user:', error);
+        throw error;
+    }
+}
+
+// ❌ Mutation of props
+function UserProfile({ user }: Props) {
+    user.lastViewed = new Date();  // Mutating prop!
+    return <div>{user.name}</div>;
+}
+
+// ✅ Don't mutate props
+function UserProfile({ user, onView }: Props) {
+    useEffect(() => {
+        onView(user.id);  // Notify parent to update
+    }, [user.id]);
+    return <div>{user.name}</div>;
+}
+```
+
+## Advanced Review Patterns
+
+### Pattern 1: Architectural Review
+
+```markdown
+When reviewing significant changes:
+
+1. **Design Document First**
+   - For large features, request design doc before code
+   - Review design with team before implementation
+   - Agree on approach to avoid rework
+
+2. **Review in Stages**
+   - First PR: Core abstractions and interfaces
+   - Second PR: Implementation
+   - Third PR: Integration and tests
+   - Easier to review, faster to iterate
+
+3. **Consider Alternatives**
+   - "Have we considered using [pattern/library]?"
+   - "What's the tradeoff vs. the simpler approach?"
+   - "How will this evolve as requirements change?"
+```
+
+### Pattern 2: Test Quality Review
+
+```typescript
+// ❌ Poor test: Implementation detail testing
+test('increments counter variable', () => {
+    const component = render(<Counter />);
+    const button = component.getByRole('button');
+    fireEvent.click(button);
+    expect(component.state.counter).toBe(1);  // Testing internal state
+});
+
+// ✅ Good test: Behavior testing
+test('displays incremented count when clicked', () => {
+    render(<Counter />);
+    const button = screen.getByRole('button', { name: /increment/i });
+    fireEvent.click(button);
+    expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+
+// Review questions for tests:
+// - Do tests describe behavior, not implementation?
+// - Are test names clear and descriptive?
+// - Do tests cover edge cases?
+// - Are tests independent (no shared state)?
+// - Can tests run in any order?
+```
+
+### Pattern 3: Security Review
+
+```markdown
+## Security Review Checklist
+
+### Authentication & Authorization
+
+- [ ] Is authentication required where needed?
+- [ ] Are authorization checks before every action?
+- [ ] Is JWT validation proper (signature, expiry)?
+- [ ] Are API keys/secrets properly secured?
+
+### Input Validation
+
+- [ ] All user inputs validated?
+- [ ] File uploads restricted (size, type)?
+- [ ] SQL queries parameterized?
+- [ ] XSS protection (escape output)?
+
+### Data Protection
+
+- [ ] Passwords hashed (bcrypt/argon2)?
+- [ ] Sensitive data encrypted at rest?
+- [ ] HTTPS enforced for sensitive data?
+- [ ] PII handled according to regulations?
+
+### Common Vulnerabilities
+
+- [ ] No eval() or similar dynamic execution?
+- [ ] No hardcoded secrets?
+- [ ] CSRF protection for state-changing operations?
+- [ ] Rate limiting on public endpoints?
+```
+
+## Giving Difficult Feedback
+
+### Pattern: The Sandwich Method (Modified)
+
+```markdown
+Traditional: Praise + Criticism + Praise (feels fake)
+
+Better: Context + Specific Issue + Helpful Solution
+
+Example:
+"I noticed the payment processing logic is inline in the
+controller. This makes it harder to test and reuse.
+
+[Specific Issue]
+The calculateTotal() function mixes tax calculation,
+discount logic, and database queries, making it difficult
+to unit test and reason about.
+
+[Helpful Solution]
+Could we extract this into a PaymentService class? That
+would make it testable and reusable. I can pair with you
+on this if helpful."
+```
+
+### Handling Disagreements
+
+```markdown
+When author disagrees with your feedback:
+
+1. **Seek to Understand**
+   "Help me understand your approach. What led you to
+   choose this pattern?"
+
+2. **Acknowledge Valid Points**
+   "That's a good point about X. I hadn't considered that."
+
+3. **Provide Data**
+   "I'm concerned about performance. Can we add a benchmark
+   to validate the approach?"
+
+4. **Escalate if Needed**
+   "Let's get [architect/senior dev] to weigh in on this."
+
+5. **Know When to Let Go**
+   If it's working and not a critical issue, approve it.
+   Perfection is the enemy of progress.
+```
+
+## Best Practices
+
+1. **Review Promptly**: Within 24 hours, ideally same day
+2. **Limit PR Size**: 200-400 lines max for effective review
+3. **Review in Time Blocks**: 60 minutes max, take breaks
+4. **Use Review Tools**: GitHub, GitLab, or dedicated tools
+5. **Automate What You Can**: Linters, formatters, security scans
+6. **Build Rapport**: Emoji, praise, and empathy matter
+7. **Be Available**: Offer to pair on complex issues
+8. **Learn from Others**: Review others' review comments
+
+## Common Pitfalls
+
+- **Perfectionism**: Blocking PRs for minor style preferences
+- **Scope Creep**: "While you're at it, can you also..."
+- **Inconsistency**: Different standards for different people
+- **Delayed Reviews**: Letting PRs sit for days
+- **Ghosting**: Requesting changes then disappearing
+- **Rubber Stamping**: Approving without actually reviewing
+- **Bike Shedding**: Debating trivial details extensively
+
+## Templates
+
+### PR Review Comment Template
+
+```markdown
+## Summary
+
+[Brief overview of what was reviewed]
+
+## Strengths
+
+- [What was done well]
+- [Good patterns or approaches]
+
+## Required Changes
+
+🔴 [Blocking issue 1]
+🔴 [Blocking issue 2]
+
+## Suggestions
+
+💡 [Improvement 1]
+💡 [Improvement 2]
+
+## Questions
+
+❓ [Clarification needed on X]
+❓ [Alternative approach consideration]
+
+## Verdict
+
+✅ Approve after addressing required changes
+```

--- a/.agents/skills/config-system/SKILL.md
+++ b/.agents/skills/config-system/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "config-system"
+description: "Generator/Reviewer sub-structs, property-based tool filters"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/config/config.go"
+---
+
+## Context
+
+Hyoka's config system is YAML-driven and highly composable. Each evaluation config defines separate generator and reviewer specifications, with tool filtering via properties (allow/deny lists and skill injection).
+
+## Config Structure
+
+### Top-Level ToolConfig
+```yaml
+name: baseline/claude-opus-4.6
+description: "Baseline Opus eval"
+generator:
+  model: claude-opus-4.6
+  system_prompt: "You are..."
+  skills: [...]
+  mcp_servers: {...}
+  tools: [...]
+  available_tools: [...]    # Allowlist
+  excluded_tools: [...]     # Denylist
+reviewer:
+  models: [claude-opus-4.6, gpt-5.4]
+  system_prompt: "Review this code..."
+plugins: [...]
+limits:
+  max_turns: 25
+  max_files: 50
+  max_output_size: 1048576
+  max_session_actions: 50
+```
+
+### Generator vs. Reviewer Separation
+
+**GeneratorConfig** (code generation):
+- Single `model` field (one generator model)
+- Optional `system_prompt` override
+- Skills injection for generator context
+- MCP servers for external tools
+- Tool filters (available_tools / excluded_tools)
+
+**ReviewerConfig** (code review):
+- `models` array (multiple reviewers in parallel)
+- Optional `system_prompt` for review instructions
+- Skills injection for review guidance
+- No MCP servers (reviewers don't call tools)
+
+## Tool Filtering
+
+Tools are filtered via **ToolEntry** specs:
+```go
+type ToolEntry struct {
+    Name       string            `yaml:"name"`
+    Include    bool              `yaml:"include"`           // whitelist
+    Exclude    bool              `yaml:"exclude"`           // blacklist
+    Properties map[string]string `yaml:"properties"`        // filters by context
+}
+```
+
+### Property-Based Tool Filtering
+
+Properties are **snake_case** metadata on tools (e.g., `language:python`, `service:keyvault`). Generator model sees only tools matching the current prompt's properties.
+
+**Example:**
+```yaml
+# Config
+tools:
+  - name: python_test_runner
+    include: true
+    properties:
+      language: python
+
+# Prompt metadata
+language: python  # Matches → tool included
+
+language: dotnet  # No match → tool hidden
+```
+
+## Composition Patterns
+
+**Skill Injection:**
+```yaml
+generator:
+  skills:
+    - type: local
+      path: ./skills/generator/**/*.md
+    - type: remote
+      name: azure-prompt-patterns
+      repo: github.com/Azure/hyoka-skills
+```
+
+**MCP Server Configuration:**
+```yaml
+generator:
+  mcp_servers:
+    azure-cli:
+      type: command
+      command: az
+      args: ["--version"]
+      tools: ["azure_resource_list", "azure_resource_get"]
+```
+
+## Key Patterns
+
+- **Single model for generation, multiple for review:** Enables comparison across reviewers
+- **Property-based filtering:** Tools scope automatically to prompt language/service
+- **SessionLimits as guardrails:** Per-config turn/file/action limits override engine defaults
+- **Plugins for extensibility:** Config-level plugin registration (for future custom scoring)
+
+## Related Code Locations
+
+- **Config loading:** `hyoka/internal/config/config.go`
+- **Tool filtering logic:** `hyoka/internal/config/tools.go`
+- **Example configs:** `configs/*.yaml`
+
+## Anti-Patterns
+
+- Hardcoding tool availability (use properties instead)
+- Using different skill sets for generator and reviewer without documentation
+- Conflicting available_tools and excluded_tools (excluded wins)
+- Ignoring SessionLimits in custom configs (defaults should be sufficient)

--- a/.agents/skills/contributor-guide/SKILL.md
+++ b/.agents/skills/contributor-guide/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: "contributor-guide"
+description: "How to contribute, build, test"
+domain: "collaboration"
+confidence: "high"
+source: "hyoka/README.md, docs/contributing.md"
+---
+
+## Context
+
+Hyoka is an open evaluation tool for Azure SDK code generation. Contributors should follow the setup and workflow documented here to ensure smooth development and testing.
+
+## Development Setup
+
+### Prerequisites
+
+- **Go 1.24.5+** (check with `go version`)
+- **Copilot SDK** installed and authenticated
+- **git** configured with GitHub SSH access
+
+### Clone and Build
+
+```bash
+# Clone the repo
+git clone https://github.com/ronniegeraghty/hyoka.git
+cd hyoka
+
+# Install dependencies (uses go.work for workspace)
+go mod download
+
+# Build the CLI
+go build ./hyoka/...
+
+# Run the CLI
+go run ./hyoka <command>
+```
+
+## Development Workflow
+
+### Before Starting Work
+
+1. **Create a branch** from `ronniegeraghty/dev`:
+   ```bash
+   git checkout ronniegeraghty/dev
+   git pull origin ronniegeraghty/dev
+   git checkout -b ronniegeraghty/issue-{N}-{description}
+   ```
+
+2. **Configure git identity:**
+   ```bash
+   git config user.name "ronniegeraghty"
+   git config user.email "ronniegeraghty@users.noreply.github.com"
+   ```
+
+### Making Changes
+
+1. **Edit code** in `hyoka/internal/` or `hyoka/cmd/`
+2. **Run tests** to verify no regressions:
+   ```bash
+   go test -race ./hyoka/...
+   ```
+3. **Run linter** (if configured):
+   ```bash
+   go fmt ./hyoka/...
+   ```
+4. **Test manually** with a quick eval run:
+   ```bash
+   go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+     --config baseline/claude-opus-4.6 --log-level debug
+   ```
+
+### Before Committing
+
+1. **Ensure tests pass** with race detector:
+   ```bash
+   go test -race ./hyoka/...
+   ```
+
+2. **Clean up orphaned sessions** from test runs:
+   ```bash
+   go run ./hyoka clean
+   ```
+
+3. **Include the Co-authored-by trailer** in commit message:
+   ```
+   git commit -m "Fix eval engine timeout handling
+
+   - Add timeout context to generation phase
+   - Capture timeout error in action timeline
+   
+   Closes #162
+   
+   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+   ```
+
+### Pushing and Creating a PR
+
+1. **Push to your fork:**
+   ```bash
+   gh auth switch --user ronniegeraghty
+   git push origin ronniegeraghty/issue-{N}-{description}
+   ```
+
+2. **Create a PR** against `ronniegeraghty/dev`:
+   ```bash
+   gh pr create --base ronniegeraghty/dev \
+     --title "Fix: eval engine timeout" \
+     --body "Closes #162"
+   ```
+
+3. **Link to board:** Edit issue on Azure/projects/424 and set Status → "In Progress"
+
+## Testing During Development
+
+### Quick Test Run
+
+For iterating on changes, run a single prompt × single config (fastest):
+
+```bash
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config baseline/claude-opus-4.6 --log-level debug
+```
+
+Python prompts finish quickest (5-10 minutes). After each run, clean up:
+
+```bash
+go run ./hyoka clean
+```
+
+### Check Logs
+
+```bash
+# View the debug log
+cat hyoka-debug.log
+
+# Search for role-prefixed output
+grep "role=" hyoka-debug.log | head -20
+```
+
+### Browse Results
+
+```bash
+go run ./hyoka serve
+# Open http://localhost:8080
+```
+
+## Common Development Tasks
+
+### Adding a New Grader Type
+
+1. **Create the grader:** `hyoka/internal/graders/my_grader.go`
+2. **Implement the interface:**
+   ```go
+   type MyGrader struct { /* fields */ }
+   func (g *MyGrader) Kind() string { return "my" }
+   func (g *MyGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) { /* ... */ }
+   ```
+3. **Register in factory:** `hyoka/internal/graders/registry.go`
+4. **Write tests:** `hyoka/internal/graders/my_grader_test.go`
+5. **Update config examples:** `configs/*.yaml`
+
+### Adding a New CLI Command
+
+1. **Create command file:** `hyoka/cmd/mycommand.go`
+2. **Implement Cobra command:**
+   ```go
+   var myCmd = &cobra.Command{
+       Use: "mycommand",
+       RunE: func(cmd *cobra.Command, args []string) error { /* ... */ },
+   }
+   func init() { rootCmd.AddCommand(myCmd) }
+   ```
+3. **Document in help text**
+4. **Write tests:** `hyoka/cmd/mycommand_test.go`
+
+### Updating Documentation
+
+- **Architecture docs:** `docs/architecture.md`
+- **CLI reference:** `docs/cli-reference.md`
+- **Contributing guide:** `docs/contributing.md`
+- **README:** `hyoka/README.md`
+
+## Code Review Process
+
+1. **Submit PR** with `Closes #{issue}` in description
+2. **Address review comments** in follow-up commits
+3. **Ensure tests pass** (CI runs on PR)
+4. **Squash if requested** for history cleanliness
+5. **Merge to dev** (maintainer handles merge)
+
+## Release Workflow
+
+(Handled by maintainers)
+
+1. Tag release on `main` branch
+2. Create GitHub Release with changelog
+3. Upload binary artifacts
+
+## Resources
+
+- **Go stdlib docs:** https://pkg.go.dev/std
+- **Cobra docs:** https://cobra.dev
+- **slog guide:** https://pkg.go.dev/log/slog
+- **GitHub Copilot CLI docs:** https://github.com/cli/cli/wiki/GitHub-Copilot-CLI
+
+## Anti-Patterns
+
+- Working directly on `main` branch (use feature branches)
+- Committing without running `go test -race`
+- Leaving orphaned Copilot sessions (always run `hyoka clean`)
+- Skipping tests to speed up iteration (tests catch regressions)
+- Hardcoding paths or config names in code

--- a/.agents/skills/copilot-sdk-integration/SKILL.md
+++ b/.agents/skills/copilot-sdk-integration/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: "copilot-sdk-integration"
+description: "How hyoka uses the Copilot SDK"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/copilot.go"
+---
+
+## Context
+
+Hyoka integrates with the Copilot SDK to launch agent sessions (both for code generation and code review). The SDK provides session lifecycle management, tool invocation, and action history capture.
+
+## Session Lifecycle
+
+### Creation
+```go
+sess, err := SDK.NewSession(ctx, &SessionOptions{
+    Model: "claude-opus-4.6",
+    SystemPrompt: "You are an Azure SDK code generator...",
+    Tools: toolSet,
+    Skills: skillPaths,
+    MCPServers: mcpConfigs,
+    MaxTurns: 25,
+    MaxFiles: 50,
+    MaxOutputSize: 1MB,
+})
+```
+
+### Agent Turn Loop
+```go
+// Send initial prompt
+resp, err := sess.SendMessage(ctx, prompt)
+
+// Agent responds with actions (tool calls, file operations, etc)
+for action := range resp.Actions {
+    // Hyoka captures action metadata for timeline
+    timeline.Append(action)
+    
+    // Let SDK handle tool execution
+    result, err := sess.ExecuteAction(ctx, action)
+}
+
+// Repeat until agent stops or max turns reached
+```
+
+### Cleanup
+```go
+sess.Close()  // Kills Copilot process, cleans workspace
+```
+
+## Action Capture
+
+The SDK returns **SessionEventRecord** for each agent action:
+- Type: `tool_call`, `tool_result`, `file_read`, `file_write`, `bash_command`
+- Tool name, arguments, output
+- Duration, success/failure status
+- Turn number
+
+Hyoka maps these into **ActionEvent** for graders and reports.
+
+## Skills Integration
+
+Skills are **SKILL.md files** injected into the SDK session. They provide domain knowledge (e.g., Azure SDK patterns, Python conventions) without needing direct prompt modification.
+
+```yaml
+generator:
+  skills:
+    - type: local
+      path: ./skills/generator/**/*.md
+```
+
+The SDK concatenates skills into the system prompt at session creation.
+
+## MCP Server Integration
+
+MCP (Model Context Protocol) servers extend tool availability beyond built-in SDK tools.
+
+```yaml
+generator:
+  mcp_servers:
+    azure-cli:
+      type: command
+      command: /usr/bin/az
+      args: ["mcp", "run"]
+      tools: ["azure_resource_list"]
+```
+
+The SDK spawns the MCP server process and routes tool calls to it.
+
+## Timeout and Resource Monitoring
+
+- **Session timeout:** If agent doesn't respond within `--gen-timeout` (default 600s), SDK terminates
+- **Resource monitoring:** Optional per-config (via `--monitor-resources`), tracks CPU/memory per session
+- **Process tracking:** Hyoka tracks child PIDs for cleanup on interruption
+
+## Tool Result Feedback Loop
+
+After each tool execution:
+1. SDK captures result (stdout, stderr, exit code)
+2. Hyoka records in action timeline
+3. Result fed back to agent in next turn
+4. Agent continues or stops
+
+## Error Handling
+
+- **Tool not found:** Agent sees error, can adjust
+- **Tool timeout:** Reported to agent, can retry
+- **SDK session crash:** Entire eval marked as failed, workspace preserved for debugging
+
+## Code Locations
+
+- **Copilot SDK session management:** `hyoka/internal/eval/copilot.go`
+- **Action capture and timeline:** `hyoka/internal/eval/action.go`
+- **Engine integration:** `hyoka/internal/eval/engine.go` (orchestrates SDK calls)
+
+## Anti-Patterns
+
+- Modifying agent response mid-turn (let SDK handle tool execution)
+- Killing process without calling `sess.Close()` (orphans may remain)
+- Assuming all tools are available (check config tool filters)
+- Not capturing action timeline (required for graders and debugging)

--- a/.agents/skills/cross-squad/SKILL.md
+++ b/.agents/skills/cross-squad/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "cross-squad"
+description: "Coordinating work across multiple Squad instances"
+domain: "orchestration"
+confidence: "medium"
+source: "manual"
+tools:
+  - name: "squad-discover"
+    description: "List known squads and their capabilities"
+    when: "When you need to find which squad can handle a task"
+  - name: "squad-delegate"
+    description: "Create work in another squad's repository"
+    when: "When a task belongs to another squad's domain"
+---
+
+## Context
+When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
+
+Cross-squad orchestration applies when:
+- A task requires capabilities owned by another squad
+- An architectural decision affects multiple squads
+- A feature spans multiple repositories with different squads
+- A squad needs to request infrastructure, tooling, or support from another squad
+
+## Patterns
+
+### Discovery via Manifest
+Each squad publishes a `.squad/manifest.json` declaring its name, capabilities, and contact information. Squads discover each other through:
+1. **Well-known paths**: Check `.squad/manifest.json` in known org repos
+2. **Upstream config**: Squads already listed in `.squad/upstream.json` are checked for manifests
+3. **Explicit registry**: A central `squad-registry.json` can list all squads in an org
+
+```json
+{
+  "name": "platform-squad",
+  "version": "1.0.0",
+  "description": "Platform infrastructure team",
+  "capabilities": ["kubernetes", "helm", "monitoring", "ci-cd"],
+  "contact": {
+    "repo": "org/platform",
+    "labels": ["squad:platform"]
+  },
+  "accepts": ["issues", "prs"],
+  "skills": ["helm-developer", "operator-developer", "pipeline-engineer"]
+}
+```
+
+### Context Sharing
+When delegating work, share only what the target squad needs:
+- **Capability list**: What this squad can do (from manifest)
+- **Relevant decisions**: Only decisions that affect the target squad
+- **Handoff context**: A concise description of why this work is being delegated
+
+Do NOT share:
+- Internal team state (casting history, session logs)
+- Full decision archives (send only relevant excerpts)
+- Authentication credentials or secrets
+
+### Work Handoff Protocol
+1. **Check manifest**: Verify the target squad accepts the work type (issues, PRs)
+2. **Create issue**: Use `gh issue create` in the target repo with:
+   - Title: `[cross-squad] <description>`
+   - Label: `squad:cross-squad` (or the squad's configured label)
+   - Body: Context, acceptance criteria, and link back to originating issue
+3. **Track**: Record the cross-squad issue URL in the originating squad's orchestration log
+4. **Poll**: Periodically check if the delegated issue is closed/completed
+
+### Feedback Loop
+Track delegated work completion:
+- Poll target issue status via `gh issue view`
+- Update originating issue with status changes
+- Close the feedback loop when delegated work merges
+
+## Examples
+
+### Discovering squads
+```bash
+# List all squads discoverable from upstreams and known repos
+squad discover
+
+# Output:
+#   platform-squad  →  org/platform  (kubernetes, helm, monitoring)
+#   frontend-squad  →  org/frontend  (react, nextjs, storybook)
+#   data-squad      →  org/data      (spark, airflow, dbt)
+```
+
+### Delegating work
+```bash
+# Delegate a task to the platform squad
+squad delegate platform-squad "Add Prometheus metrics endpoint for the auth service"
+
+# Creates issue in org/platform with cross-squad label and context
+```
+
+### Manifest in squad.config.ts
+```typescript
+export default defineSquad({
+  manifest: {
+    name: 'platform-squad',
+    capabilities: ['kubernetes', 'helm'],
+    contact: { repo: 'org/platform', labels: ['squad:platform'] },
+    accepts: ['issues', 'prs'],
+    skills: ['helm-developer', 'operator-developer'],
+  },
+});
+```
+
+## Anti-Patterns
+- **Direct file writes across repos** — Never modify another squad's `.squad/` directory. Use issues and PRs as the communication protocol.
+- **Tight coupling** — Don't depend on another squad's internal structure. Use the manifest as the public API contract.
+- **Unbounded delegation** — Always include acceptance criteria and a timeout. Don't create open-ended requests.
+- **Skipping discovery** — Don't hardcode squad locations. Use manifests and the discovery protocol.
+- **Sharing secrets** — Never include credentials, tokens, or internal URLs in cross-squad issues.
+- **Circular delegation** — Track delegation chains. If squad A delegates to B which delegates back to A, something is wrong.

--- a/.agents/skills/distributed-mesh/SKILL.md
+++ b/.agents/skills/distributed-mesh/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: "distributed-mesh"
+description: "How to coordinate with squads on different machines using git as transport"
+domain: "distributed-coordination"
+confidence: "high"
+source: "multi-model-consensus (Opus 4.6, Sonnet 4.5, GPT-5.4)"
+---
+
+## SCOPE
+
+**✅ THIS SKILL PRODUCES (exactly these, nothing more):**
+
+1. **`mesh.json`** — Generated from user answers about zones and squads (which squads participate, what zone each is in, paths/URLs for each), using `mesh.json.example` in this skill's directory as the schema template
+2. **`sync-mesh.sh` and `sync-mesh.ps1`** — Copied from this skill's directory into the project root (these are bundled resources, NOT generated code)
+3. **Zone 2 state repo initialization** (if applicable) — If the user specified a Zone 2 shared state repo, run `sync-mesh.sh --init` to scaffold the state repo structure
+4. **A decision entry** in `.squad/decisions/inbox/` documenting the mesh configuration for team awareness
+
+**❌ THIS SKILL DOES NOT PRODUCE:**
+
+- **No application code** — No validators, libraries, or modules of any kind
+- **No test files** — No test suites, test cases, or test scaffolding
+- **No GENERATING sync scripts** — They are bundled with this skill as pre-built resources. COPY them, don't generate them.
+- **No daemons or services** — No background processes, servers, or persistent runtimes
+- **No modifications to existing squad files** beyond the decision entry (no changes to team.md, routing.md, agent charters, etc.)
+
+**Your role:** Configure the mesh topology and install the bundled sync scripts. Nothing more.
+
+## Context
+
+When squads are on different machines (developer laptops, CI runners, cloud VMs, partner orgs), the local file-reading convention still works — but remote files need to arrive on your disk first. This skill teaches the pattern for distributed squad communication.
+
+**When this applies:**
+- Squads span multiple machines, VMs, or CI runners
+- Squads span organizations or companies
+- An agent needs context from a squad whose files aren't on the local filesystem
+
+**When this does NOT apply:**
+- All squads are on the same machine (just read the files directly)
+
+## Patterns
+
+### The Core Principle
+
+> "The filesystem is the mesh, and git is how the mesh crosses machine boundaries."
+
+The agent interface never changes. Agents always read local files. The distributed layer's only job is to make remote files appear locally before the agent reads them.
+
+### Three Zones of Communication
+
+**Zone 1 — Local:** Same filesystem. Read files directly. Zero transport.
+
+**Zone 2 — Remote-Trusted:** Different host, same org, shared git auth. Transport: `git pull` from a shared repo. This collapses Zone 2 into Zone 1 — files materialize on disk, agent reads them normally.
+
+**Zone 3 — Remote-Opaque:** Different org, no shared auth. Transport: `curl` to fetch published contracts (SUMMARY.md). One-way visibility — you see only what they publish.
+
+### Agent Lifecycle (Distributed)
+
+```
+1. SYNC:    git pull (Zone 2) + curl (Zone 3) — materialize remote state
+2. READ:    cat .mesh/**/state.md — all files are local now
+3. WORK:    do their assigned work (the agent's normal task, NOT mesh-building)
+4. WRITE:   update own billboard, log, drops
+5. PUBLISH: git add + commit + push — share state with remote peers
+```
+
+Steps 2–4 are identical to local-only. Steps 1 and 5 are the entire distributed extension. **Note:** "WORK" means the agent performs its normal squad duties — it does NOT mean "build mesh infrastructure."
+
+### The mesh.json Config
+
+```json
+{
+  "squads": {
+    "auth-squad": { "zone": "local", "path": "../auth-squad/.mesh" },
+    "ci-squad": {
+      "zone": "remote-trusted",
+      "source": "git@github.com:our-org/ci-squad.git",
+      "ref": "main",
+      "sync_to": ".mesh/remotes/ci-squad"
+    },
+    "partner-fraud": {
+      "zone": "remote-opaque",
+      "source": "https://partner.dev/squad-contracts/fraud/SUMMARY.md",
+      "sync_to": ".mesh/remotes/partner-fraud",
+      "auth": "bearer"
+    }
+  }
+}
+```
+
+Three zone types, one file. Local squads need only a path. Remote-trusted need a git URL. Remote-opaque need an HTTP URL.
+
+### Write Partitioning
+
+Each squad writes only to its own directory (`boards/{self}.md`, `squads/{self}/*`, `drops/{date}-{self}-*.md`). No two squads write to the same file. Git push/pull never conflicts. If push fails ("branch is behind"), the fix is always `git pull --rebase && git push`.
+
+### Trust Boundaries
+
+Trust maps to git permissions:
+- **Same repo access** = full mesh visibility
+- **Read-only access** = can observe, can't write
+- **No access** = invisible (correct behavior)
+
+For selective visibility, use separate repos per audience (internal, partner, public). Git permissions ARE the trust negotiation.
+
+### Phased Rollout
+
+- **Phase 0:** Convention only — document zones, agree on mesh.json fields, manually run `git pull`/`git push`. Zero new code.
+- **Phase 1:** Sync script (~30 lines bash or PowerShell) when manual sync gets tedious.
+- **Phase 2:** Published contracts + curl fetch when a Zone 3 partner appears.
+- **Phase 3:** Never. No MCP federation, A2A, service discovery, message queues.
+
+**Important:** Phases are NOT auto-advanced. These are project-level decisions — you start at Phase 0 (manual sync) and only move forward when the team decides complexity is justified.
+
+### Mesh State Repo
+
+The shared mesh state repo is a plain git repository — NOT a Squad project. It holds:
+- One directory per participating squad
+- Each directory contains at minimum a SUMMARY.md with the squad's current state
+- A root README explaining what the repo is and who participates
+
+No `.squad/` folder, no agents, no automation. Write partitioning means each squad only pushes to its own directory. The repo is a rendezvous point, not an intelligent system.
+
+If you want a squad that *observes* mesh health, that's a separate Squad project that lists the state repo as a Zone 2 remote in its `mesh.json` — it does NOT live inside the state repo.
+
+## Examples
+
+### Developer Laptop + CI Squad (Zone 2)
+
+Auth-squad agent wakes up. `git pull` brings ci-squad's latest results. Agent reads: "3 test failures in auth module." Adjusts work. Pushes results when done. **Overhead: one `git pull`, one `git push`.**
+
+### Two Orgs Collaborating (Zone 3)
+
+Payment-squad fetches partner's published SUMMARY.md via curl. Reads: "Risk scoring v3 API deprecated April 15. New field `device_fingerprint` required." The consuming agent (in payment-squad's team) reads this information and uses it to inform its work — for example, updating payment integration code to include the new field. Partner can't see payment-squad's internals.
+
+### Same Org, Shared Mesh Repo (Zone 2)
+
+Three squads on different machines. One shared git repo holds the mesh. Each squad: `git pull` before work, `git push` after. Write partitioning ensures zero merge conflicts.
+
+## AGENT WORKFLOW (Deterministic Setup)
+
+When a user invokes this skill to set up a distributed mesh, follow these steps **exactly, in order:**
+
+### Step 1: ASK the user for mesh topology
+
+Ask these questions (adapt phrasing naturally, but get these answers):
+
+1. **Which squads are participating?** (List of squad names)
+2. **For each squad, which zone is it in?**
+   - `local` — same filesystem (just need a path)
+   - `remote-trusted` — different machine, same org, shared git access (need git URL + ref)
+   - `remote-opaque` — different org, no shared auth (need HTTPS URL to published contract)
+3. **For each squad, what's the connection info?**
+   - Local: relative or absolute path to their `.mesh/` directory
+   - Remote-trusted: git URL (SSH or HTTPS), ref (branch/tag), and where to sync it to locally
+   - Remote-opaque: HTTPS URL to their SUMMARY.md, where to sync it, and auth type (none/bearer)
+4. **Where should the shared state live?** (For Zone 2 squads: git repo URL for the mesh state, or confirm each squad syncs independently)
+
+### Step 2: GENERATE `mesh.json`
+
+Using the answers from Step 1, create a `mesh.json` file at the project root. Use `mesh.json.example` from THIS skill's directory (`.squad/skills/distributed-mesh/mesh.json.example`) as the schema template.
+
+Structure:
+
+```json
+{
+  "squads": {
+    "<squad-name>": { "zone": "local", "path": "<relative-or-absolute-path>" },
+    "<squad-name>": {
+      "zone": "remote-trusted",
+      "source": "<git-url>",
+      "ref": "<branch-or-tag>",
+      "sync_to": ".mesh/remotes/<squad-name>"
+    },
+    "<squad-name>": {
+      "zone": "remote-opaque",
+      "source": "<https-url-to-summary>",
+      "sync_to": ".mesh/remotes/<squad-name>",
+      "auth": "<none|bearer>"
+    }
+  }
+}
+```
+
+Write this file to the project root. Do NOT write any other code.
+
+### Step 3: COPY sync scripts
+
+Copy the bundled sync scripts from THIS skill's directory into the project root:
+
+- **Source:** `.squad/skills/distributed-mesh/sync-mesh.sh`
+- **Destination:** `sync-mesh.sh` (project root)
+
+- **Source:** `.squad/skills/distributed-mesh/sync-mesh.ps1`
+- **Destination:** `sync-mesh.ps1` (project root)
+
+These are bundled resources. Do NOT generate them — COPY them directly.
+
+### Step 4: RUN `--init` (if Zone 2 state repo exists)
+
+If the user specified a Zone 2 shared state repo in Step 1, run the initialization:
+
+**On Unix/Linux/macOS:**
+```bash
+bash sync-mesh.sh --init
+```
+
+**On Windows:**
+```powershell
+.\sync-mesh.ps1 -Init
+```
+
+This scaffolds the state repo structure (squad directories, placeholder SUMMARY.md files, root README).
+
+**Skip this step if:**
+- No Zone 2 squads are configured (local/opaque only)
+- The state repo already exists and is initialized
+
+### Step 5: WRITE a decision entry
+
+Create a decision file at `.squad/decisions/inbox/<your-agent-name>-mesh-setup.md` with this content:
+
+```markdown
+### <YYYY-MM-DD>: Mesh configuration
+
+**By:** <your-agent-name> (via distributed-mesh skill)
+
+**What:** Configured distributed mesh with <N> squads across zones <list-zones-used>
+
+**Squads:**
+- `<squad-name>` — Zone <X> — <brief-connection-info>
+- `<squad-name>` — Zone <X> — <brief-connection-info>
+- ...
+
+**State repo:** <git-url-if-zone-2-used, or "N/A (local/opaque only)">
+
+**Why:** <user's stated reason for setting up the mesh, or "Enable cross-machine squad coordination">
+```
+
+Write this file. The Scribe will merge it into the main decisions file later.
+
+### Step 6: STOP
+
+**You are done.** Do not:
+- Generate sync scripts (they're bundled with this skill — COPY them)
+- Write validator code
+- Write test files
+- Create any other modules, libraries, or application code
+- Modify existing squad files (team.md, routing.md, charters)
+- Auto-advance to Phase 2 or Phase 3
+
+Output a simple completion message:
+
+```
+✅ Mesh configured. Created:
+- mesh.json (<N> squads)
+- sync-mesh.sh and sync-mesh.ps1 (copied from skill bundle)
+- Decision entry: .squad/decisions/inbox/<filename>
+
+Run `bash sync-mesh.sh` (or `.\sync-mesh.ps1` on Windows) before agents start to materialize remote state.
+```
+
+---
+
+## Anti-Patterns
+
+**❌ Code generation anti-patterns:**
+- Writing `mesh-config-validator.js` or any validator module
+- Writing test files for mesh configuration
+- Generating sync scripts instead of copying the bundled ones from this skill's directory
+- Creating library modules or utilities
+- Building any code that "runs the mesh" — the mesh is read by agents, not executed
+
+**❌ Architectural anti-patterns:**
+- Building a federation protocol — Git push/pull IS federation
+- Running a sync daemon or server — Agents are not persistent. Sync at startup, publish at shutdown
+- Real-time notifications — Agents don't need real-time. They need "recent enough." `git pull` is recent enough
+- Schema validation for markdown — The LLM reads markdown. If the format changes, it adapts
+- Service discovery protocol — mesh.json is a file with 10 entries. Not a "discovery problem"
+- Auth framework — Git SSH keys and HTTPS tokens. Not a framework. Already configured
+- Message queues / event buses — Agents wake, read, work, write, sleep. Nobody's home to receive events
+- Any component requiring a running process — That's the line. Don't cross it
+
+**❌ Scope creep anti-patterns:**
+- Auto-advancing phases without user decision
+- Modifying agent charters or routing rules
+- Setting up CI/CD pipelines for mesh sync
+- Creating dashboards or monitoring tools

--- a/.agents/skills/distributed-mesh/mesh.json.example
+++ b/.agents/skills/distributed-mesh/mesh.json.example
@@ -1,0 +1,30 @@
+{
+  "squads": {
+    "auth-squad": {
+      "zone": "local",
+      "path": "../auth-squad/.mesh"
+    },
+    "api-squad": {
+      "zone": "local",
+      "path": "../api-squad/.mesh"
+    },
+    "ci-squad": {
+      "zone": "remote-trusted",
+      "source": "git@github.com:our-org/ci-squad.git",
+      "ref": "main",
+      "sync_to": ".mesh/remotes/ci-squad"
+    },
+    "data-squad": {
+      "zone": "remote-trusted",
+      "source": "git@github.com:our-org/data-pipeline.git",
+      "ref": "main",
+      "sync_to": ".mesh/remotes/data-squad"
+    },
+    "partner-fraud": {
+      "zone": "remote-opaque",
+      "source": "https://partner.example.com/squad-contracts/fraud/SUMMARY.md",
+      "sync_to": ".mesh/remotes/partner-fraud",
+      "auth": "bearer"
+    }
+  }
+}

--- a/.agents/skills/distributed-mesh/sync-mesh.ps1
+++ b/.agents/skills/distributed-mesh/sync-mesh.ps1
@@ -1,0 +1,111 @@
+# sync-mesh.ps1 — Materialize remote squad state locally
+#
+# Reads mesh.json, fetches remote squads into local directories.
+# Run before agent reads. No daemon. No service. ~40 lines.
+#
+# Usage: .\sync-mesh.ps1 [path-to-mesh.json]
+#        .\sync-mesh.ps1 -Init [path-to-mesh.json]
+# Requires: git
+param(
+    [switch]$Init,
+    [string]$MeshJson = "mesh.json"
+)
+$ErrorActionPreference = "Stop"
+
+# Handle -Init mode
+if ($Init) {
+    if (-not (Test-Path $MeshJson)) {
+        Write-Host "❌ $MeshJson not found"
+        exit 1
+    }
+    
+    Write-Host "🚀 Initializing mesh state repository..."
+    $config = Get-Content $MeshJson -Raw | ConvertFrom-Json
+    $squads = $config.squads.PSObject.Properties.Name
+    
+    # Create squad directories with placeholder SUMMARY.md
+    foreach ($squad in $squads) {
+        if (-not (Test-Path $squad)) {
+            New-Item -ItemType Directory -Path $squad | Out-Null
+            Write-Host "  ✓ Created $squad/"
+        } else {
+            Write-Host "  • $squad/ exists (skipped)"
+        }
+        
+        $summaryPath = "$squad/SUMMARY.md"
+        if (-not (Test-Path $summaryPath)) {
+            "# $squad`n`n_No state published yet._" | Set-Content $summaryPath
+            Write-Host "  ✓ Created $summaryPath"
+        } else {
+            Write-Host "  • $summaryPath exists (skipped)"
+        }
+    }
+    
+    # Generate root README.md
+    if (-not (Test-Path "README.md")) {
+        $readme = @"
+# Squad Mesh State Repository
+
+This repository tracks published state from participating squads.
+
+## Participating Squads
+
+"@
+        foreach ($squad in $squads) {
+            $zone = $config.squads.$squad.zone
+            $readme += "- **$squad** (Zone: $zone)`n"
+        }
+        $readme += @"
+
+Each squad directory contains a ``SUMMARY.md`` with their latest published state.
+State is synchronized using ``sync-mesh.sh`` or ``sync-mesh.ps1``.
+"@
+        $readme | Set-Content "README.md"
+        Write-Host "  ✓ Created README.md"
+    } else {
+        Write-Host "  • README.md exists (skipped)"
+    }
+    
+    Write-Host ""
+    Write-Host "✅ Mesh state repository initialized"
+    exit 0
+}
+
+$config = Get-Content $MeshJson -Raw | ConvertFrom-Json
+
+# Zone 2: Remote-trusted — git clone/pull
+foreach ($entry in $config.squads.PSObject.Properties | Where-Object { $_.Value.zone -eq "remote-trusted" }) {
+    $squad  = $entry.Name
+    $source = $entry.Value.source
+    $ref    = if ($entry.Value.ref) { $entry.Value.ref } else { "main" }
+    $target = $entry.Value.sync_to
+
+    if (Test-Path "$target/.git") {
+        git -C $target pull --rebase --quiet 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Host "⚠ ${squad}: pull failed (using stale)" }
+    } else {
+        New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
+        git clone --quiet --depth 1 --branch $ref $source $target 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Host "⚠ ${squad}: clone failed (unavailable)" }
+    }
+}
+
+# Zone 3: Remote-opaque — fetch published contracts
+foreach ($entry in $config.squads.PSObject.Properties | Where-Object { $_.Value.zone -eq "remote-opaque" }) {
+    $squad  = $entry.Name
+    $source = $entry.Value.source
+    $target = $entry.Value.sync_to
+    $auth   = $entry.Value.auth
+
+    New-Item -ItemType Directory -Force -Path $target | Out-Null
+    $params = @{ Uri = $source; OutFile = "$target/SUMMARY.md"; UseBasicParsing = $true }
+    if ($auth -eq "bearer") {
+        $tokenVar = ($squad.ToUpper() -replace '-', '_') + "_TOKEN"
+        $token = [Environment]::GetEnvironmentVariable($tokenVar)
+        if ($token) { $params.Headers = @{ Authorization = "Bearer $token" } }
+    }
+    try { Invoke-WebRequest @params -ErrorAction Stop }
+    catch { "# ${squad} — unavailable ($(Get-Date))" | Set-Content "$target/SUMMARY.md" }
+}
+
+Write-Host "✓ Mesh sync complete"

--- a/.agents/skills/distributed-mesh/sync-mesh.sh
+++ b/.agents/skills/distributed-mesh/sync-mesh.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# sync-mesh.sh — Materialize remote squad state locally
+#
+# Reads mesh.json, fetches remote squads into local directories.
+# Run before agent reads. No daemon. No service. ~40 lines.
+#
+# Usage: ./sync-mesh.sh [path-to-mesh.json]
+#        ./sync-mesh.sh --init [path-to-mesh.json]
+# Requires: jq (https://github.com/jqlang/jq), git, curl
+
+set -euo pipefail
+
+# Handle --init mode
+if [ "${1:-}" = "--init" ]; then
+  MESH_JSON="${2:-mesh.json}"
+  
+  if [ ! -f "$MESH_JSON" ]; then
+    echo "❌ $MESH_JSON not found"
+    exit 1
+  fi
+  
+  echo "🚀 Initializing mesh state repository..."
+  squads=$(jq -r '.squads | keys[]' "$MESH_JSON")
+  
+  # Create squad directories with placeholder SUMMARY.md
+  for squad in $squads; do
+    if [ ! -d "$squad" ]; then
+      mkdir -p "$squad"
+      echo "  ✓ Created $squad/"
+    else
+      echo "  • $squad/ exists (skipped)"
+    fi
+    
+    if [ ! -f "$squad/SUMMARY.md" ]; then
+      echo -e "# $squad\n\n_No state published yet._" > "$squad/SUMMARY.md"
+      echo "  ✓ Created $squad/SUMMARY.md"
+    else
+      echo "  • $squad/SUMMARY.md exists (skipped)"
+    fi
+  done
+  
+  # Generate root README.md
+  if [ ! -f "README.md" ]; then
+    {
+      echo "# Squad Mesh State Repository"
+      echo ""
+      echo "This repository tracks published state from participating squads."
+      echo ""
+      echo "## Participating Squads"
+      echo ""
+      for squad in $squads; do
+        zone=$(jq -r ".squads.\"$squad\".zone" "$MESH_JSON")
+        echo "- **$squad** (Zone: $zone)"
+      done
+      echo ""
+      echo "Each squad directory contains a \`SUMMARY.md\` with their latest published state."
+      echo "State is synchronized using \`sync-mesh.sh\` or \`sync-mesh.ps1\`."
+    } > README.md
+    echo "  ✓ Created README.md"
+  else
+    echo "  • README.md exists (skipped)"
+  fi
+  
+  echo ""
+  echo "✅ Mesh state repository initialized"
+  exit 0
+fi
+
+MESH_JSON="${1:-mesh.json}"
+
+# Zone 2: Remote-trusted — git clone/pull
+for squad in $(jq -r '.squads | to_entries[] | select(.value.zone == "remote-trusted") | .key' "$MESH_JSON"); do
+  source=$(jq -r ".squads.\"$squad\".source" "$MESH_JSON")
+  ref=$(jq -r ".squads.\"$squad\".ref // \"main\"" "$MESH_JSON")
+  target=$(jq -r ".squads.\"$squad\".sync_to" "$MESH_JSON")
+
+  if [ -d "$target/.git" ]; then
+    git -C "$target" pull --rebase --quiet 2>/dev/null \
+      || echo "⚠ $squad: pull failed (using stale)"
+  else
+    mkdir -p "$(dirname "$target")"
+    git clone --quiet --depth 1 --branch "$ref" "$source" "$target" 2>/dev/null \
+      || echo "⚠ $squad: clone failed (unavailable)"
+  fi
+done
+
+# Zone 3: Remote-opaque — fetch published contracts
+for squad in $(jq -r '.squads | to_entries[] | select(.value.zone == "remote-opaque") | .key' "$MESH_JSON"); do
+  source=$(jq -r ".squads.\"$squad\".source" "$MESH_JSON")
+  target=$(jq -r ".squads.\"$squad\".sync_to" "$MESH_JSON")
+  auth=$(jq -r ".squads.\"$squad\".auth // \"\"" "$MESH_JSON")
+
+  mkdir -p "$target"
+  auth_flag=""
+  if [ "$auth" = "bearer" ]; then
+    token_var="$(echo "${squad}" | tr '[:lower:]-' '[:upper:]_')_TOKEN"
+    [ -n "${!token_var:-}" ] && auth_flag="--header \"Authorization: Bearer ${!token_var}\""
+  fi
+
+  eval curl --silent --fail $auth_flag "$source" -o "$target/SUMMARY.md" 2>/dev/null \
+    || echo "# ${squad} — unavailable ($(date))" > "$target/SUMMARY.md"
+done
+
+echo "✓ Mesh sync complete"

--- a/.agents/skills/docs-standards/SKILL.md
+++ b/.agents/skills/docs-standards/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: "docs-standards"
+description: "Microsoft Style Guide + Squad-specific documentation patterns"
+domain: "documentation"
+confidence: "high"
+source: "earned (PAO charter, multiple doc PR reviews)"
+---
+
+## Context
+
+Squad documentation follows the Microsoft Style Guide with Squad-specific conventions. Consistency across docs builds trust and improves discoverability.
+
+## Patterns
+
+### Microsoft Style Guide Rules
+- **Sentence-case headings:** "Getting started" not "Getting Started"
+- **Active voice:** "Run the command" not "The command should be run"
+- **Second person:** "You can configure..." not "Users can configure..."
+- **Present tense:** "The system routes..." not "The system will route..."
+- **No ampersands in prose:** "and" not "&" (except in code, brand names, or UI elements)
+
+### Squad Formatting Patterns
+- **Scannability first:** Paragraphs for narrative (3-4 sentences max), bullets for scannable lists, tables for structured data
+- **"Try this" prompts at top:** Start feature/scenario pages with practical prompts users can copy
+- **Experimental warnings:** Features in preview get callout at top
+- **Cross-references at bottom:** Related pages linked after main content
+
+### Structure
+- **Title (H1)** → **Warning/callout** → **Try this code** → **Overview** → **HR** → **Content (H2 sections)**
+
+### Test Sync Rule
+- **Always update test assertions:** When adding docs pages to `features/`, `scenarios/`, `guides/`, update corresponding `EXPECTED_*` arrays in `test/docs-build.test.ts` in the same commit
+
+## Examples
+
+✓ **Correct:**
+```markdown
+# Getting started with Squad
+
+> ⚠️ **Experimental:** This feature is in preview.
+
+Try this:
+\`\`\`bash
+squad init
+\`\`\`
+
+Squad helps you build AI teams...
+
+---
+
+## Install Squad
+
+Run the following command...
+```
+
+✗ **Incorrect:**
+```markdown
+# Getting Started With Squad  // Title case
+
+Squad is a tool which will help users... // Third person, future tense
+
+You can install Squad with npm & configure it... // Ampersand in prose
+```
+
+## Anti-Patterns
+
+- Title-casing headings because "it looks nicer"
+- Writing in passive voice or third person
+- Long paragraphs of dense text (breaks scannability)
+- Adding doc pages without updating test assertions
+- Using ampersands outside code blocks

--- a/.agents/skills/economy-mode/SKILL.md
+++ b/.agents/skills/economy-mode/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "economy-mode"
+description: "Shifts Layer 3 model selection to cost-optimized alternatives when economy mode is active."
+domain: "model-selection"
+confidence: "low"
+source: "manual"
+---
+
+## SCOPE
+
+✅ THIS SKILL PRODUCES:
+- A modified Layer 3 model selection table applied when economy mode is active
+- `economyMode: true` written to `.squad/config.json` when activated persistently
+- Spawn acknowledgments with `💰` indicator when economy mode is active
+
+❌ THIS SKILL DOES NOT PRODUCE:
+- Code, tests, or documentation
+- Cost reports or billing artifacts
+- Changes to Layer 0, Layer 1, or Layer 2 resolution (user intent always wins)
+
+## Context
+
+Economy mode shifts Layer 3 (Task-Aware Auto-Selection) to lower-cost alternatives. It does NOT override persistent config (`defaultModel`, `agentModelOverrides`) or per-agent charter preferences — those represent explicit user intent and always take priority.
+
+Use this skill when the user wants to reduce costs across an entire session or permanently, without manually specifying models for each agent.
+
+## Activation Methods
+
+| Method | How |
+|--------|-----|
+| Session phrase | "use economy mode", "save costs", "go cheap", "reduce costs" |
+| Persistent config | `"economyMode": true` in `.squad/config.json` |
+| CLI flag | `squad --economy` |
+
+**Deactivation:** "turn off economy mode", "disable economy mode", or remove `economyMode` from `config.json`.
+
+## Economy Model Selection Table
+
+When economy mode is **active**, Layer 3 auto-selection uses this table instead of the normal defaults:
+
+| Task Output | Normal Mode | Economy Mode |
+|-------------|-------------|--------------|
+| Writing code (implementation, refactoring, bug fixes) | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
+| Writing prompts or agent designs | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
+| Docs, planning, triage, changelogs, mechanical ops | `claude-haiku-4.5` | `gpt-4.1` or `gpt-5-mini` |
+| Architecture, code review, security audits | `claude-opus-4.5` | `claude-sonnet-4.5` |
+| Scribe / logger / mechanical file ops | `claude-haiku-4.5` | `gpt-4.1` |
+
+**Prefer `gpt-4.1` over `gpt-5-mini`** when the task involves structured output or agentic tool use. Prefer `gpt-5-mini` for pure text generation tasks where latency matters.
+
+## AGENT WORKFLOW
+
+### On Session Start
+
+1. READ `.squad/config.json`
+2. CHECK for `economyMode: true` — if present, activate economy mode for the session
+3. STORE economy mode state in session context
+
+### On User Phrase Trigger
+
+**Session-only (no config change):** "use economy mode", "save costs", "go cheap"
+
+1. SET economy mode active for this session
+2. ACKNOWLEDGE: `✅ Economy mode active — using cost-optimized models this session. (Layer 0 and Layer 2 preferences still apply)`
+
+**Persistent:** "always use economy mode", "save economy mode"
+
+1. WRITE `economyMode: true` to `.squad/config.json` (merge, don't overwrite other fields)
+2. ACKNOWLEDGE: `✅ Economy mode saved — cost-optimized models will be used until disabled.`
+
+### On Every Agent Spawn (Economy Mode Active)
+
+1. CHECK Layer 0a/0b first (agentModelOverrides, defaultModel) — if set, use that. Economy mode does NOT override Layer 0.
+2. CHECK Layer 1 (session directive for a specific model) — if set, use that. Economy mode does NOT override explicit session directives.
+3. CHECK Layer 2 (charter preference) — if set, use that. Economy mode does NOT override charter preferences.
+4. APPLY economy table at Layer 3 instead of normal table.
+5. INCLUDE `💰` in spawn acknowledgment: `🔧 {Name} ({model} · 💰 economy) — {task}`
+
+### On Deactivation
+
+**Trigger phrases:** "turn off economy mode", "disable economy mode", "use normal models"
+
+1. REMOVE `economyMode` from `.squad/config.json` (if it was persisted)
+2. CLEAR session economy mode state
+3. ACKNOWLEDGE: `✅ Economy mode disabled — returning to standard model selection.`
+
+### STOP
+
+After updating economy mode state and including the `💰` indicator in spawn acknowledgments, this skill is done. Do NOT:
+- Change Layer 0, Layer 1, or Layer 2 model choices
+- Override charter-specified models
+- Generate cost reports or comparisons
+- Fall back to premium models via economy mode (economy mode never bumps UP)
+
+## Config Schema
+
+`.squad/config.json` economy-related fields:
+
+```json
+{
+  "version": 1,
+  "economyMode": true
+}
+```
+
+- `economyMode` — when `true`, Layer 3 uses the economy table. Optional; absent = economy mode off.
+- Combines with `defaultModel` and `agentModelOverrides` — Layer 0 always wins.
+
+## Anti-Patterns
+
+- **Don't override Layer 0 in economy mode.** If the user set `defaultModel: "claude-opus-4.6"`, they want quality. Economy mode only affects Layer 3 auto-selection.
+- **Don't silently apply economy mode.** Always acknowledge when activated or deactivated.
+- **Don't treat economy mode as permanent by default.** Session phrases activate session-only; only "always" or `config.json` persist it.
+- **Don't bump premium tasks down too far.** Architecture and security reviews shift from opus to sonnet in economy mode — they do NOT go to fast/cheap models.

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "error-handling"
+description: "Return errors up, no log-and-return, %w wrapping"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/eval/engine.go, hyoka/internal/config/config.go patterns"
+---
+
+## Context
+
+Hyoka follows Go's idiomatic error handling pattern: errors bubble up the call stack, and are logged at the top level (in CLI commands). This separation of concerns makes the codebase testable and keeps error flows explicit.
+
+## Patterns
+
+### Return Errors Up (No Log-and-Return)
+
+**✓ Correct:**
+```go
+// In internal function
+func loadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config: %w", err)  // Wrap and return
+    }
+    // ...
+}
+
+// In CLI command (top level)
+func Execute() error {
+    cfg, err := loadConfig(cfgPath)
+    if err != nil {
+        slog.Error("Failed to load config", "error", err)  // Log once at top
+        return err
+    }
+    // ...
+}
+```
+
+**✗ Incorrect:**
+```go
+// Internal function logs AND returns
+func loadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        slog.Error("Failed to read config", "error", err)  // Wrong: logging here
+        return nil, err
+    }
+}
+```
+
+### Error Wrapping with `%w`
+
+Always wrap lower-level errors with `%w` to preserve the error chain. This enables `errors.Is()` and `errors.As()` in caller code.
+
+**✓ Correct:**
+```go
+if err != nil {
+    return fmt.Errorf("failed to build project: %w", err)
+}
+
+// Caller can inspect the chain
+if errors.Is(err, os.ErrNotExist) {
+    // Handle missing file
+}
+```
+
+**✗ Incorrect:**
+```go
+if err != nil {
+    return fmt.Errorf("failed to build project: %v", err)  // Loses error chain
+}
+```
+
+### Context in Error Messages
+
+Provide actionable context at the point where error is wrapped, not repeated at logging.
+
+**✓ Correct:**
+```go
+// In eval engine
+if err := runGrader(ctx, grader); err != nil {
+    return fmt.Errorf("grade with %q: %w", grader.Name(), err)
+}
+
+// In CLI command
+if err != nil {
+    slog.Error("Evaluation failed", "error", err)  // Message says what failed, details in error chain
+}
+```
+
+## Anti-Patterns
+
+- Logging at multiple levels (log once at top-level CLI)
+- Using `%v` instead of `%w` for error wrapping
+- Ignoring errors silently with `_ = someFunc()`
+- Returning `nil` error when error occurred
+- Logging and then returning without wrapping
+
+## Related Code Locations
+
+- **Error wrapping examples:** `hyoka/internal/eval/engine.go`
+- **CLI error handling:** `hyoka/cmd/*.go`
+- **Logging configuration:** `hyoka/internal/logging/`

--- a/.agents/skills/eval-pipeline/SKILL.md
+++ b/.agents/skills/eval-pipeline/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: "eval-pipeline"
+description: "How the eval engine works: generate → grade → report"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/engine.go, architecture.md"
+---
+
+## Context
+
+The evaluation pipeline is the core workflow of hyoka. It orchestrates AI agent code generation, multi-model grading, and report generation. Understanding the pipeline is essential for debugging eval failures and extending the engine.
+
+## Pipeline Phases
+
+### 1. Generation Phase
+- **Input:** Prompt (with service, language, plane metadata)
+- **Process:** 
+  - Creates a workspace (temporary directory)
+  - Launches Copilot SDK session with generator model
+  - Injects skills and MCP servers from config
+  - Runs max 25 turns (configurable via `--max-session-actions`)
+  - Captures all tool calls, file reads/writes, and stdout
+- **Output:** Generated code + action timeline
+
+### 2. Build Verification Phase (optional)
+- **Input:** Generated code
+- **Process:**
+  - Runs language-specific build command (e.g., `cargo build` for Rust)
+  - Collects stderr/stdout for report
+  - Marks success/failure
+- **Output:** Build status + logs
+
+### 3. Grading Phase
+- **Input:** Generated code + action timeline + config
+- **Process:**
+  - Runs 6 pluggable grader types independently
+  - Each grader inspects code/timeline and scores against criteria
+  - Collects all grader results
+- **Output:** Grader scores (pass/fail + numeric score per grader)
+
+### 4. Review Panel Phase
+- **Input:** Generated code + build status
+- **Process:**
+  - Launches N reviewer sessions (one per reviewer model in config)
+  - Sends code + rubric to each reviewer independently
+  - Each reviewer scores against semantic criteria (e.g., "Handles errors correctly")
+  - Consolidator model merges individual reviews → consensus score
+- **Output:** Panel scores + individual reviewer insights
+
+### 5. Report Generation Phase
+- **Input:** All phase outputs + metadata
+- **Process:**
+  - Renders JSON report with full timeline
+  - Renders HTML/Markdown from JSON
+  - Saves to `reports/{run_id}/`
+- **Output:** Multi-format reports
+
+## Key Patterns
+
+**Workspace Isolation:**
+- Each eval run gets its own temp directory (`/tmp/hyoka-{run_id}`)
+- Ensures no state leakage between runs
+
+**Action Timeline Capture:**
+- Every tool call, file operation, bash command is recorded with duration
+- Used by graders to verify required/forbidden tool usage
+- Enables post-hoc analysis of agent behavior
+
+**Async/Parallel Processing:**
+- Multiple prompts can run in parallel (via `--workers` flag)
+- Generator and review phases are sequential per prompt (generation must complete before review)
+
+**Error Handling:**
+- Generation timeout → captured as error in report, review skipped
+- Build failure → reported but review proceeds
+- Grader timeout → grader marked as timeout, engine continues
+- Single reviewer timeout → other reviewers still score
+
+## Code Locations
+
+- **Engine orchestration:** `hyoka/internal/eval/engine.go`
+- **Copilot session management:** `hyoka/internal/eval/copilot.go`
+- **Action timeline:** `hyoka/internal/eval/action.go`
+- **Workspace creation:** `hyoka/internal/eval/workspace.go`
+- **Process tracking:** `hyoka/internal/eval/proctracker.go`
+
+## Anti-Patterns
+
+- Don't call `log.Fatal` in pipeline steps — return errors
+- Don't skip phases silently; report skipped phases in output
+- Don't assume workspace directory persists after eval (it's cleaned up)
+- Don't hardcode turn/file/output limits in engine (use SessionLimits)

--- a/.agents/skills/external-comms/SKILL.md
+++ b/.agents/skills/external-comms/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: "external-comms"
+description: "PAO workflow for scanning, drafting, and presenting community responses with human review gate"
+domain: "community, communication, workflow"
+confidence: "low"
+source: "manual (RFC #426 — PAO External Communications)"
+tools:
+  - name: "github-mcp-server-list_issues"
+    description: "List open issues for scan candidates and lightweight triage"
+    when: "Use for recent open issue scans before thread-level review"
+  - name: "github-mcp-server-issue_read"
+    description: "Read the full issue, comments, and labels before drafting"
+    when: "Use after selecting a candidate so PAO has complete thread context"
+  - name: "github-mcp-server-search_issues"
+    description: "Search for candidate issues or prior squad responses"
+    when: "Use when filtering by keywords, labels, or duplicate response checks"
+  - name: "gh CLI"
+    description: "Fallback for GitHub issue comments and discussions workflows"
+    when: "Use gh issue list/comment and gh api or gh api graphql when MCP coverage is incomplete"
+---
+
+## Context
+
+Phase 1 is **draft-only mode**.
+
+- PAO scans issues and discussions, drafts responses with the humanizer skill, and presents a review table for human approval.
+- **Human review gate is mandatory** — PAO never posts autonomously.
+- Every action is logged to `.squad/comms/audit/`.
+- This workflow is triggered manually only ("PAO, check community") — no automated or Ralph-triggered activation in Phase 1.
+
+## Patterns
+
+### 1. Scan
+
+Find unanswered community items with GitHub MCP tools first, or `gh issue list` / `gh api` as fallback for issues and discussions.
+
+- Include **open** issues and discussions only.
+- Filter for items with **no squad team response**.
+- Limit to items created in the last 7 days.
+- Exclude items labeled `squad:internal` or `wontfix`.
+- Include discussions **and** issues in the same sweep.
+- Phase 1 scope is **issues and discussions only** — do not draft PR replies.
+
+### Discussion Handling (Phase 1)
+
+Discussions use the GitHub Discussions API, which differs from issues:
+
+- **Scan:** `gh api /repos/{owner}/{repo}/discussions --jq '.[] | select(.answer_chosen_at == null)'` to find unanswered discussions
+- **Categories:** Filter by Q&A and General categories only (skip Announcements, Show and Tell)
+- **Answers vs comments:** In Q&A discussions, PAO drafts an "answer" (not a comment). The human marks it as accepted answer after posting.
+- **Phase 1 scope:** Issues and Discussions ONLY. No PR comments.
+
+### 2. Classify
+
+Determine the response type before drafting.
+
+- Welcome (new contributor)
+- Troubleshooting (bug/help)
+- Feature guidance (feature request/how-to)
+- Redirect (wrong repo/scope)
+- Acknowledgment (confirmed, no fix)
+- Closing (resolved)
+- Technical uncertainty (unknown cause)
+- Empathetic disagreement (pushback on a decision or design)
+- Information request (need more reproduction details or context)
+
+### Template Selection Guide
+
+| Signal in Issue/Discussion | → Response Type | Template |
+|---------------------------|-----------------|----------|
+| New contributor (0 prior issues) | Welcome | T1 |
+| Error message, stack trace, "doesn't work" | Troubleshooting | T2 |
+| "How do I...?", "Can Squad...?", "Is there a way to...?" | Feature Guidance | T3 |
+| Wrong repo, out of scope for Squad | Redirect | T4 |
+| Confirmed bug, no fix available yet | Acknowledgment | T5 |
+| Fix shipped, PR merged that resolves issue | Closing | T6 |
+| Unclear cause, needs investigation | Technical Uncertainty | T7 |
+| Author disagrees with a decision or design | Empathetic Disagreement | T8 |
+| Need more reproduction info or context | Information Request | T9 |
+
+Use exactly one template as the base draft. Replace placeholders with issue-specific details, then apply the humanizer patterns. If the thread spans multiple signals, choose the highest-risk template and capture the nuance in the thread summary.
+
+### Confidence Classification
+
+| Confidence | Criteria | Example |
+|-----------|----------|---------|
+| 🟢 High | Answer exists in Squad docs or FAQ, similar question answered before, no technical ambiguity | "How do I install Squad?" |
+| 🟡 Medium | Technical answer is sound but involves judgment calls, OR docs exist but don't perfectly match the question, OR tone is tricky | "Can Squad work with Azure DevOps?" (yes, but setup is nuanced) |
+| 🔴 Needs Review | Technical uncertainty, policy/roadmap question, potential reputational risk, author is frustrated/angry, question about unreleased features | "When will Squad support Claude?" |
+
+**Auto-escalation rules:**
+- Any mention of competitors → 🔴
+- Any mention of pricing/licensing → 🔴
+- Author has >3 follow-up comments without resolution → 🔴
+- Question references a closed-wontfix issue → 🔴
+
+### 3. Draft
+
+Use the humanizer skill for every draft.
+
+- Complete **Thread-Read Verification** before writing.
+- Read the **full thread**, including all comments, before writing.
+- Select the matching template from the **Template Selection Guide** and record the template ID in the review notes.
+- Treat templates as reusable drafting assets: keep the structure, replace placeholders, and only improvise when the thread truly requires it.
+- Validate the draft against the humanizer anti-patterns.
+- Flag long threads (`>10` comments) with `⚠️`.
+
+### Thread-Read Verification
+
+Before drafting, PAO MUST verify complete thread coverage:
+
+1. **Count verification:** Compare API comment count with actually-read comments. If mismatch, abort draft.
+2. **Deleted comment check:** Use `gh api` timeline to detect deleted comments. If found, flag as ⚠️ in review table.
+3. **Thread summary:** Include in every draft: "Thread: {N} comments, last activity {date}, {summary of key points}"
+4. **Long thread flag:** If >10 comments, add ⚠️ to review table and include condensed thread summary
+5. **Evidence line in review table:** Each draft row includes "Read: {N}/{total} comments" column
+
+### 4. Present
+
+Show drafts for review in this exact format:
+
+```text
+📝 PAO — Community Response Drafts
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| # | Item | Author | Type | Confidence | Read | Preview |
+|---|------|--------|------|------------|------|---------|
+| 1 | Issue #N | @user | Type | 🟢/🟡/🔴 | N/N | "First words..." |
+
+Confidence: 🟢 High | 🟡 Medium | 🔴 Needs review
+
+Full drafts below ▼
+```
+
+Each full draft must begin with the thread summary line:
+`Thread: {N} comments, last activity {date}, {summary of key points}`
+
+### 5. Human Action
+
+Wait for explicit human direction before anything is posted.
+
+- `pao approve 1 3` — approve drafts 1 and 3
+- `pao edit 2` — edit draft 2
+- `pao skip` — skip all
+- `banana` — freeze all pending (safe word)
+
+### Rollback — Bad Post Recovery
+
+If a posted response turns out to be wrong, inappropriate, or needs correction:
+
+1. **Delete the comment:**
+   - Issues: `gh api -X DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}`
+   - Discussions: `gh api graphql -f query='mutation { deleteDiscussionComment(input: {id: "{node_id}"}) { comment { id } } }'`
+2. **Log the deletion:** Write audit entry with action `delete`, include reason and original content
+3. **Draft replacement** (if needed): PAO drafts a corrected response, goes through normal review cycle
+4. **Postmortem:** If the error reveals a pattern gap, update humanizer anti-patterns or add a new test case
+
+**Safe word — `banana`:**
+- Immediately freezes all pending drafts in the review queue
+- No new scans or drafts until `pao resume` is issued
+- Audit entry logged with halter identity and reason
+
+### 6. Post
+
+After approval:
+
+- Human posts via `gh issue comment` for issues or `gh api` for discussion answers/comments.
+- PAO helps by preparing the CLI command.
+- Write the audit entry after the posting action.
+
+### 7. Audit
+
+Log every action.
+
+- Location: `.squad/comms/audit/{timestamp}.md`
+- Required fields vary by action — see `.squad/comms/templates/audit-entry.md` Conditional Fields table
+- Universal required fields: `timestamp`, `action`
+- All other fields are conditional on the action type
+
+## Examples
+
+These are reusable templates. Keep the structure, replace placeholders, and adjust only where the thread requires it.
+
+### Example scan command
+
+```bash
+gh issue list --state open --json number,title,author,labels,comments --limit 20
+```
+
+### Example review table
+
+```text
+📝 PAO — Community Response Drafts
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| # | Item | Author | Type | Confidence | Read | Preview |
+|---|------|--------|------|------------|------|---------|
+| 1 | Issue #426 | @newdev | Welcome | 🟢 | 1/1 | "Hey @newdev! Welcome to Squad..." |
+| 2 | Discussion #18 | @builder | Feature guidance | 🟡 | 4/4 | "Great question! Today the CLI..." |
+| 3 | Issue #431 ⚠️ | @debugger | Technical uncertainty | 🔴 | 12/12 | "Interesting find, @debugger..." |
+
+Confidence: 🟢 High | 🟡 Medium | 🔴 Needs review
+
+Full drafts below ▼
+```
+
+### Example audit entry (post action)
+
+```markdown
+---
+timestamp: "2026-03-16T21:30:00Z"
+action: "post"
+item_number: 426
+draft_id: 1
+reviewer: "@bradygaster"
+---
+
+## Context (draft, approve, edit, skip, post, delete actions)
+- Thread depth: 3
+- Response type: welcome
+- Confidence: 🟢
+- Long thread flag: false
+
+## Draft Content (draft, edit, post actions)
+Thread: 3 comments, last activity 2026-03-16, reporter hit a preview-build regression after install.
+
+Hey @newdev! Welcome to Squad 👋 Thanks for opening this.
+We reproduced the issue in preview builds and we're checking the regression point now.
+Let us know if you can share the command you ran right before the failure.
+
+## Post Result (post, delete actions)
+https://github.com/bradygaster/squad/issues/426#issuecomment-123456
+```
+
+### T1 — Welcome
+
+```text
+Hey {author}! Welcome to Squad 👋 Thanks for opening this.
+{specific acknowledgment or first answer}
+Let us know if you have questions — happy to help!
+```
+
+### T2 — Troubleshooting
+
+```text
+Thanks for the detailed report, {author}!
+Here's what we think is happening: {explanation}
+{steps or workaround}
+Let us know if that helps, or if you're seeing something different.
+```
+
+### T3 — Feature Guidance
+
+```text
+Great question! {context on current state}
+{guidance or workaround}
+We've noted this as a potential improvement — {tracking info if applicable}.
+```
+
+### T4 — Redirect
+
+```text
+Thanks for reaching out! This one is actually better suited for {correct location}.
+{brief explanation of why}
+Feel free to open it there — they'll be able to help!
+```
+
+### T5 — Acknowledgment
+
+```text
+Good catch, {author}. We've confirmed this is a real issue.
+{what we know so far}
+We'll update this thread when we have a fix. Thanks for flagging it!
+```
+
+### T6 — Closing
+
+```text
+This should be resolved in {version/PR}! 🎉
+{brief summary of what changed}
+Thanks for reporting this, {author} — it made Squad better.
+```
+
+### T7 — Technical Uncertainty
+
+```text
+Interesting find, {author}. We're not 100% sure what's causing this yet.
+Here's what we've ruled out: {list}
+We'd love more context if you have it — {specific ask}.
+We'll dig deeper and update this thread.
+```
+
+### T8 — Empathetic Disagreement
+
+```text
+We hear you, {author}. That's a fair concern.
+
+The current design choice was driven by {reason}. We know it's not ideal for every use case.
+
+{what alternatives exist or what trade-off was made}
+
+If you have ideas for how to make this work better for your scenario, we'd love to hear them — open a discussion or drop your thoughts here!
+```
+
+### T9 — Information Request
+
+```text
+Thanks for reporting this, {author}!
+
+To help us dig into this, could you share:
+- {specific ask 1}
+- {specific ask 2}
+- {specific ask 3, if applicable}
+
+That context will help us narrow down what's happening. Appreciate it!
+```
+
+## Anti-Patterns
+
+- ❌ Posting without human review (NEVER — this is the cardinal rule)
+- ❌ Drafting without reading full thread (context is everything)
+- ❌ Ignoring confidence flags (🔴 items need Flight/human review)
+- ❌ Scanning closed issues (only open items)
+- ❌ Responding to issues labeled `squad:internal` or `wontfix`
+- ❌ Skipping audit logging (every action must be recorded)
+- ❌ Drafting for issues where a squad member already responded (avoid duplicates)
+- ❌ Drafting pull request responses in Phase 1 (issues/discussions only)
+- ❌ Treating templates like loose examples instead of reusable drafting assets
+- ❌ Asking for more info without specific requests

--- a/.agents/skills/gh-auth-isolation/SKILL.md
+++ b/.agents/skills/gh-auth-isolation/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: "gh-auth-isolation"
+description: "Safely manage multiple GitHub identities (EMU + personal) in agent workflows"
+domain: "security, github-integration, authentication, multi-account"
+confidence: "high"
+source: "earned (production usage across 50+ sessions with EMU corp + personal GitHub accounts)"
+tools:
+  - name: "gh"
+    description: "GitHub CLI for authenticated operations"
+    when: "When accessing GitHub resources requiring authentication"
+---
+
+## Context
+
+Many developers use GitHub through an Enterprise Managed User (EMU) account at work while maintaining a personal GitHub account for open-source contributions. AI agents spawned by Squad inherit the shell's default `gh` authentication — which is usually the EMU account. This causes failures when agents try to push to personal repos, create PRs on forks, or interact with resources outside the enterprise org.
+
+This skill teaches agents how to detect the active identity, switch contexts safely, and avoid mixing credentials across operations.
+
+## Patterns
+
+### Detect Current Identity
+
+Before any GitHub operation, check which account is active:
+
+```bash
+gh auth status
+```
+
+Look for:
+- `Logged in to github.com as USERNAME` — the active account
+- `Token scopes: ...` — what permissions are available
+- Multiple accounts will show separate entries
+
+### Extract a Specific Account's Token
+
+When you need to operate as a specific user (not the default):
+
+```bash
+# Get the personal account token (by username)
+gh auth token --user personaluser
+
+# Get the EMU account token
+gh auth token --user corpalias_enterprise
+```
+
+**Use case:** Push to a personal fork while the default `gh` auth is the EMU account.
+
+### Push to Personal Repos from EMU Shell
+
+The most common scenario: your shell defaults to the EMU account, but you need to push to a personal GitHub repo.
+
+```bash
+# 1. Extract the personal token
+$token = gh auth token --user personaluser
+
+# 2. Push using token-authenticated HTTPS
+git push https://personaluser:$token@github.com/personaluser/repo.git branch-name
+```
+
+**Why this works:** `gh auth token --user` reads from `gh`'s credential store without switching the active account. The token is used inline for a single operation and never persisted.
+
+### Create PRs on Personal Forks
+
+When the default `gh` context is EMU but you need to create a PR from a personal fork:
+
+```bash
+# Option 1: Use --repo flag (works if token has access)
+gh pr create --repo upstream/repo --head personaluser:branch --title "..." --body "..."
+
+# Option 2: Temporarily set GH_TOKEN for one command
+$env:GH_TOKEN = $(gh auth token --user personaluser)
+gh pr create --repo upstream/repo --head personaluser:branch --title "..."
+Remove-Item Env:\GH_TOKEN
+```
+
+### Config Directory Isolation (Advanced)
+
+For complete isolation between accounts, use separate `gh` config directories:
+
+```bash
+# Personal account operations
+$env:GH_CONFIG_DIR = "$HOME/.config/gh-public"
+gh auth login  # Login with personal account (one-time setup)
+gh repo clone personaluser/repo
+
+# EMU account operations (default)
+Remove-Item Env:\GH_CONFIG_DIR
+gh auth status  # Back to EMU account
+```
+
+**Setup (one-time):**
+```bash
+# Create isolated config for personal account
+mkdir ~/.config/gh-public
+$env:GH_CONFIG_DIR = "$HOME/.config/gh-public"
+gh auth login --web --git-protocol https
+```
+
+### Shell Aliases for Quick Switching
+
+Add to your shell profile for convenience:
+
+```powershell
+# PowerShell profile
+function ghp { $env:GH_CONFIG_DIR = "$HOME/.config/gh-public"; gh @args; Remove-Item Env:\GH_CONFIG_DIR }
+function ghe { gh @args }  # Default EMU
+
+# Usage:
+# ghp repo clone personaluser/repo   # Uses personal account
+# ghe issue list                       # Uses EMU account
+```
+
+```bash
+# Bash/Zsh profile
+alias ghp='GH_CONFIG_DIR=~/.config/gh-public gh'
+alias ghe='gh'
+
+# Usage:
+# ghp repo clone personaluser/repo
+# ghe issue list
+```
+
+## Examples
+
+### ✓ Correct: Agent pushes blog post to personal GitHub Pages
+
+```powershell
+# Agent needs to push to personaluser.github.io (personal repo)
+# Default gh auth is corpalias_enterprise (EMU)
+
+$token = gh auth token --user personaluser
+git remote set-url origin https://personaluser:$token@github.com/personaluser/personaluser.github.io.git
+git push origin main
+
+# Clean up — don't leave token in remote URL
+git remote set-url origin https://github.com/personaluser/personaluser.github.io.git
+```
+
+### ✓ Correct: Agent creates a PR from personal fork to upstream
+
+```powershell
+# Fork: personaluser/squad, Upstream: bradygaster/squad
+# Agent is on branch contrib/fix-docs in the fork clone
+
+git push origin contrib/fix-docs  # Pushes to fork (may need token auth)
+
+# Create PR targeting upstream
+gh pr create --repo bradygaster/squad --head personaluser:contrib/fix-docs `
+  --title "docs: fix installation guide" `
+  --body "Fixes #123"
+```
+
+### ✗ Incorrect: Blindly pushing with wrong account
+
+```bash
+# BAD: Agent assumes default gh auth works for personal repos
+git push origin main
+# ERROR: Permission denied — EMU account has no access to personal repo
+
+# BAD: Hardcoding tokens in scripts
+git push https://personaluser:ghp_xxxxxxxxxxxx@github.com/personaluser/repo.git main
+# SECURITY RISK: Token exposed in command history and process list
+```
+
+### ✓ Correct: Check before you push
+
+```bash
+# Always verify which account has access before operations
+gh auth status
+# If wrong account, use token extraction:
+$token = gh auth token --user personaluser
+git push https://personaluser:$token@github.com/personaluser/repo.git main
+```
+
+## Anti-Patterns
+
+- ❌ **Hardcoding tokens** in scripts, environment variables, or committed files. Use `gh auth token --user` to extract at runtime.
+- ❌ **Assuming the default `gh` auth works** for all repos. EMU accounts can't access personal repos and vice versa.
+- ❌ **Switching `gh auth login`** globally mid-session. This changes the default for ALL processes and can break parallel agents.
+- ❌ **Storing personal tokens in `.env`** or `.squad/` files. These get committed by Scribe. Use `gh`'s credential store.
+- ❌ **Ignoring token cleanup** after inline HTTPS pushes. Always reset the remote URL to avoid persisting tokens.
+- ❌ **Using `gh auth switch`** in multi-agent sessions. One agent switching affects all others sharing the shell.
+- ❌ **Mixing EMU and personal operations** in the same git clone. Use separate clones or explicit remote URLs per operation.

--- a/.agents/skills/github-multi-account/SKILL.md
+++ b/.agents/skills/github-multi-account/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: github-multi-account
+description: Detect and set up account-locked gh aliases for multi-account GitHub. The AI reads this skill, detects accounts, asks the user which is personal/work, and runs the setup automatically.
+confidence: high
+source: https://github.com/tamirdresher/squad-skills/tree/main/plugins/github-multi-account
+author: tamirdresher
+---
+
+# GitHub Multi-Account — AI-Driven Setup
+
+## When to Activate
+When the user has multiple GitHub accounts (check with `gh auth status`). If you see 2+ accounts listed, this skill applies.
+
+## What to Do (as the AI agent)
+
+### Step 1: Detect accounts
+Run: `gh auth status`
+Look for multiple accounts. Note which usernames are listed.
+
+### Step 2: Ask the user
+Ask: "I see you have multiple GitHub accounts: {list them}. Which one is your personal account and which is your work/EMU account?"
+
+### Step 3: Run the setup automatically
+Once the user confirms, do ALL of this for them:
+
+```powershell
+# 1. Define the functions
+$personal = "THEIR_PERSONAL_USERNAME"
+$work = "THEIR_WORK_USERNAME"
+
+# 2. Add to PowerShell profile
+$profilePath = $PROFILE.CurrentUserAllHosts
+if (!(Test-Path $profilePath)) { New-Item -Path $profilePath -Force | Out-Null }
+$existing = Get-Content $profilePath -Raw -ErrorAction SilentlyContinue
+if ($existing -notmatch "gh-personal") {
+    $block = @"
+
+# === GitHub Multi-Account Aliases ===
+function gh-personal { gh auth switch --user $personal 2>`$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user $work 2>`$null | Out-Null; gh @args }
+Set-Alias ghp gh-personal
+Set-Alias ghw gh-work
+"@
+    Add-Content -Path $profilePath -Value $block
+}
+
+# 3. Create CMD wrappers
+$binDir = Join-Path $env:USERPROFILE ".squad\bin"
+if (!(Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
+"@echo off`ngh auth switch --user $personal >nul 2>&1`ngh %*" | Out-File "$binDir\ghp.cmd" -Encoding ascii
+"@echo off`ngh auth switch --user $work >nul 2>&1`ngh %*" | Out-File "$binDir\ghw.cmd" -Encoding ascii
+
+# 4. Add to PATH
+$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($userPath -notmatch [regex]::Escape($binDir)) {
+    [Environment]::SetEnvironmentVariable("PATH", "$binDir;$userPath", "User")
+    $env:PATH = "$binDir;$env:PATH"
+}
+
+# 5. Load in current session
+function gh-personal { gh auth switch --user $personal 2>$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user $work 2>$null | Out-Null; gh @args }
+Set-Alias ghp gh-personal
+Set-Alias ghw gh-work
+```
+
+### Step 4: Verify for the user
+Run these and show the results:
+```powershell
+ghp api user --jq '.login'   # should show personal username
+ghw api user --jq '.login'   # should show work username
+```
+
+### Step 5: Tell the user
+"All set! From now on use `ghp` for personal repos and `ghw` for work repos. I'll use them too."
+
+## After Setup — Usage Rules
+
+1. **NEVER** use bare `gh` for repo operations — always `ghp` or `ghw`
+2. **NEVER** manually `gh auth switch` — the aliases handle it
+3. Determine alias by repo owner:
+   - Personal account repos → `ghp` / `gh-personal`
+   - Work/EMU account repos → `ghw` / `gh-work`
+
+## Repo-Specific Account Binding
+
+This repo (`bradygaster/squad`) is bound to the **bradygaster** (personal) account.
+All `gh` operations in this repo MUST use `ghp` / `gh-personal`.
+
+## For Squad Agents
+At the TOP of any script touching GitHub, define:
+```powershell
+function gh-personal { gh auth switch --user bradygaster 2>$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user bradyg_microsoft 2>$null | Out-Null; gh @args }
+```

--- a/.agents/skills/golang-patterns/SKILL.md
+++ b/.agents/skills/golang-patterns/SKILL.md
@@ -1,0 +1,674 @@
+---
+name: golang-patterns
+description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.
+origin: ECC
+---
+
+# Go Development Patterns
+
+Idiomatic Go patterns and best practices for building robust, efficient, and maintainable applications.
+
+## When to Activate
+
+- Writing new Go code
+- Reviewing Go code
+- Refactoring existing Go code
+- Designing Go packages/modules
+
+## Core Principles
+
+### 1. Simplicity and Clarity
+
+Go favors simplicity over cleverness. Code should be obvious and easy to read.
+
+```go
+// Good: Clear and direct
+func GetUser(id string) (*User, error) {
+    user, err := db.FindUser(id)
+    if err != nil {
+        return nil, fmt.Errorf("get user %s: %w", id, err)
+    }
+    return user, nil
+}
+
+// Bad: Overly clever
+func GetUser(id string) (*User, error) {
+    return func() (*User, error) {
+        if u, e := db.FindUser(id); e == nil {
+            return u, nil
+        } else {
+            return nil, e
+        }
+    }()
+}
+```
+
+### 2. Make the Zero Value Useful
+
+Design types so their zero value is immediately usable without initialization.
+
+```go
+// Good: Zero value is useful
+type Counter struct {
+    mu    sync.Mutex
+    count int // zero value is 0, ready to use
+}
+
+func (c *Counter) Inc() {
+    c.mu.Lock()
+    c.count++
+    c.mu.Unlock()
+}
+
+// Good: bytes.Buffer works with zero value
+var buf bytes.Buffer
+buf.WriteString("hello")
+
+// Bad: Requires initialization
+type BadCounter struct {
+    counts map[string]int // nil map will panic
+}
+```
+
+### 3. Accept Interfaces, Return Structs
+
+Functions should accept interface parameters and return concrete types.
+
+```go
+// Good: Accepts interface, returns concrete type
+func ProcessData(r io.Reader) (*Result, error) {
+    data, err := io.ReadAll(r)
+    if err != nil {
+        return nil, err
+    }
+    return &Result{Data: data}, nil
+}
+
+// Bad: Returns interface (hides implementation details unnecessarily)
+func ProcessData(r io.Reader) (io.Reader, error) {
+    // ...
+}
+```
+
+## Error Handling Patterns
+
+### Error Wrapping with Context
+
+```go
+// Good: Wrap errors with context
+func LoadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config %s: %w", path, err)
+    }
+
+    var cfg Config
+    if err := json.Unmarshal(data, &cfg); err != nil {
+        return nil, fmt.Errorf("parse config %s: %w", path, err)
+    }
+
+    return &cfg, nil
+}
+```
+
+### Custom Error Types
+
+```go
+// Define domain-specific errors
+type ValidationError struct {
+    Field   string
+    Message string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation failed on %s: %s", e.Field, e.Message)
+}
+
+// Sentinel errors for common cases
+var (
+    ErrNotFound     = errors.New("resource not found")
+    ErrUnauthorized = errors.New("unauthorized")
+    ErrInvalidInput = errors.New("invalid input")
+)
+```
+
+### Error Checking with errors.Is and errors.As
+
+```go
+func HandleError(err error) {
+    // Check for specific error
+    if errors.Is(err, sql.ErrNoRows) {
+        log.Println("No records found")
+        return
+    }
+
+    // Check for error type
+    var validationErr *ValidationError
+    if errors.As(err, &validationErr) {
+        log.Printf("Validation error on field %s: %s",
+            validationErr.Field, validationErr.Message)
+        return
+    }
+
+    // Unknown error
+    log.Printf("Unexpected error: %v", err)
+}
+```
+
+### Never Ignore Errors
+
+```go
+// Bad: Ignoring error with blank identifier
+result, _ := doSomething()
+
+// Good: Handle or explicitly document why it's safe to ignore
+result, err := doSomething()
+if err != nil {
+    return err
+}
+
+// Acceptable: When error truly doesn't matter (rare)
+_ = writer.Close() // Best-effort cleanup, error logged elsewhere
+```
+
+## Concurrency Patterns
+
+### Worker Pool
+
+```go
+func WorkerPool(jobs <-chan Job, results chan<- Result, numWorkers int) {
+    var wg sync.WaitGroup
+
+    for i := 0; i < numWorkers; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for job := range jobs {
+                results <- process(job)
+            }
+        }()
+    }
+
+    wg.Wait()
+    close(results)
+}
+```
+
+### Context for Cancellation and Timeouts
+
+```go
+func FetchWithTimeout(ctx context.Context, url string) ([]byte, error) {
+    ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil {
+        return nil, fmt.Errorf("create request: %w", err)
+    }
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("fetch %s: %w", url, err)
+    }
+    defer resp.Body.Close()
+
+    return io.ReadAll(resp.Body)
+}
+```
+
+### Graceful Shutdown
+
+```go
+func GracefulShutdown(server *http.Server) {
+    quit := make(chan os.Signal, 1)
+    signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+    <-quit
+    log.Println("Shutting down server...")
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    if err := server.Shutdown(ctx); err != nil {
+        log.Fatalf("Server forced to shutdown: %v", err)
+    }
+
+    log.Println("Server exited")
+}
+```
+
+### errgroup for Coordinated Goroutines
+
+```go
+import "golang.org/x/sync/errgroup"
+
+func FetchAll(ctx context.Context, urls []string) ([][]byte, error) {
+    g, ctx := errgroup.WithContext(ctx)
+    results := make([][]byte, len(urls))
+
+    for i, url := range urls {
+        i, url := i, url // Capture loop variables
+        g.Go(func() error {
+            data, err := FetchWithTimeout(ctx, url)
+            if err != nil {
+                return err
+            }
+            results[i] = data
+            return nil
+        })
+    }
+
+    if err := g.Wait(); err != nil {
+        return nil, err
+    }
+    return results, nil
+}
+```
+
+### Avoiding Goroutine Leaks
+
+```go
+// Bad: Goroutine leak if context is cancelled
+func leakyFetch(ctx context.Context, url string) <-chan []byte {
+    ch := make(chan []byte)
+    go func() {
+        data, _ := fetch(url)
+        ch <- data // Blocks forever if no receiver
+    }()
+    return ch
+}
+
+// Good: Properly handles cancellation
+func safeFetch(ctx context.Context, url string) <-chan []byte {
+    ch := make(chan []byte, 1) // Buffered channel
+    go func() {
+        data, err := fetch(url)
+        if err != nil {
+            return
+        }
+        select {
+        case ch <- data:
+        case <-ctx.Done():
+        }
+    }()
+    return ch
+}
+```
+
+## Interface Design
+
+### Small, Focused Interfaces
+
+```go
+// Good: Single-method interfaces
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+
+type Writer interface {
+    Write(p []byte) (n int, err error)
+}
+
+type Closer interface {
+    Close() error
+}
+
+// Compose interfaces as needed
+type ReadWriteCloser interface {
+    Reader
+    Writer
+    Closer
+}
+```
+
+### Define Interfaces Where They're Used
+
+```go
+// In the consumer package, not the provider
+package service
+
+// UserStore defines what this service needs
+type UserStore interface {
+    GetUser(id string) (*User, error)
+    SaveUser(user *User) error
+}
+
+type Service struct {
+    store UserStore
+}
+
+// Concrete implementation can be in another package
+// It doesn't need to know about this interface
+```
+
+### Optional Behavior with Type Assertions
+
+```go
+type Flusher interface {
+    Flush() error
+}
+
+func WriteAndFlush(w io.Writer, data []byte) error {
+    if _, err := w.Write(data); err != nil {
+        return err
+    }
+
+    // Flush if supported
+    if f, ok := w.(Flusher); ok {
+        return f.Flush()
+    }
+    return nil
+}
+```
+
+## Package Organization
+
+### Standard Project Layout
+
+```text
+myproject/
+├── cmd/
+│   └── myapp/
+│       └── main.go           # Entry point
+├── internal/
+│   ├── handler/              # HTTP handlers
+│   ├── service/              # Business logic
+│   ├── repository/           # Data access
+│   └── config/               # Configuration
+├── pkg/
+│   └── client/               # Public API client
+├── api/
+│   └── v1/                   # API definitions (proto, OpenAPI)
+├── testdata/                 # Test fixtures
+├── go.mod
+├── go.sum
+└── Makefile
+```
+
+### Package Naming
+
+```go
+// Good: Short, lowercase, no underscores
+package http
+package json
+package user
+
+// Bad: Verbose, mixed case, or redundant
+package httpHandler
+package json_parser
+package userService // Redundant 'Service' suffix
+```
+
+### Avoid Package-Level State
+
+```go
+// Bad: Global mutable state
+var db *sql.DB
+
+func init() {
+    db, _ = sql.Open("postgres", os.Getenv("DATABASE_URL"))
+}
+
+// Good: Dependency injection
+type Server struct {
+    db *sql.DB
+}
+
+func NewServer(db *sql.DB) *Server {
+    return &Server{db: db}
+}
+```
+
+## Struct Design
+
+### Functional Options Pattern
+
+```go
+type Server struct {
+    addr    string
+    timeout time.Duration
+    logger  *log.Logger
+}
+
+type Option func(*Server)
+
+func WithTimeout(d time.Duration) Option {
+    return func(s *Server) {
+        s.timeout = d
+    }
+}
+
+func WithLogger(l *log.Logger) Option {
+    return func(s *Server) {
+        s.logger = l
+    }
+}
+
+func NewServer(addr string, opts ...Option) *Server {
+    s := &Server{
+        addr:    addr,
+        timeout: 30 * time.Second, // default
+        logger:  log.Default(),    // default
+    }
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+
+// Usage
+server := NewServer(":8080",
+    WithTimeout(60*time.Second),
+    WithLogger(customLogger),
+)
+```
+
+### Embedding for Composition
+
+```go
+type Logger struct {
+    prefix string
+}
+
+func (l *Logger) Log(msg string) {
+    fmt.Printf("[%s] %s\n", l.prefix, msg)
+}
+
+type Server struct {
+    *Logger // Embedding - Server gets Log method
+    addr    string
+}
+
+func NewServer(addr string) *Server {
+    return &Server{
+        Logger: &Logger{prefix: "SERVER"},
+        addr:   addr,
+    }
+}
+
+// Usage
+s := NewServer(":8080")
+s.Log("Starting...") // Calls embedded Logger.Log
+```
+
+## Memory and Performance
+
+### Preallocate Slices When Size is Known
+
+```go
+// Bad: Grows slice multiple times
+func processItems(items []Item) []Result {
+    var results []Result
+    for _, item := range items {
+        results = append(results, process(item))
+    }
+    return results
+}
+
+// Good: Single allocation
+func processItems(items []Item) []Result {
+    results := make([]Result, 0, len(items))
+    for _, item := range items {
+        results = append(results, process(item))
+    }
+    return results
+}
+```
+
+### Use sync.Pool for Frequent Allocations
+
+```go
+var bufferPool = sync.Pool{
+    New: func() interface{} {
+        return new(bytes.Buffer)
+    },
+}
+
+func ProcessRequest(data []byte) []byte {
+    buf := bufferPool.Get().(*bytes.Buffer)
+    defer func() {
+        buf.Reset()
+        bufferPool.Put(buf)
+    }()
+
+    buf.Write(data)
+    // Process...
+    return buf.Bytes()
+}
+```
+
+### Avoid String Concatenation in Loops
+
+```go
+// Bad: Creates many string allocations
+func join(parts []string) string {
+    var result string
+    for _, p := range parts {
+        result += p + ","
+    }
+    return result
+}
+
+// Good: Single allocation with strings.Builder
+func join(parts []string) string {
+    var sb strings.Builder
+    for i, p := range parts {
+        if i > 0 {
+            sb.WriteString(",")
+        }
+        sb.WriteString(p)
+    }
+    return sb.String()
+}
+
+// Best: Use standard library
+func join(parts []string) string {
+    return strings.Join(parts, ",")
+}
+```
+
+## Go Tooling Integration
+
+### Essential Commands
+
+```bash
+# Build and run
+go build ./...
+go run ./cmd/myapp
+
+# Testing
+go test ./...
+go test -race ./...
+go test -cover ./...
+
+# Static analysis
+go vet ./...
+staticcheck ./...
+golangci-lint run
+
+# Module management
+go mod tidy
+go mod verify
+
+# Formatting
+gofmt -w .
+goimports -w .
+```
+
+### Recommended Linter Configuration (.golangci.yml)
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gofmt
+    - goimports
+    - misspell
+    - unconvert
+    - unparam
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    check-shadowing: true
+
+issues:
+  exclude-use-default: false
+```
+
+## Quick Reference: Go Idioms
+
+| Idiom | Description |
+|-------|-------------|
+| Accept interfaces, return structs | Functions accept interface params, return concrete types |
+| Errors are values | Treat errors as first-class values, not exceptions |
+| Don't communicate by sharing memory | Use channels for coordination between goroutines |
+| Make the zero value useful | Types should work without explicit initialization |
+| A little copying is better than a little dependency | Avoid unnecessary external dependencies |
+| Clear is better than clever | Prioritize readability over cleverness |
+| gofmt is no one's favorite but everyone's friend | Always format with gofmt/goimports |
+| Return early | Handle errors first, keep happy path unindented |
+
+## Anti-Patterns to Avoid
+
+```go
+// Bad: Naked returns in long functions
+func process() (result int, err error) {
+    // ... 50 lines ...
+    return // What is being returned?
+}
+
+// Bad: Using panic for control flow
+func GetUser(id string) *User {
+    user, err := db.Find(id)
+    if err != nil {
+        panic(err) // Don't do this
+    }
+    return user
+}
+
+// Bad: Passing context in struct
+type Request struct {
+    ctx context.Context // Context should be first param
+    ID  string
+}
+
+// Good: Context as first parameter
+func ProcessRequest(ctx context.Context, id string) error {
+    // ...
+}
+
+// Bad: Mixing value and pointer receivers
+type Counter struct{ n int }
+func (c Counter) Value() int { return c.n }    // Value receiver
+func (c *Counter) Increment() { c.n++ }        // Pointer receiver
+// Pick one style and be consistent
+```
+
+**Remember**: Go code should be boring in the best way - predictable, consistent, and easy to understand. When in doubt, keep it simple.

--- a/.agents/skills/grader-system/SKILL.md
+++ b/.agents/skills/grader-system/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: "grader-system"
+description: "Pluggable grader architecture (6 types, gate semantics)"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/graders/grader.go, hyoka/internal/graders/registry.go"
+---
+
+## Context
+
+Hyoka's grading system is pluggable and multi-layered. Six independent grader types inspect generated code and action timelines from different angles, then consolidate into a holistic assessment. Graders are **advisory** — they report findings, they don't gate evaluation completion.
+
+## Grader Architecture
+
+All graders implement:
+```go
+type Grader interface {
+    Kind() string
+    Name() string
+    Grade(ctx context.Context, input GraderInput) (GraderResult, error)
+}
+```
+
+### GraderInput
+```go
+type GraderInput struct {
+    Code           string          // Generated code
+    Language       string          // e.g., "python"
+    ActionLog      []ActionEvent   // Timeline of agent actions
+    BuildStatus    string          // "success", "failed", "skipped"
+    BuildOutput    string          // Compiler/interpreter output
+}
+```
+
+### GraderResult
+```go
+type GraderResult struct {
+    Kind    string                  // e.g., "behavior", "lint"
+    Name    string                  // Grader instance name
+    Pass    bool                    // Critical gate (true = safe to deploy)
+    Score   float64                 // 0.0-1.0 numeric score
+    Message string                  // Human-readable summary
+    Details interface{}             // Type-specific details
+}
+```
+
+## Six Grader Types
+
+### 1. Behavior Grader
+Inspects action timeline for required/forbidden tool usage and turn limits.
+
+```yaml
+graders:
+  - kind: behavior
+    name: tool_compliance
+    required_tools: [file_write, read_file]
+    forbidden_tools: [rm, sudo]
+    max_turns: 25
+```
+
+**Details:** `BehaviorGraderDetails` with ToolsUsed, MaxTurns, Violations
+
+### 2. Lint Grader
+Runs language-specific linters on generated code.
+
+```yaml
+graders:
+  - kind: lint
+    name: python_lint
+    linters: [pylint, black, mypy]
+    threshold: 0.8  # Must pass 80% of linters
+```
+
+**Details:** `LintGraderDetails` with per-linter pass/fail, warnings
+
+### 3. Build Grader
+Verifies code builds (or interprets) without errors.
+
+```yaml
+graders:
+  - kind: build
+    name: cargo_build
+```
+
+**Details:** `BuildGraderDetails` with exit code, stderr excerpt
+
+### 4. File Grader
+Checks generated file structure (count, naming, organization).
+
+```yaml
+graders:
+  - kind: file
+    name: file_structure
+    min_files: 2
+    max_files: 50
+    required_files: [main.py, tests.py]
+```
+
+**Details:** `FileGraderDetails` with file list, violations
+
+### 5. Program Grader
+Runs generated code and checks output against expected results.
+
+```yaml
+graders:
+  - kind: program
+    name: integration_test
+    test_command: python tests.py
+    expected_output: "All tests passed"
+```
+
+**Details:** `ProgramGraderDetails` with actual vs. expected output
+
+### 6. Prompt Grader
+Uses an LLM to score code against semantic criteria (a.k.a. "LLM-as-judge").
+
+```yaml
+graders:
+  - kind: prompt
+    name: semantic_correctness
+    rubric: "Does the code correctly implement the requested feature?"
+    model: claude-opus-4.6
+```
+
+**Details:** `PromptGraderDetails` with rubric reasoning, score breakdown
+
+## Gate Semantics
+
+**Soft gates (reporting):**
+- Graders run independently in parallel
+- Timeout on one grader doesn't block others
+- Failure on one grader doesn't prevent report generation
+
+**Hard gates (evaluation completion):**
+- If generation or review phases **hard-fail** (e.g., timeout, SDK crash), eval stops
+- Grader failures do NOT stop evaluation (graders are advisory)
+
+## Pluggable Registry
+
+Graders are registered via factory functions:
+
+```go
+type GraderFactory func(name string, cfg map[string]any) (Grader, error)
+
+var registry = map[string]GraderFactory{
+    "behavior": NewBehaviorGrader,
+    "lint":     NewLintGrader,
+    "build":    NewBuildGrader,
+    "file":     NewFileGrader,
+    "program":  NewProgramGrader,
+    "prompt":   NewPromptGrader,
+}
+
+// New grader types can be added by updating registry
+```
+
+## Configuration
+
+Graders are defined in config YAML:
+
+```yaml
+graders:
+  - kind: behavior
+    name: required_tools
+    required_tools: [file_write, bash]
+  
+  - kind: lint
+    name: python_style
+    linters: [pylint]
+    threshold: 0.9
+
+  - kind: prompt
+    name: correctness
+    model: gpt-5.4
+```
+
+## Error Handling
+
+Each grader catches its own errors:
+
+```go
+func (g *LintGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) {
+    // Run linter
+    cmd := exec.CommandContext(ctx, "pylint", ...)
+    
+    // Timeout?
+    if ctx.Err() != nil {
+        return GraderResult{
+            Pass: false,
+            Message: "Linter timeout",
+        }, nil  // Return error object, not error value
+    }
+}
+```
+
+Grader errors are **not** fatal — they're reported in the grader result.
+
+## Code Locations
+
+- **Grader interface and registry:** `hyoka/internal/graders/grader.go`
+- **Individual grader implementations:** `hyoka/internal/graders/{kind}_grader.go`
+- **Example grader tests:** `hyoka/internal/graders/*_test.go`
+
+## Anti-Patterns
+
+- Using grader failures as eval blockers (they're advisory only)
+- Hardcoding grader lists in engine (add via config)
+- Ignoring grader timeout errors (report them)
+- Assuming all graders finish synchronously (they may timeout)

--- a/.agents/skills/history-hygiene/SKILL.md
+++ b/.agents/skills/history-hygiene/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: history-hygiene
+description: Record final outcomes to history.md, not intermediate requests or reversed decisions
+domain: documentation, team-collaboration
+confidence: high
+source: earned (Kobayashi v0.6.0 incident, team intervention)
+---
+
+## Context
+
+History files (.md files tracking decisions, spawns, outcomes) are read cold by future agents. Stale or incorrect entries poison decision-making downstream. The Kobayashi incident proved this: history said "Brady decided v0.6.0" when Brady had reversed that to v0.8.17. Future spawns read the wrong truth and repeated the mistake.
+
+## Patterns
+
+- **Record the final outcome**, not the initial request.
+- **Wait for confirmation** before writing to history — don't log intermediate states.
+- **If a decision reverses**, update the entry immediately — don't leave stale data.
+- **One read = one truth.** A future agent should never need to cross-reference other files to understand what actually happened.
+
+## Examples
+
+✓ **Correct:**
+- "Migration target: v0.8.17 (initially discussed as v0.6.0, corrected by Brady)"
+- "Reverted to Node 18 per Brady's explicit request on 2024-01-15"
+
+✗ **Incorrect:**
+- "Brady directed v0.6.0" (when later reversed)
+- Recording what was *requested* instead of what *actually happened*
+- Logging entries before outcome is confirmed
+
+## Anti-Patterns
+
+- Writing intermediate or "for now" states to disk
+- Attributing decisions without confirming final direction
+- Treating history like a draft — history is the source of truth
+- Assuming readers will cross-reference or verify; they won't

--- a/.agents/skills/humanizer/SKILL.md
+++ b/.agents/skills/humanizer/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: "humanizer"
+description: "Tone enforcement patterns for external-facing community responses"
+domain: "communication, tone, community"
+confidence: "low"
+source: "manual (RFC #426 — PAO External Communications)"
+---
+
+## Context
+
+Use this skill whenever PAO drafts external-facing responses for issues or discussions.
+
+- Tone must be warm, helpful, and human-sounding — never robotic or corporate.
+- Brady's constraint applies everywhere: **Humanized tone is mandatory**.
+- This applies to **all external-facing content** drafted by PAO in Phase 1 issues/discussions workflows.
+
+## Patterns
+
+1. **Warm opening** — Start with acknowledgment ("Thanks for reporting this", "Great question!")
+2. **Active voice** — "We're looking into this" not "This is being investigated"
+3. **Second person** — Address the person directly ("you" not "the user")
+4. **Conversational connectors** — "That said...", "Here's what we found...", "Quick note:"
+5. **Specific, not vague** — "This affects the casting module in v0.8.x" not "We are aware of issues"
+6. **Empathy markers** — "I can see how that would be frustrating", "Good catch!"
+7. **Action-oriented closes** — "Let us know if that helps!" not "Please advise if further assistance is required"
+8. **Uncertainty is OK** — "We're not 100% sure yet, but here's what we think is happening..." is better than false confidence
+9. **Profanity filter** — Never include profanity, slurs, or aggressive language, even when quoting
+10. **Baseline comparison** — Responses should align with tone of 5-10 "gold standard" responses (>80% similarity threshold)
+11. **Empathetic disagreement** — "We hear you. That's a fair concern." before explaining the reasoning
+12. **Information request** — Ask for specific details, not open-ended "can you provide more info?"
+13. **No link-dumping** — Don't just paste URLs. Provide context: "Check out the [getting started guide](url) — specifically the section on routing" not just a bare link
+
+## Examples
+
+### 1. Welcome
+
+```text
+Hey {author}! Welcome to Squad 👋 Thanks for opening this.
+{substantive response}
+Let us know if you have questions — happy to help!
+```
+
+### 2. Troubleshooting
+
+```text
+Thanks for the detailed report, {author}!
+Here's what we think is happening: {explanation}
+{steps or workaround}
+Let us know if that helps, or if you're seeing something different.
+```
+
+### 3. Feature guidance
+
+```text
+Great question! {context on current state}
+{guidance or workaround}
+We've noted this as a potential improvement — {tracking info if applicable}.
+```
+
+### 4. Redirect
+
+```text
+Thanks for reaching out! This one is actually better suited for {correct location}.
+{brief explanation of why}
+Feel free to open it there — they'll be able to help!
+```
+
+### 5. Acknowledgment
+
+```text
+Good catch, {author}. We've confirmed this is a real issue.
+{what we know so far}
+We'll update this thread when we have a fix. Thanks for flagging it!
+```
+
+### 6. Closing
+
+```text
+This should be resolved in {version/PR}! 🎉
+{brief summary of what changed}
+Thanks for reporting this, {author} — it made Squad better.
+```
+
+### 7. Technical uncertainty
+
+```text
+Interesting find, {author}. We're not 100% sure what's causing this yet.
+Here's what we've ruled out: {list}
+We'd love more context if you have it — {specific ask}.
+We'll dig deeper and update this thread.
+```
+
+## Anti-Patterns
+
+- ❌ Corporate speak: "We appreciate your patience as we investigate this matter"
+- ❌ Marketing hype: "Squad is the BEST way to..." or "This amazing feature..."
+- ❌ Passive voice: "It has been determined that..." or "The issue is being tracked"
+- ❌ Dismissive: "This works as designed" without empathy
+- ❌ Over-promising: "We'll ship this next week" without commitment from the team
+- ❌ Empty acknowledgment: "Thanks for your feedback" with no substance
+- ❌ Robot signatures: "Best regards, PAO" or "Sincerely, The Squad Team"
+- ❌ Excessive emoji: More than 1-2 emoji per response
+- ❌ Quoting profanity: Even when the original issue contains it, paraphrase instead
+- ❌ Link-dumping: Pasting URLs without context ("See: https://...")
+- ❌ Open-ended info requests: "Can you provide more information?" without specifying what information

--- a/.agents/skills/init-mode/SKILL.md
+++ b/.agents/skills/init-mode/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: "init-mode"
+description: "Team initialization flow (Phase 1 proposal + Phase 2 creation)"
+domain: "orchestration"
+confidence: "high"
+source: "extracted"
+tools:
+  - name: "ask_user"
+    description: "Confirm team roster with selectable menu"
+    when: "Phase 1 proposal — requires explicit user confirmation"
+---
+
+## Context
+
+Init Mode activates when `.squad/team.md` does not exist, or exists but has zero roster entries under `## Members`. The coordinator proposes a team (Phase 1), waits for user confirmation, then creates the team structure (Phase 2).
+
+## Patterns
+
+### Phase 1: Propose the Team
+
+No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+
+1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey Brady, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
+2. Ask: *"What are you building? (language, stack, what it does)"*
+3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
+   - Determine team size (typically 4–5 + Scribe).
+   - Determine assignment shape from the user's project description.
+   - Derive resonance signals from the session and repo context.
+   - Select a universe. If the universe is custom, allocate character names from that universe based on the related list found in the `.squad/templates/casting/` directory. Prefer custom universes when available.
+   - Scribe is always "Scribe" — exempt from casting.
+   - Ralph is always "Ralph" — exempt from casting.
+4. Propose the team with their cast names. Example (names will vary per cast):
+
+```
+🏗️  {CastName1}  — Lead          Scope, decisions, code review
+⚛️  {CastName2}  — Frontend Dev  React, UI, components
+🔧  {CastName3}  — Backend Dev   APIs, database, services
+🧪  {CastName4}  — Tester        Tests, quality, edge cases
+📋  Scribe       — (silent)      Memory, decisions, session logs
+🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
+```
+
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
+   - **question:** *"Look right?"*
+   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+
+**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
+
+### Phase 2: Create the Team
+
+**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
+
+> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
+
+6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/).
+
+**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
+
+**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
+
+**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
+```
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
+```
+The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
+
+7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+
+8. **Post-setup input sources** (optional — ask after team is created, not during casting):
+   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
+   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
+   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
+   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
+   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+
+## Examples
+
+**Example flow:**
+1. Coordinator detects no team.md → Init Mode
+2. Runs `git config user.name` → "Brady"
+3. Asks: *"Hey Brady, what are you building?"*
+4. User: *"TypeScript CLI tool with GitHub API integration"*
+5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
+6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
+7. Uses `ask_user` with choices → user selects "Yes, hire this team"
+8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
+9. Says: *"✅ Team hired. Try: 'Keaton, set up the project structure'"*
+
+## Anti-Patterns
+
+- ❌ Creating files before user confirms Phase 1
+- ❌ Mixing agents from different universes in the same cast
+- ❌ Skipping the `ask_user` tool and assuming confirmation
+- ❌ Proceeding to Phase 2 when user said "add someone" or "change a role"
+- ❌ Using `## Team Roster` instead of `## Members` as the header (breaks GitHub workflows)
+- ❌ Forgetting to initialize `.squad/casting/` state files
+- ❌ Reading or storing `git config user.email` (PII violation)

--- a/.agents/skills/logging-conventions/SKILL.md
+++ b/.agents/skills/logging-conventions/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: "logging-conventions"
+description: "slog usage, no third-party logging"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/logging/logging.go, all internal packages"
+---
+
+## Context
+
+Hyoka uses Go's standard `log/slog` package (available since Go 1.21). No third-party logging libraries are used. Logging follows a simple hierarchy: diagnostic logs go to slog, user-facing output goes to stdout/stderr.
+
+## slog Basics
+
+```go
+import "log/slog"
+
+// Debug: development/troubleshooting info
+slog.Debug("Session started", "session_id", sessID, "model", model)
+
+// Info: important events users might care about
+slog.Info("Evaluation complete", "prompt_id", id, "duration_s", elapsed)
+
+// Warn: recoverable issues (grader timeout, build skipped)
+slog.Warn("Grader timeout", "grader_name", name, "duration_s", 30)
+
+// Error: problems that don't stop evaluation (reviewer model unavailable)
+slog.Error("Failed to load skill", "path", p, "error", err)
+```
+
+## Initialization
+
+slog is typically initialized in `main()` or in the logging package:
+
+```go
+// main.go or logging.go
+package main
+
+import (
+    "log/slog"
+    "os"
+)
+
+func init() {
+    // Default: JSON output to stderr
+    handler := slog.NewJSONHandler(os.Stderr, nil)
+    slog.SetDefault(slog.New(handler))
+}
+```
+
+## Log Levels
+
+Control verbosity with `--log-level` flag:
+
+```bash
+go run ./hyoka run --prompt-id ... --log-level debug    # Very verbose
+go run ./hyoka run --prompt-id ... --log-level info     # Important events
+go run ./hyoka run --prompt-id ... --log-level warn     # Warnings only
+```
+
+Mapping (from least to most verbose):
+1. **ERROR** — Errors only
+2. **WARN** — Warnings + errors
+3. **INFO** — Important events + warnings + errors
+4. **DEBUG** — Development diagnostics + everything else
+
+## Structured Attributes
+
+Always use key-value pairs, not formatted strings:
+
+**✓ Correct:**
+```go
+slog.Info("Evaluation started",
+    "prompt_id", promptID,
+    "config", configName,
+    "model", model,
+)
+```
+
+**✗ Incorrect:**
+```go
+slog.Info(fmt.Sprintf("Evaluation %s with config %s using model %s",
+    promptID, configName, model))
+```
+
+Structured attributes enable filtering and aggregation in log analysis tools.
+
+## Logging Pattern: Errors
+
+Always log at the point where you can provide context:
+
+```go
+// Load config
+cfg, err := loadConfig(cfgPath)
+if err != nil {
+    // Log with context
+    slog.Error("Failed to load config",
+        "path", cfgPath,
+        "error", err,
+    )
+    return err
+}
+
+// Process config (no logging here — error means we already logged above)
+if err := processConfig(cfg); err != nil {
+    slog.Error("Failed to process config",
+        "config_name", cfg.Name,
+        "error", err,
+    )
+    return err
+}
+```
+
+## Logging Pattern: Lifecycle Events
+
+Use **Info** for important milestones:
+
+```go
+func (e *Engine) Run(ctx context.Context, prompt *Prompt, cfg *Config) (*Result, error) {
+    slog.Info("Evaluation starting",
+        "prompt_id", prompt.ID,
+        "config", cfg.Name,
+    )
+    defer func(start time.Time) {
+        duration := time.Since(start)
+        slog.Info("Evaluation complete",
+            "prompt_id", prompt.ID,
+            "duration_s", duration.Seconds(),
+        )
+    }(time.Now())
+    
+    // ... evaluation logic
+}
+```
+
+## Logging Pattern: Debug Traces
+
+Use **Debug** for developer troubleshooting:
+
+```go
+// generation phase
+slog.Debug("Copilot session created",
+    "session_id", sess.ID(),
+    "model", cfg.Generator.Model,
+)
+
+slog.Debug("Action captured",
+    "type", action.Type,
+    "tool", action.Tool,
+    "duration_ms", action.DurationMs,
+)
+
+// review phase
+slog.Debug("Review panel score",
+    "reviewer_model", model,
+    "score", score,
+)
+```
+
+## Log File Output
+
+When `--log-file` is specified, slog output is both written to the file and echoed to stderr:
+
+```bash
+go run ./hyoka run ... --log-file hyoka-debug.log
+```
+
+The file captures full debug output; users see warnings and errors in console.
+
+## slog Configuration (if needed)
+
+For custom output formatting:
+
+```go
+import (
+    "log/slog"
+    "os"
+)
+
+// Text format (instead of JSON)
+handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+    Level: slog.LevelDebug,
+})
+slog.SetDefault(slog.New(handler))
+
+// Or with pretty-printing
+handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+    Level:     slog.LevelDebug,
+    AddSource: true,  // Include file:line
+})
+```
+
+## Anti-Patterns
+
+- Logging errors AND returning them with same context (return once, log once)
+- Using `log.Printf` or `fmt.Printf` for diagnostic output (use slog)
+- Logging user output (progress, results) — write to stdout directly
+- String formatting in log arguments (use structured attributes)
+- Logging secrets or sensitive data
+- `slog.Error()` for non-critical issues (use `slog.Warn()`)
+
+## Related Code Locations
+
+- **slog setup:** `hyoka/internal/logging/logging.go`
+- **CLI log-level flag:** `hyoka/cmd/root.go`
+- **Example logging patterns:** `hyoka/internal/eval/engine.go`

--- a/.agents/skills/model-selection/SKILL.md
+++ b/.agents/skills/model-selection/SKILL.md
@@ -1,0 +1,117 @@
+# Model Selection
+
+> Determines which LLM model to use for each agent spawn.
+
+## SCOPE
+
+✅ THIS SKILL PRODUCES:
+- A resolved `model` parameter for every `task` tool call
+- Persistent model preferences in `.squad/config.json`
+- Spawn acknowledgments that include the resolved model
+
+❌ THIS SKILL DOES NOT PRODUCE:
+- Code, tests, or documentation
+- Model performance benchmarks
+- Cost reports or billing artifacts
+
+## Context
+
+Squad supports 18+ models across three tiers (premium, standard, fast). The coordinator must select the right model for each agent spawn. Users can set persistent preferences that survive across sessions.
+
+## 5-Layer Model Resolution Hierarchy
+
+Resolution is **first-match-wins** — the highest layer with a value wins.
+
+| Layer | Name | Source | Persistence |
+|-------|------|--------|-------------|
+| **0a** | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Persistent (survives sessions) |
+| **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
+| **1** | Session Directive | User said "use X" in current session | Session-only |
+| **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
+| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
+| **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
+
+**Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
+
+## AGENT WORKFLOW
+
+### On Session Start
+
+1. READ `.squad/config.json`
+2. CHECK for `defaultModel` field — if present, this is the Layer 0 override for all spawns
+3. CHECK for `agentModelOverrides` field — if present, these are per-agent Layer 0a overrides
+4. STORE both values in session context for the duration
+
+### On Every Agent Spawn
+
+1. CHECK Layer 0a: Is there an `agentModelOverrides.{agentName}` in config.json? → Use it.
+2. CHECK Layer 0b: Is there a `defaultModel` in config.json? → Use it.
+3. CHECK Layer 1: Did the user give a session directive? → Use it.
+4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
+5. CHECK Layer 3: Determine task type:
+   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
+   - Prompts, agent designs → `claude-sonnet-4.6`
+   - Visual/design with image analysis → `claude-opus-4.6`
+   - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
+6. FALLBACK Layer 4: `claude-haiku-4.5`
+7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
+
+### When User Sets a Preference
+
+**Trigger phrases:** "always use X", "use X for everything", "switch to X", "default to X"
+
+1. VALIDATE the model ID against the catalog (18+ models)
+2. WRITE `defaultModel` to `.squad/config.json` (merge, don't overwrite)
+3. ACKNOWLEDGE: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
+
+**Per-agent trigger:** "use X for {agent}"
+
+1. VALIDATE model ID
+2. WRITE to `agentModelOverrides.{agent}` in `.squad/config.json`
+3. ACKNOWLEDGE: `✅ {Agent} will always use {model} — saved to config.`
+
+### When User Clears a Preference
+
+**Trigger phrases:** "switch back to automatic", "clear model preference", "use default models"
+
+1. REMOVE `defaultModel` from `.squad/config.json`
+2. ACKNOWLEDGE: `✅ Model preference cleared — returning to automatic selection.`
+
+### STOP
+
+After resolving the model and including it in the spawn template, this skill is done. Do NOT:
+- Generate model comparison reports
+- Run benchmarks or speed tests
+- Create new config files (only modify existing `.squad/config.json`)
+- Change the model after spawn (fallback chains handle runtime failures)
+
+## Config Schema
+
+`.squad/config.json` model-related fields:
+
+```json
+{
+  "version": 1,
+  "defaultModel": "claude-opus-4.6",
+  "agentModelOverrides": {
+    "fenster": "claude-sonnet-4.6",
+    "mcmanus": "claude-haiku-4.5"
+  }
+}
+```
+
+- `defaultModel` — applies to ALL agents unless overridden by `agentModelOverrides`
+- `agentModelOverrides` — per-agent overrides that take priority over `defaultModel`
+- Both fields are optional. When absent, Layers 1-4 apply normally.
+
+## Fallback Chains
+
+If a model is unavailable (rate limit, plan restriction), retry within the same tier:
+
+```
+Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
+Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
+Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
+```
+
+**Never fall UP in tier.** A fast task won't land on a premium model via fallback.

--- a/.agents/skills/nap/SKILL.md
+++ b/.agents/skills/nap/SKILL.md
@@ -1,0 +1,24 @@
+# Skill: nap
+
+> Context hygiene — compress, prune, archive .squad/ state
+
+## What It Does
+
+Reclaims context window budget by compressing agent histories, pruning old logs,
+archiving stale decisions, and cleaning orphaned inbox files.
+
+## When To Use
+
+- Before heavy fan-out work (many agents will spawn)
+- When history.md files exceed 15KB
+- When .squad/ total size exceeds 1MB
+- After long-running sessions or sprints
+
+## Invocation
+
+- CLI: `squad nap` / `squad nap --deep` / `squad nap --dry-run`
+- REPL: `/nap` / `/nap --dry-run` / `/nap --deep`
+
+## Confidence
+
+medium — Confirmed by team vote (4-1) and initial implementation

--- a/.agents/skills/personal-squad/SKILL.md
+++ b/.agents/skills/personal-squad/SKILL.md
@@ -1,0 +1,57 @@
+# Personal Squad — Skill Document
+
+## What is a Personal Squad?
+
+A personal squad is a user-level collection of AI agents that travel with you across projects. Unlike project agents (defined in a project's `.squad/` directory), personal agents live in your global config directory and are automatically discovered when you start a squad session.
+
+## Directory Structure
+
+```
+~/.config/squad/personal-squad/    # Linux/macOS
+%APPDATA%/squad/personal-squad/    # Windows
+├── agents/
+│   ├── {agent-name}/
+│   │   ├── charter.md
+│   │   └── history.md
+│   └── ...
+└── config.json                    # Optional: personal squad config
+```
+
+## How It Works
+
+1. **Ambient Discovery:** When Squad starts a session, it checks for a personal squad directory
+2. **Merge:** Personal agents are merged into the session cast alongside project agents
+3. **Ghost Protocol:** Personal agents can read project state but not write to it
+4. **Kill Switch:** Set `SQUAD_NO_PERSONAL=1` to disable ambient discovery
+
+## Commands
+
+- `squad personal init` — Bootstrap a personal squad directory
+- `squad personal list` — List your personal agents
+- `squad personal add {name} --role {role}` — Add a personal agent
+- `squad personal remove {name}` — Remove a personal agent
+- `squad cast` — Show the current session cast (project + personal)
+
+## Ghost Protocol
+
+See `templates/ghost-protocol.md` for the full rules. Key points:
+- Personal agents advise; project agents execute
+- No writes to project `.squad/` state
+- Transparent origin tagging in logs
+- Project agents take precedence on conflicts
+
+## Configuration
+
+Optional `config.json` in the personal squad directory:
+```json
+{
+  "defaultModel": "auto",
+  "ghostProtocol": true,
+  "agents": {}
+}
+```
+
+## Environment Variables
+
+- `SQUAD_NO_PERSONAL` — Set to any value to disable personal squad discovery
+- `SQUAD_PERSONAL_DIR` — Override the default personal squad directory path

--- a/.agents/skills/process-lifecycle/SKILL.md
+++ b/.agents/skills/process-lifecycle/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: "process-lifecycle"
+description: "Session creation, workspace isolation, cleanup"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/eval/workspace.go, hyoka/internal/eval/copilot.go, hyoka/internal/clean/"
+---
+
+## Context
+
+Each hyoka evaluation runs in an isolated workspace with its own session. Understanding process lifecycle is critical for debugging eval failures, preventing resource leaks, and writing tests.
+
+## Workspace Lifecycle
+
+### Creation
+
+When an evaluation starts:
+
+```go
+// Create workspace directory
+ws, err := NewWorkspace(ctx, "eval-run-123")
+if err != nil {
+    return fmt.Errorf("create workspace: %w", err)
+}
+defer ws.Close()  // Cleanup deferred
+
+// Start Copilot session in workspace
+sess, err := copilot.NewSession(ctx, &SessionOptions{
+    WorkingDir: ws.Path(),
+    Model:      "claude-opus-4.6",
+    // ...
+})
+```
+
+Workspace is created as a temporary directory:
+- **Linux/Mac:** `/tmp/hyoka-{run_id}-XXXXXX`
+- **Windows:** `%TEMP%\hyoka-{run_id}-XXXXXX`
+- Contains all generated files, logs, and session metadata
+
+### Session Initialization
+
+Copilot SDK launches the agent process:
+
+```
+┌─────────────────────────────────────┐
+│ hyoka (CLI process, PID 1234)       │
+└──────────────┬──────────────────────┘
+               │
+               ├─→ Workspace: /tmp/hyoka-eval-1
+               │
+               └─→ Copilot process (PID 1235) [child]
+                   ├─→ MCP server (PID 1236) [grandchild]
+                   └─→ Tool subprocess (PID 1237) [grandchild]
+```
+
+The CLI tracks all child PIDs for cleanup on signal.
+
+### File Operations
+
+Agent writes generated code to workspace:
+
+```
+/tmp/hyoka-eval-1/
+  main.py           # Generated code
+  test_main.py      # Generated tests
+  Copilot.log       # Session log
+  action_timeline.json  # Captured actions
+```
+
+The CLI captures all file operations in the action timeline.
+
+### Cleanup Phase
+
+When evaluation completes (success or failure):
+
+```go
+// Workspace cleanup
+if err := ws.Close(); err != nil {
+    slog.Warn("Workspace cleanup failed", "path", ws.Path(), "error", err)
+}
+
+// Copilot session cleanup
+if err := sess.Close(); err != nil {
+    slog.Warn("Session cleanup failed", "error", err)
+}
+
+// Orphaned process cleanup (if signal received)
+// kill all child PIDs
+```
+
+Cleanup removes:
+- Workspace directory + all files
+- Copilot process + child processes
+- Temporary MCP servers
+
+## Process Tracking
+
+Hyoka tracks child processes to ensure cleanup on interruption:
+
+```go
+// hyoka/internal/eval/proctracker.go
+tracker := NewProcessTracker()
+
+// Register Copilot process
+tracker.Add(sess.PID())
+
+// On SIGINT, cleanup
+<-sigChan
+tracker.KillAll()  // Kills all tracked processes
+```
+
+### PID Files
+
+For long-running evaluations, PIDs are written to files:
+
+```
+reports/{run_id}/
+  pids.txt     # List of tracked PIDs
+```
+
+If eval crashes, `hyoka clean` reads these files and kills orphaned processes.
+
+## Session State
+
+### Before Generation
+```
+Created ✓
+Tools loaded ✓
+MCP servers started ✓
+Skills injected ✓
+Ready for agent ✓
+```
+
+### During Generation
+```
+Agent running...
+Tool calls executed...
+Files written...
+Actions captured...
+```
+
+### After Generation
+```
+Agent stopped ✓
+Build phase (optional)
+Review phase (if enabled)
+Workspace preserved (for debugging)
+```
+
+### Cleanup
+```
+Workspace deleted ✓
+Session closed ✓
+Processes killed ✓
+```
+
+## Workspace Isolation
+
+Each eval is isolated to prevent:
+- **State leakage:** Code from eval 1 not visible to eval 2
+- **File conflicts:** Two evals writing to same file
+- **Process conflicts:** Child processes from eval 1 interfering with eval 2
+
+This is achieved by:
+- Unique workspace directories (per run ID)
+- Separate Copilot sessions (each with own process tree)
+- Deferred cleanup (filesystem cleanup guaranteed even on panic)
+
+## Cleanup Command
+
+```bash
+go run ./hyoka clean
+```
+
+This command:
+1. Finds all abandoned sessions (workspace dirs left on disk)
+2. Reads PIDs from `reports/{run_id}/pids.txt`
+3. Kills orphaned processes
+4. Removes workspace directories
+5. Reports cleaned sessions
+
+Useful after:
+- Interrupted eval runs
+- Process crashes
+- Development/testing (always run before committing)
+
+## Session Limits
+
+Per-evaluation guardrails prevent runaway sessions:
+
+```yaml
+limits:
+  max_turns: 25                    # Max agent turns
+  max_files: 50                    # Max files created
+  max_output_size: 1048576         # Max output (1 MB)
+  max_session_actions: 50          # Max tool calls
+```
+
+When limit exceeded:
+```
+Generation phase stops → Session killed → Error reported
+```
+
+## Testing with Temporary Workspaces
+
+In tests, use stub workspaces:
+
+```go
+// Stub workspace that doesn't create disk files
+type stubWorkspace struct {
+    files map[string]string  // In-memory files
+}
+
+func (sw *stubWorkspace) WriteFile(path, content string) error {
+    sw.files[path] = content
+    return nil
+}
+```
+
+Never create real workspaces in tests (use stubs or temp directories).
+
+## Code Locations
+
+- **Workspace management:** `hyoka/internal/eval/workspace.go`
+- **Process tracking:** `hyoka/internal/eval/proctracker.go`
+- **Cleanup command:** `hyoka/cmd/clean.go`
+- **Session lifecycle:** `hyoka/internal/eval/copilot.go`
+
+## Anti-Patterns
+
+- Not deferring workspace cleanup (may leak on early return)
+- Hardcoding workspace paths (use WorkingDir option)
+- Not tracking child processes (orphans may remain)
+- Assuming workspace persists after eval (it's deleted)
+- Ignoring cleanup errors in tests (cleanup failures indicate leaks)

--- a/.agents/skills/project-conventions/SKILL.md
+++ b/.agents/skills/project-conventions/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: "project-conventions"
+description: "Core conventions and patterns for this codebase"
+domain: "project-conventions"
+confidence: "medium"
+source: "template"
+---
+
+## Context
+
+> **This is a starter template.** Replace the placeholder patterns below with your actual project conventions. Skills train agents on codebase-specific practices — accurate documentation here improves agent output quality.
+
+## Patterns
+
+### [Pattern Name]
+
+Describe a key convention or practice used in this codebase. Be specific about what to do and why.
+
+### Error Handling
+
+<!-- Example: How does your project handle errors? -->
+<!-- - Use try/catch with specific error types? -->
+<!-- - Log to a specific service? -->
+<!-- - Return error objects vs throwing? -->
+
+### Testing
+
+<!-- Example: What test framework? Where do tests live? How to run them? -->
+<!-- - Test framework: Jest/Vitest/node:test/etc. -->
+<!-- - Test location: test/, __tests__/, *.test.ts, etc. -->
+<!-- - Run command: npm test, etc. -->
+
+### Code Style
+
+<!-- Example: Linting, formatting, naming conventions -->
+<!-- - Linter: ESLint config? -->
+<!-- - Formatter: Prettier? -->
+<!-- - Naming: camelCase, snake_case, etc.? -->
+
+### File Structure
+
+<!-- Example: How is the project organized? -->
+<!-- - src/ — Source code -->
+<!-- - test/ — Tests -->
+<!-- - docs/ — Documentation -->
+
+## Examples
+
+```
+// Add code examples that demonstrate your conventions
+```
+
+## Anti-Patterns
+
+<!-- List things to avoid in this codebase -->
+- **[Anti-pattern]** — Explanation of what not to do and why.

--- a/.agents/skills/prompt-conventions/SKILL.md
+++ b/.agents/skills/prompt-conventions/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: "prompt-conventions"
+description: "Prompt frontmatter format, properties, migration"
+domain: "content"
+confidence: "high"
+source: "hyoka/internal/prompt/prompt.go, prompts/*.md files"
+---
+
+## Context
+
+Hyoka prompts are Markdown files with YAML frontmatter. The frontmatter defines metadata (service, language, category, difficulty) that's used for filtering, tool selection, and grading. Prompts are organized by language/service and must follow a consistent structure.
+
+## Prompt File Structure
+
+```markdown
+---
+id: identity-dp-python-default-credential
+service: identity
+language: python
+plane: data-plane
+category: auth
+difficulty: beginner
+tags: [authentication, patterns]
+---
+
+# Prompt Title
+
+Your task is to generate Python code that uses the Azure Identity library...
+
+## Requirements
+
+- Code should handle authentication
+- Include error handling
+- Add type hints
+
+## Expected Output
+
+A Python script that demonstrates the DefaultAzureCredential pattern.
+```
+
+## Frontmatter Fields
+
+### Required Fields
+
+- **id:** Unique identifier (pattern: `{service}-{plane}-{language}-{short-name}`)
+  - Examples: `identity-dp-python-default-credential`, `key-vault-mp-dotnet-crud`
+  - Must be unique across all prompts
+  - Snake_case, lowercase
+
+- **service:** Azure service name
+  - Values: `identity`, `key-vault`, `storage`, `cosmos-db`, etc.
+  - Used for `--service` filtering
+
+- **language:** Programming language
+  - Values: `python`, `dotnet`, `java`, `js-ts`, `go`, `rust`, `cpp`
+  - Used for `--language` filtering and tool selection
+
+- **plane:** Deployment plane
+  - Values: `data-plane` or `management-plane`
+  - Used for `--plane` filtering
+
+### Optional Fields
+
+- **category:** Use-case category
+  - Examples: `auth`, `crud`, `pagination`, `streaming`
+  - Used for `--category` filtering
+
+- **difficulty:** Skill level for generated code
+  - Values: `beginner`, `intermediate`, `advanced`
+  - Informational for report context
+
+- **tags:** Additional keyword filters (array)
+  - Examples: `[authentication, error-handling, async]`
+  - Used for `--tags` filtering
+
+## File Organization
+
+Prompts are stored in `prompts/` organized by service/language:
+
+```
+prompts/
+  identity/
+    python/
+      default-credential.md
+      managed-identity.md
+    dotnet/
+      default-credential.md
+  key-vault/
+    python/
+      crud-secrets.md
+    go/
+      get-secret.md
+```
+
+## Prompt ID Naming Convention
+
+Pattern: `{service}-{plane-abbrev}-{language}-{short-name}`
+
+- **service:** Service name (identity, key-vault, storage, etc.)
+- **plane-abbrev:** `dp` (data-plane) or `mp` (management-plane)
+- **language:** `python`, `dotnet`, `java`, `js-ts`, `go`, `rust`, `cpp`
+- **short-name:** Hyphenated description (max 4 words)
+
+Examples:
+- ✓ `identity-dp-python-default-credential`
+- ✓ `key-vault-dp-dotnet-crud-secrets`
+- ✓ `storage-mp-java-list-containers`
+- ✗ `DefaultCredentialPython` (wrong case, no plane/service prefix)
+- ✗ `identity-python-auth-with-logging-and-retry` (too long)
+
+## Prompt Content Guidelines
+
+### Header
+Brief, actionable description of the task.
+
+### Requirements Section
+List concrete requirements for generated code:
+- Functionality (what should the code do?)
+- Error handling expectations
+- Language-specific conventions (e.g., type hints for Python)
+- API patterns to follow
+
+### Expected Output
+Describe the form of generated code (script vs. module, entry point, etc.)
+
+### Example (optional)
+Show a snippet of expected behavior or output format.
+
+## Properties for Tool Selection
+
+Properties in tool config filters match prompt metadata:
+
+```yaml
+# Config
+tools:
+  - name: python_test_runner
+    properties:
+      language: python    # Matches prompt.language
+      service: key-vault  # Matches prompt.service
+```
+
+Prompt metadata is compared against tool properties — tools only appear if all properties match.
+
+## Prompt Validation
+
+Validate prompts before running:
+
+```bash
+go run ./hyoka validate --prompt-id identity-dp-python-default-credential
+
+# Or validate all prompts
+go run ./hyoka validate
+```
+
+The validator checks:
+- Required frontmatter fields present
+- ID uniqueness
+- Language/service/plane values valid
+- Prompt file exists and is readable
+
+## Property Migration (Advanced)
+
+For changes to property schema or tool filtering logic:
+
+1. **Update prompt frontmatter** in batch:
+   ```bash
+   # Script to add/rename fields across all prompts
+   for f in prompts/*/*.md; do
+     # Add new field or rename existing
+     sed -i 's/old_field:/new_field:/' "$f"
+   done
+   ```
+
+2. **Update tool filters** in config:
+   ```yaml
+   # Before
+   properties:
+     lang: python
+   
+   # After (new property name)
+   properties:
+     language: python
+   ```
+
+3. **Test with dry-run:**
+   ```bash
+   go run ./hyoka run --service identity --language python --dry-run
+   ```
+
+## Listing and Filtering Prompts
+
+```bash
+# List all prompts
+go run ./hyoka list
+
+# Filter by service
+go run ./hyoka list --service key-vault
+
+# Filter by language + service
+go run ./hyoka list --service identity --language python
+
+# Filter by tags
+go run ./hyoka list --tags "auth,crud"
+```
+
+## Anti-Patterns
+
+- IDs with uppercase or special characters (use snake_case)
+- Inconsistent plane values (`data_plane` vs `data-plane`)
+- Missing required frontmatter fields
+- Prompts with same ID in different directories (validator should catch)
+- Tool properties that don't match any prompt metadata
+- Overly specific prompts (too narrow to be useful across models)
+
+## Related Code Locations
+
+- **Prompt structure:** `hyoka/internal/prompt/prompt.go`
+- **Validation logic:** `hyoka/internal/validate/validate.go`
+- **Example prompts:** `hyoka/prompts/*/`
+- **List command:** `hyoka/cmd/list.go`

--- a/.agents/skills/property-migration/SKILL.md
+++ b/.agents/skills/property-migration/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: "property-migration"
+description: "How properties map works, snake_case convention"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/config/tools.go, hyoka/internal/prompt/prompt.go"
+---
+
+## Context
+
+Hyoka uses property-based tool filtering to dynamically match tools to prompts based on metadata (language, service, plane). This allows a single config to work across multiple prompts without hardcoding tool lists. Property migration is the process of updating the property schema when business logic or tool definitions change.
+
+## Property System Overview
+
+### How It Works
+
+1. **Prompt declares properties:**
+   ```yaml
+   id: key-vault-dp-python-crud
+   language: python
+   service: key-vault
+   plane: data-plane
+   ```
+
+2. **Tool defines property filters:**
+   ```yaml
+   # config.yaml
+   tools:
+     - name: python_key_vault_sdk
+       include: true
+       properties:
+         language: python
+         service: key-vault
+   ```
+
+3. **Engine matches at runtime:**
+   ```
+   Does prompt.language (python) match tool.properties.language (python)? ✓
+   Does prompt.service (key-vault) match tool.properties.service (key-vault)? ✓
+   → Tool included in session
+   ```
+
+4. **No match excludes tool:**
+   ```
+   Does prompt.language (dotnet) match tool.properties.language (python)? ✗
+   → Tool hidden from session
+   ```
+
+## Property Convention: snake_case
+
+All property names and values use **snake_case** (not camelCase or kebab-case):
+
+**✓ Correct:**
+```yaml
+properties:
+  language: python            # not "Language" or "PYTHON"
+  service: key_vault          # not "keyVault" or "Key-Vault"
+  deployment_plane: data_plane  # not "deploymentPlane"
+```
+
+**✗ Incorrect:**
+```yaml
+properties:
+  Language: python            # CamelCase in key
+  language: Python            # CamelCase in value
+  service: Key-Vault          # Kebab-case
+```
+
+## Valid Property Names
+
+- **language:** Python, dotnet, java, js_ts, go, rust, cpp
+- **service:** identity, key_vault, storage, cosmos_db, app_config, etc.
+- **plane:** data_plane, management_plane
+- **category:** auth, crud, pagination, streaming, etc.
+- **difficulty:** beginner, intermediate, advanced (optional)
+
+## Migration Scenarios
+
+### Scenario 1: Adding a New Property
+
+When you want to filter tools by a new dimension:
+
+1. **Define in prompt frontmatter:**
+   ```yaml
+   # prompts/storage/python/blob-upload.md
+   tier: premium  # New property
+   ```
+
+2. **Add to tool filter (optional):**
+   ```yaml
+   # config.yaml
+   tools:
+     - name: storage_premium_tools
+       properties:
+         language: python
+         service: storage
+         tier: premium  # Now filtered
+   ```
+
+3. **Verify tool visibility:**
+   ```bash
+   go run ./hyoka run --prompt-id storage-dp-python-blob-upload --dry-run
+   # Shows: storage_premium_tools included
+   
+   go run ./hyoka run --prompt-id storage-dp-python-blob-list --dry-run
+   # Shows: storage_premium_tools NOT included (no tier=premium)
+   ```
+
+### Scenario 2: Renaming a Property
+
+If you rename `service` to `azure_service`:
+
+1. **Update all prompts** (batch script):
+   ```bash
+   for f in prompts/**/*.md; do
+     sed -i 's/^service:/azure_service:/' "$f"
+   done
+   ```
+
+2. **Update all configs:**
+   ```yaml
+   # Before
+   properties:
+     service: key_vault
+   
+   # After
+   properties:
+     azure_service: key_vault
+   ```
+
+3. **Validate no orphaned properties:**
+   ```bash
+   grep -r "service:" prompts/  # Should be empty (all renamed)
+   grep -r "service:" configs/  # Should be empty
+   ```
+
+### Scenario 3: Changing Property Values
+
+If `plane` values change from `data-plane` to `data_plane`:
+
+1. **Update all prompts:**
+   ```bash
+   for f in prompts/**/*.md; do
+     sed -i 's/plane: data-plane/plane: data_plane/' "$f"
+     sed -i 's/plane: management-plane/plane: management_plane/' "$f"
+   done
+   ```
+
+2. **Update all configs:**
+   ```yaml
+   # Before
+   properties:
+     plane: data-plane
+   
+   # After
+   properties:
+     plane: data_plane
+   ```
+
+3. **Test property matching:**
+   ```bash
+   go run ./hyoka list --plane data_plane
+   # Verify correct prompts listed
+   ```
+
+## Property Matching Logic
+
+```go
+// hyoka/internal/config/tools.go
+func matchesProperties(prompt *Prompt, toolProps map[string]string) bool {
+    for key, expectedValue := range toolProps {
+        actualValue := prompt.GetProperty(key)
+        if actualValue != expectedValue {
+            return false  // Property mismatch → tool not included
+        }
+    }
+    return true  // All properties match → tool included
+}
+```
+
+## Best Practices
+
+1. **Use properties consistently:** If a property exists, use it in ALL relevant places (prompts + tools)
+2. **Document property semantics:** List valid values in architecture docs or code comments
+3. **Test after migration:** Run `go run ./hyoka list` to verify filtering still works
+4. **Batch migrations:** Update prompts and configs in the same commit
+5. **Avoid redundant properties:** Don't encode info that's already in prompt ID
+
+## Testing Property Matches
+
+Create a test to verify property matching:
+
+```go
+func TestPropertyMatching(t *testing.T) {
+    tests := []struct {
+        prompt   *Prompt
+        toolProp map[string]string
+        expect   bool
+    }{
+        {
+            prompt: &Prompt{Language: "python", Service: "key_vault"},
+            toolProp: map[string]string{
+                "language": "python",
+                "service": "key_vault",
+            },
+            expect: true,
+        },
+        {
+            prompt: &Prompt{Language: "dotnet", Service: "key_vault"},
+            toolProp: map[string]string{
+                "language": "python",  // Mismatch
+                "service": "key_vault",
+            },
+            expect: false,
+        },
+    }
+    
+    for _, tt := range tests {
+        if matchesProperties(tt.prompt, tt.toolProp) != tt.expect {
+            t.Fail()
+        }
+    }
+}
+```
+
+## Code Locations
+
+- **Property matching logic:** `hyoka/internal/config/tools.go`
+- **Prompt property parsing:** `hyoka/internal/prompt/prompt.go`
+- **Tool configuration:** `hyoka/internal/config/config.go`
+- **Example prompts:** `hyoka/prompts/**/*.md`
+
+## Anti-Patterns
+
+- Using camelCase or kebab-case for property names (use snake_case)
+- Hardcoding tool names instead of using property filters
+- Property values that don't match prompt metadata
+- Leaving orphaned properties in configs after migration
+- Not testing property matching after schema changes

--- a/.agents/skills/report-generation/SKILL.md
+++ b/.agents/skills/report-generation/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: "report-generation"
+description: "JSON/HTML/Markdown reports, template system"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/report/*.go"
+---
+
+## Context
+
+Hyoka generates multi-format evaluation reports (JSON, HTML, Markdown) from a unified internal representation. Reports capture the entire evaluation timeline: generation, build, grading, and review phases.
+
+## Report Formats
+
+### JSON Report
+
+The canonical format — contains all raw data and is used to generate other formats:
+
+```json
+{
+  "metadata": {
+    "run_id": "eval-2024-04-06-123456",
+    "timestamp": "2024-04-06T12:34:56Z",
+    "prompt": {
+      "id": "identity-dp-python-default-credential",
+      "service": "identity",
+      "language": "python"
+    },
+    "config": {
+      "name": "baseline/claude-opus-4.6"
+    }
+  },
+  "generation": {
+    "status": "success",
+    "duration_ms": 45000,
+    "code": "# Generated Python code...",
+    "action_timeline": {
+      "events": [...],
+      "summary": {...}
+    }
+  },
+  "build": {
+    "status": "success",
+    "duration_ms": 5000,
+    "stdout": "Compilation successful",
+    "stderr": ""
+  },
+  "graders": [
+    {
+      "kind": "behavior",
+      "name": "tool_compliance",
+      "pass": true,
+      "score": 1.0,
+      "message": "All required tools used"
+    }
+  ],
+  "review": {
+    "status": "success",
+    "reviewers": [
+      {
+        "model": "claude-opus-4.6",
+        "score": 0.9,
+        "findings": "Code is mostly correct..."
+      }
+    ],
+    "consensus_score": 0.85
+  }
+}
+```
+
+### HTML Report
+
+Browser-viewable report with interactive elements:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Evaluation Report: identity-dp-python</title>
+  <style>...</style>
+</head>
+<body>
+  <div class="report-container">
+    <h1>Evaluation Report</h1>
+    <section class="generation">
+      <h2>Generation Phase</h2>
+      <code>{{ .Code }}</code>
+      <div class="timeline">...</div>
+    </section>
+    <section class="graders">
+      <h2>Grading Results</h2>
+      ...
+    </section>
+  </div>
+  <script>
+    // Interactive features (expand/collapse, filtering)
+  </script>
+</body>
+</html>
+```
+
+### Markdown Report
+
+Human-readable text format for documentation and sharing:
+
+```markdown
+# Evaluation Report: identity-dp-python
+
+## Generation
+- Status: Success
+- Duration: 45s
+
+## Code
+\`\`\`python
+# Generated code...
+\`\`\`
+
+## Graders
+| Grader | Status | Score | Message |
+|--------|--------|-------|---------|
+| behavior | Pass | 1.0 | All required tools used |
+| lint | Pass | 0.95 | 1 warning |
+
+## Review Panel
+- Claude Opus 4.6: 0.9
+- GPT-5.4: 0.85
+- Consensus: 0.875
+```
+
+## Report Generation Pipeline
+
+1. **Evaluation Completion:** Engine returns `EvaluationResult` with all phase outputs
+2. **JSON Marshaling:** Convert result to JSON bytes
+3. **File Write:** Save JSON to `reports/{run_id}/report.json`
+4. **Template Rendering:** Apply HTML/Markdown templates to JSON
+5. **Asset Linking:** Copy static assets (CSS, JS) to report directory
+
+## Template System
+
+Reports use Go's `text/template` package:
+
+```go
+// report.go
+type ReportTemplate struct {
+    HTML      *template.Template
+    Markdown  *template.Template
+}
+
+func (rt *ReportTemplate) RenderHTML(data EvaluationResult) (string, error) {
+    var buf bytes.Buffer
+    if err := rt.HTML.Execute(&buf, data); err != nil {
+        return "", err
+    }
+    return buf.String(), nil
+}
+```
+
+### Template Variables
+
+Templates can access all fields from `EvaluationResult`:
+
+```handlebars
+{{- .Metadata.RunID }}
+{{- .Generation.Status }}
+{{- range .Graders }}
+  {{- .Kind }}: {{- .Score }}
+{{- end }}
+```
+
+## Report Storage
+
+Reports are written to:
+```
+reports/
+  {run_id}/
+    report.json           # Canonical data
+    report.html           # Browser view
+    report.md             # Text format
+    assets/
+      style.css
+      script.js
+```
+
+## Multi-Report Aggregation
+
+For batch runs (multiple prompts × configs):
+
+```json
+{
+  "batch_metadata": {
+    "run_date": "2024-04-06",
+    "prompts": 5,
+    "configs": 2,
+    "total_evals": 10
+  },
+  "summary": {
+    "avg_score": 0.82,
+    "pass_count": 8,
+    "fail_count": 2
+  },
+  "reports": [
+    { "prompt_id": "...", "config": "...", "result": {...} }
+  ]
+}
+```
+
+## Re-rendering from JSON
+
+The `rerender` command regenerates HTML/Markdown from saved JSON:
+
+```bash
+go run ./hyoka rerender --report-id eval-2024-04-06-123456 --format html
+```
+
+This allows updating templates without re-running evaluations.
+
+## Code Locations
+
+- **Report structure:** `hyoka/internal/report/report.go`
+- **JSON marshaling:** `hyoka/internal/report/json.go`
+- **HTML/Markdown rendering:** `hyoka/internal/report/render.go`
+- **Templates:** `hyoka/templates/`
+
+## Anti-Patterns
+
+- Hardcoding paths in templates (use config for asset paths)
+- Not including action timeline in JSON (required for reproducibility)
+- Rendering HTML/Markdown before generation completes (wait for all phases)
+- Losing build/grader details in summary format (preserve full data in JSON)
+- Assuming report directory exists (create it before writing)

--- a/.agents/skills/reskill/SKILL.md
+++ b/.agents/skills/reskill/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: "reskill"
+description: "Team-wide charter and history optimization through skill extraction"
+domain: "team-optimization"
+confidence: "high"
+source: "manual — Brady directive to reduce per-agent context overhead"
+---
+
+## Context
+
+When the coordinator hears "team, reskill" (or similar: "optimize context", "slim down charters"), trigger a team-wide optimization pass. The goal: reduce per-agent context consumption by extracting shared patterns from charters and histories into reusable skills.
+
+This is a periodic maintenance activity. Run whenever charter/history bloat is suspected.
+
+## Process
+
+### Step 1: Audit
+Read all agent charters and histories. Measure byte sizes. Identify:
+
+- **Boilerplate** — sections repeated across ≥3 charters with <10% variation (collaboration, model, boundaries template)
+- **Shared knowledge** — domain knowledge duplicated in 2+ charters (incident postmortems, technical patterns)
+- **Mature learnings** — history entries appearing 3+ times across agents that should be promoted to skills
+
+### Step 2: Extract
+For each identified pattern:
+1. Create or update a skill at `.squad/skills/{skill-name}/SKILL.md`
+2. Follow the skill template format (frontmatter + Context + Patterns + Examples + Anti-Patterns)
+3. Set confidence: low (first observation), medium (2+ agents), high (team-wide)
+
+### Step 3: Trim
+**Charters** — target ≤1.5KB per agent:
+- Remove Collaboration section entirely (spawn prompt + agent-collaboration skill covers it)
+- Remove Voice section (tagline blockquote at top of charter already captures it)
+- Trim Model section to single line: `Preferred: {model}`
+- Remove "When I'm unsure" boilerplate from Boundaries
+- Remove domain knowledge now covered by a skill — add skill reference comment if helpful
+- Keep: Identity, What I Own, unique How I Work patterns, Boundaries (domain list only)
+
+**Histories** — target ≤8KB per agent:
+- Apply history-hygiene skill to any history >12KB
+- Promote recurring patterns (3+ occurrences across agents) to skills
+- Summarize old entries into `## Core Context` section
+- Remove session-specific metadata (dates, branch names, requester names)
+
+### Step 4: Report
+Output a savings table:
+
+| Agent | Charter Before | Charter After | History Before | History After | Saved |
+|-------|---------------|---------------|----------------|---------------|-------|
+
+Include totals and percentage reduction.
+
+## Patterns
+
+### Minimal Charter Template (target format after reskill)
+
+```
+# {Name} — {Role}
+
+> {Tagline — one sentence capturing voice and philosophy}
+
+## Identity
+- **Name:** {Name}
+- **Role:** {Role}
+- **Expertise:** {comma-separated list}
+
+## What I Own
+- {bullet list of owned artifacts/domains}
+
+## How I Work
+- {unique patterns and principles — NOT boilerplate}
+
+## Boundaries
+**I handle:** {domain list}
+**I don't handle:** {explicit exclusions}
+
+## Model
+Preferred: {model}
+```
+
+### Skill Extraction Threshold
+- **1 charter** → leave in charter (unique to that agent)
+- **2 charters** → consider extracting if >500 bytes of overlap
+- **3+ charters** → always extract to a shared skill
+
+## Anti-Patterns
+- Don't delete unique per-agent identity or domain-specific knowledge
+- Don't create skills for content only one agent uses
+- Don't merge unrelated patterns into a single mega-skill
+- Don't remove Model preference line (coordinator needs it for model selection)
+- Don't touch `.squad/decisions.md` during reskill
+- Don't remove the tagline blockquote — it's the charter's soul in one line

--- a/.agents/skills/reviewer-protocol/SKILL.md
+++ b/.agents/skills/reviewer-protocol/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "reviewer-protocol"
+description: "Reviewer rejection workflow and strict lockout semantics"
+domain: "orchestration"
+confidence: "high"
+source: "extracted"
+---
+
+## Context
+
+When a team member has a **Reviewer** role (e.g., Tester, Code Reviewer, Lead), they may approve or reject work from other agents. On rejection, the coordinator enforces strict lockout rules to ensure the original author does NOT self-revise. This prevents defensive feedback loops and ensures independent review.
+
+## Patterns
+
+### Reviewer Rejection Protocol
+
+When a team member has a **Reviewer** role:
+
+- Reviewers may **approve** or **reject** work from other agents.
+- On **rejection**, the Reviewer may choose ONE of:
+  1. **Reassign:** Require a *different* agent to do the revision (not the original author).
+  2. **Escalate:** Require a *new* agent be spawned with specific expertise.
+- The Coordinator MUST enforce this. If the Reviewer says "someone else should fix this," the original agent does NOT get to self-revise.
+- If the Reviewer approves, work proceeds normally.
+
+### Strict Lockout Semantics
+
+When an artifact is **rejected** by a Reviewer:
+
+1. **The original author is locked out.** They may NOT produce the next version of that artifact. No exceptions.
+2. **A different agent MUST own the revision.** The Coordinator selects the revision author based on the Reviewer's recommendation (reassign or escalate).
+3. **The Coordinator enforces this mechanically.** Before spawning a revision agent, the Coordinator MUST verify that the selected agent is NOT the original author. If the Reviewer names the original author as the fix agent, the Coordinator MUST refuse and ask the Reviewer to name a different agent.
+4. **The locked-out author may NOT contribute to the revision** in any form — not as a co-author, advisor, or pair. The revision must be independently produced.
+5. **Lockout scope:** The lockout applies to the specific artifact that was rejected. The original author may still work on other unrelated artifacts.
+6. **Lockout duration:** The lockout persists for that revision cycle. If the revision is also rejected, the same rule applies again — the revision author is now also locked out, and a third agent must revise.
+7. **Deadlock handling:** If all eligible agents have been locked out of an artifact, the Coordinator MUST escalate to the user rather than re-admitting a locked-out author.
+
+## Examples
+
+**Example 1: Reassign after rejection**
+1. Fenster writes authentication module
+2. Hockney (Tester) reviews → rejects: "Error handling is missing. Verbal should fix this."
+3. Coordinator: Fenster is now locked out of this artifact
+4. Coordinator spawns Verbal to revise the authentication module
+5. Verbal produces v2
+6. Hockney reviews v2 → approves
+7. Lockout clears for next artifact
+
+**Example 2: Escalate for expertise**
+1. Edie writes TypeScript config
+2. Keaton (Lead) reviews → rejects: "Need someone with deeper TS knowledge. Escalate."
+3. Coordinator: Edie is now locked out
+4. Coordinator spawns new agent (or existing TS expert) to revise
+5. New agent produces v2
+6. Keaton reviews v2
+
+**Example 3: Deadlock handling**
+1. Fenster writes module → rejected
+2. Verbal revises → rejected
+3. Hockney revises → rejected
+4. All 3 eligible agents are now locked out
+5. Coordinator: "All eligible agents have been locked out. Escalating to user: [artifact details]"
+
+**Example 4: Reviewer accidentally names original author**
+1. Fenster writes module → rejected
+2. Hockney says: "Fenster should fix the error handling"
+3. Coordinator: "Fenster is locked out as the original author. Please name a different agent."
+4. Hockney: "Verbal, then"
+5. Coordinator spawns Verbal
+
+## Anti-Patterns
+
+- ❌ Allowing the original author to self-revise after rejection
+- ❌ Treating the locked-out author as an "advisor" or "co-author" on the revision
+- ❌ Re-admitting a locked-out author when deadlock occurs (must escalate to user)
+- ❌ Applying lockout across unrelated artifacts (scope is per-artifact)
+- ❌ Accepting the Reviewer's assignment when they name the original author (must refuse and ask for a different agent)
+- ❌ Clearing lockout before the revision is approved (lockout persists through revision cycle)
+- ❌ Skipping verification that the revision agent is not the original author

--- a/.agents/skills/secret-handling/SKILL.md
+++ b/.agents/skills/secret-handling/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: secret-handling
+description: Never read .env files or write secrets to .squad/ committed files
+domain: security, file-operations, team-collaboration
+confidence: high
+source: earned (issue #267 — credential leak incident)
+---
+
+## Context
+
+Spawned agents have read access to the entire repository, including `.env` files containing live credentials. If an agent reads secrets and writes them to `.squad/` files (decisions, logs, history), Scribe auto-commits them to git, exposing them in remote history. This skill codifies absolute prohibitions and safe alternatives.
+
+## Patterns
+
+### Prohibited File Reads
+
+**NEVER read these files:**
+- `.env` (production secrets)
+- `.env.local` (local dev secrets)
+- `.env.production` (production environment)
+- `.env.development` (development environment)
+- `.env.staging` (staging environment)
+- `.env.test` (test environment with real credentials)
+- Any file matching `.env.*` UNLESS explicitly allowed (see below)
+
+**Allowed alternatives:**
+- `.env.example` (safe — contains placeholder values, no real secrets)
+- `.env.sample` (safe — documentation template)
+- `.env.template` (safe — schema/structure reference)
+
+**If you need config info:**
+1. **Ask the user directly** — "What's the database connection string?"
+2. **Read `.env.example`** — shows structure without exposing secrets
+3. **Read documentation** — check `README.md`, `docs/`, config guides
+
+**NEVER assume you can "just peek at .env to understand the schema."** Use `.env.example` or ask.
+
+### Prohibited Output Patterns
+
+**NEVER write these to `.squad/` files:**
+
+| Pattern Type | Examples | Regex Pattern (for scanning) |
+|--------------|----------|-------------------------------|
+| API Keys | `OPENAI_API_KEY=sk-proj-...`, `GITHUB_TOKEN=ghp_...` | `[A-Z_]+(?:KEY|TOKEN|SECRET)=[^\s]+` |
+| Passwords | `DB_PASSWORD=super_secret_123`, `password: "..."` | `(?:PASSWORD|PASS|PWD)[:=]\s*["']?[^\s"']+` |
+| Connection Strings | `postgres://user:pass@host:5432/db`, `Server=...;Password=...` | `(?:postgres|mysql|mongodb)://[^@]+@|(?:Server|Host)=.*(?:Password|Pwd)=` |
+| JWT Tokens | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` | `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` |
+| Private Keys | `-----BEGIN PRIVATE KEY-----`, `-----BEGIN RSA PRIVATE KEY-----` | `-----BEGIN [A-Z ]+PRIVATE KEY-----` |
+| AWS Credentials | `AKIA...`, `aws_secret_access_key=...` | `AKIA[0-9A-Z]{16}|aws_secret_access_key=[^\s]+` |
+| Email Addresses | `user@example.com` (PII violation per team decision) | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` |
+
+**What to write instead:**
+- Placeholder values: `DATABASE_URL=<set in .env>`
+- Redacted references: `API key configured (see .env.example)`
+- Architecture notes: "App uses JWT auth — token stored in session"
+- Schema documentation: "Requires OPENAI_API_KEY, GITHUB_TOKEN (see .env.example for format)"
+
+### Scribe Pre-Commit Validation
+
+**Before committing `.squad/` changes, Scribe MUST:**
+
+1. **Scan all staged files** for secret patterns (use regex table above)
+2. **Check for prohibited file names** (don't commit `.env` even if manually staged)
+3. **If secrets detected:**
+   - STOP the commit (do NOT proceed)
+   - Remove the file from staging: `git reset HEAD <file>`
+   - Report to user:
+     ```
+     🚨 SECRET DETECTED — commit blocked
+     
+     File: .squad/decisions/inbox/river-db-config.md
+     Pattern: DATABASE_URL=postgres://user:password@localhost:5432/prod
+     
+     This file contains credentials and MUST NOT be committed.
+     Please remove the secret, replace with placeholder, and try again.
+     ```
+   - Exit with error (never silently skip)
+
+4. **If no secrets detected:**
+   - Proceed with commit as normal
+
+**Implementation note for Scribe:**
+- Run validation AFTER staging files, BEFORE calling `git commit`
+- Use PowerShell `Select-String` or `git diff --cached` to scan staged content
+- Fail loud — secret leaks are unacceptable, blocking the commit is correct behavior
+
+### Remediation — If a Secret Was Already Committed
+
+**If you discover a secret in git history:**
+
+1. **STOP immediately** — do not make more commits
+2. **Alert the user:**
+   ```
+   🚨 CREDENTIAL LEAK DETECTED
+   
+   A secret was found in git history:
+   Commit: abc1234
+   File: .squad/decisions/inbox/agent-config.md
+   Pattern: API_KEY=sk-proj-...
+   
+   This requires immediate remediation:
+   1. Revoke the exposed credential (regenerate API key, rotate password)
+   2. Remove from git history (git filter-repo or BFG)
+   3. Force-push the cleaned history
+   
+   Do NOT proceed with new work until this is resolved.
+   ```
+3. **Do NOT attempt to fix it yourself** — secret removal requires specialized tools
+4. **Wait for user confirmation** before resuming work
+
+## Examples
+
+### ✓ Correct: Reading Config Schema
+
+**Agent needs to know what environment variables are required:**
+
+```
+Agent: "What environment variables does this app need?"
+→ Reads `.env.example`:
+    OPENAI_API_KEY=sk-...
+    DATABASE_URL=postgres://user:pass@localhost:5432/db
+    REDIS_URL=redis://localhost:6379
+
+→ Writes to .squad/decisions/inbox/river-env-setup.md:
+    "App requires three environment variables:
+    - OPENAI_API_KEY (OpenAI API key, format: sk-...)
+    - DATABASE_URL (Postgres connection string)
+    - REDIS_URL (Redis connection string)
+    See .env.example for full schema."
+```
+
+### ✗ Incorrect: Reading Live Credentials
+
+**Agent needs to know database schema:**
+
+```
+Agent: (reads .env)
+    DATABASE_URL=postgres://admin:super_secret_pw@prod.example.com:5432/appdb
+
+→ Writes to .squad/decisions/inbox/river-db-schema.md:
+    "Database connection: postgres://admin:super_secret_pw@prod.example.com:5432/appdb"
+    
+🚨 VIOLATION: Live credential written to committed file
+```
+
+**Correct approach:**
+```
+Agent: (reads .env.example OR asks user)
+User: "It's a Postgres database, schema is in migrations/"
+
+→ Writes to .squad/decisions/inbox/river-db-schema.md:
+    "Database: Postgres (connection configured in .env). Schema defined in db/migrations/."
+```
+
+### ✓ Correct: Scribe Pre-Commit Validation
+
+**Scribe is about to commit:**
+
+```powershell
+# Stage files
+git add .squad/
+
+# Scan staged content for secrets
+$stagedContent = git diff --cached
+$secretPatterns = @(
+    '[A-Z_]+(?:KEY|TOKEN|SECRET)=[^\s]+',
+    '(?:PASSWORD|PASS|PWD)[:=]\s*["'']?[^\s"'']+',
+    'eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+)
+
+$detected = $false
+foreach ($pattern in $secretPatterns) {
+    if ($stagedContent -match $pattern) {
+        $detected = $true
+        Write-Host "🚨 SECRET DETECTED: $($matches[0])"
+        break
+    }
+}
+
+if ($detected) {
+    # Remove from staging, report, exit
+    git reset HEAD .squad/
+    Write-Error "Commit blocked — secret detected in staged files"
+    exit 1
+}
+
+# Safe to commit
+git commit -F $msgFile
+```
+
+## Anti-Patterns
+
+- ❌ Reading `.env` "just to check the schema" — use `.env.example` instead
+- ❌ Writing "sanitized" connection strings that still contain credentials
+- ❌ Assuming "it's just a dev environment" makes secrets safe to commit
+- ❌ Committing first, scanning later — validation MUST happen before commit
+- ❌ Silently skipping secret detection — fail loud, never silent
+- ❌ Trusting agents to "know better" — enforce at multiple layers (prompt, hook, architecture)
+- ❌ Writing secrets to "temporary" files in `.squad/` — Scribe commits ALL `.squad/` changes
+- ❌ Extracting "just the host" from a connection string — still leaks infrastructure topology

--- a/.agents/skills/serve-patterns/SKILL.md
+++ b/.agents/skills/serve-patterns/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: "serve-patterns"
+description: "API endpoints, SPA dashboard, path traversal protection"
+domain: "architecture"
+confidence: "high"
+source: "hyoka/internal/serve/serve.go"
+---
+
+## Context
+
+The `hyoka serve` command launches a local web server for browsing evaluation reports. The server provides RESTful endpoints for retrieving reports and serves a single-page application (SPA) dashboard. Security focuses on path traversal protection and sandboxing report access.
+
+## Server Architecture
+
+```
+┌─────────────────────┐
+│  SPA Dashboard      │
+│  (React/JS)         │
+└──────────┬──────────┘
+           │ HTTP requests
+           ↓
+┌─────────────────────────────────────┐
+│  REST API (hyoka serve)             │
+│  :8080                              │
+│  ├─ GET /api/reports                │
+│  ├─ GET /api/reports/{id}           │
+│  ├─ GET /api/reports/{id}/json      │
+│  └─ GET /static/*                   │
+└──────────┬──────────────────────────┘
+           │
+           ↓
+      reports/
+      ├─ {run_id1}/
+      │  ├─ report.json
+      │  └─ report.html
+      └─ {run_id2}/
+         ├─ report.json
+         └─ report.html
+```
+
+## API Endpoints
+
+### List Reports
+```
+GET /api/reports
+
+Response:
+{
+  "reports": [
+    {
+      "id": "eval-2024-04-06-123456",
+      "prompt": "identity-dp-python-default-credential",
+      "config": "baseline/claude-opus-4.6",
+      "timestamp": "2024-04-06T12:34:56Z",
+      "status": "success"
+    }
+  ]
+}
+```
+
+### Get Report Metadata
+```
+GET /api/reports/{id}
+
+Response:
+{
+  "id": "eval-2024-04-06-123456",
+  "prompt": {...},
+  "config": {...},
+  "generation": { "status": "success", "duration_ms": 45000 },
+  "build": { "status": "success" },
+  "graders": [...],
+  "review": {...}
+}
+```
+
+### Get Full Report JSON
+```
+GET /api/reports/{id}/json
+
+Response:
+(Full report.json from disk)
+```
+
+### Serve Static Files
+```
+GET /static/{path}
+
+Serves from reports/{id}/assets/ with path traversal protection
+```
+
+## Path Traversal Protection
+
+Critical security feature: prevent access to files outside `reports/` directory.
+
+**Vulnerable pattern:**
+```go
+// ✗ WRONG: Directly concatenates user input
+filePath := filepath.Join(reportDir, userInput)
+// If userInput = "../../etc/passwd", could read arbitrary files!
+```
+
+**Safe pattern:**
+```go
+// ✓ CORRECT: Validate path is within sandbox
+filePath := filepath.Join(reportDir, filepath.Clean(userInput))
+if !strings.HasPrefix(filePath, reportDir) {
+    return fmt.Errorf("path traversal attempt")
+}
+// Read file safely
+```
+
+### Implementation
+
+```go
+// hyoka/internal/serve/serve.go
+func (s *Server) serveReport(w http.ResponseWriter, r *http.Request) {
+    reportID := chi.URLParam(r, "id")
+    
+    // Validate report ID format
+    if !isValidRunID(reportID) {
+        http.Error(w, "Invalid report ID", http.StatusBadRequest)
+        return
+    }
+    
+    // Construct safe path
+    reportPath := filepath.Join(s.reportDir, reportID, "report.json")
+    
+    // Verify path is within sandbox
+    absReportPath, _ := filepath.Abs(reportPath)
+    absSandbox, _ := filepath.Abs(s.reportDir)
+    if !strings.HasPrefix(absReportPath, absSandbox) {
+        http.Error(w, "Forbidden", http.StatusForbidden)
+        return
+    }
+    
+    // Read and serve
+    data, err := os.ReadFile(reportPath)
+    // ...
+}
+```
+
+## Routing
+
+Use a router (e.g., chi) for clean, type-safe route handling:
+
+```go
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) setupRoutes() *chi.Mux {
+    r := chi.NewRouter()
+    
+    // API routes
+    r.Get("/api/reports", s.listReports)
+    r.Get("/api/reports/{id}", s.getReport)
+    r.Get("/api/reports/{id}/json", s.getReportJSON)
+    
+    // Static files (SPA assets)
+    r.Get("/static/*", s.serveStatic)
+    
+    // SPA fallback (serve index.html for unmatched routes)
+    r.NotFound(s.serveSPA)
+    
+    return r
+}
+```
+
+## SPA (Single-Page Application) Serving
+
+The dashboard is a static SPA (HTML + JS) that:
+1. Loads list of reports via `/api/reports`
+2. Fetches detailed report via `/api/reports/{id}`
+3. Renders interactive UI in browser
+
+```go
+// Serve index.html for all non-API routes
+func (s *Server) serveSPA(w http.ResponseWriter, r *http.Request) {
+    if r.RequestURI == "/" {
+        // Home page
+        http.ServeFile(w, r, filepath.Join(s.staticDir, "index.html"))
+        return
+    }
+    
+    // Route not found
+    http.NotFound(w, r)
+}
+```
+
+## CORS (Cross-Origin Resource Sharing)
+
+If SPA is on different domain than API:
+
+```go
+func (s *Server) setupCORS() func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Access-Control-Allow-Origin", "*")
+            w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+            w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+            next.ServeHTTP(w, r)
+        })
+    }
+}
+```
+
+## Error Handling
+
+```go
+func (s *Server) getReport(w http.ResponseWriter, r *http.Request) {
+    reportID := chi.URLParam(r, "id")
+    
+    // Validate ID
+    if reportID == "" {
+        http.Error(w, "Report ID required", http.StatusBadRequest)
+        return
+    }
+    
+    // Read report
+    data, err := s.readReport(reportID)
+    if err != nil {
+        if os.IsNotExist(err) {
+            http.Error(w, "Report not found", http.StatusNotFound)
+            return
+        }
+        http.Error(w, "Internal server error", http.StatusInternalServerError)
+        slog.Error("Failed to read report", "id", reportID, "error", err)
+        return
+    }
+    
+    // Serve
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(data)
+}
+```
+
+## Server Startup
+
+```bash
+# Default (localhost:8080)
+go run ./hyoka serve
+
+# Custom port
+go run ./hyoka serve --port 9000
+
+# Custom report directory
+go run ./hyoka serve --report-dir ./my-reports
+```
+
+Implementation:
+
+```go
+var serveCmd = &cobra.Command{
+    Use:   "serve",
+    Short: "Start local web server for browsing reports",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        port, _ := cmd.Flags().GetInt("port")
+        reportDir, _ := cmd.Flags().GetString("report-dir")
+        
+        server, err := NewServer(reportDir, port)
+        if err != nil {
+            return err
+        }
+        
+        slog.Info("Server starting", "url", fmt.Sprintf("http://localhost:%d", port))
+        return server.Start()
+    },
+}
+```
+
+## Testing
+
+```go
+func TestPathTraversal(t *testing.T) {
+    server := NewServer("./reports", 8080)
+    
+    tests := []struct {
+        reportID string
+        expect   int  // HTTP status
+    }{
+        {"eval-valid-123", 200},
+        {"../../etc/passwd", 400},  // Bad format
+        {"./../secret", 400},       // Path traversal attempt
+    }
+    
+    for _, tt := range tests {
+        req := httptest.NewRequest("GET", fmt.Sprintf("/api/reports/%s", tt.reportID), nil)
+        w := httptest.NewRecorder()
+        server.getReport(w, req)
+        
+        if w.Code != tt.expect {
+            t.Errorf("reportID %q: expected %d, got %d", tt.reportID, tt.expect, w.Code)
+        }
+    }
+}
+```
+
+## Code Locations
+
+- **Server implementation:** `hyoka/internal/serve/serve.go`
+- **API handlers:** `hyoka/internal/serve/handlers.go` (if split)
+- **Serve command:** `hyoka/cmd/serve.go`
+- **Static assets:** `hyoka/site/` or `hyoka/templates/`
+
+## Anti-Patterns
+
+- Not validating report IDs (enables directory traversal)
+- Serving files outside `reports/` directory
+- Not escaping HTML in JSON responses (XSS risk)
+- Hardcoding port in code (use flags)
+- Not logging API errors (makes debugging hard)
+- Assuming localhost is secure (anyone with network access can reach port 8080)

--- a/.agents/skills/session-recovery/SKILL.md
+++ b/.agents/skills/session-recovery/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: "session-recovery"
+description: "Find and resume interrupted Copilot CLI sessions using session_store queries"
+domain: "workflow-recovery"
+confidence: "high"
+source: "earned"
+tools:
+  - name: "sql"
+    description: "Query session_store database for past session history"
+    when: "Always — session_store is the source of truth for session history"
+---
+
+## Context
+
+Squad agents run in Copilot CLI sessions that can be interrupted — terminal crashes, network drops, machine restarts, or accidental window closes. When this happens, in-progress work may be left in a partially-completed state: branches with uncommitted changes, issues marked in-progress with no active agent, or checkpoints that were never finalized.
+
+Copilot CLI stores session history in a SQLite database called `session_store` (read-only, accessed via the `sql` tool with `database: "session_store"`). This skill teaches agents how to query that store to detect interrupted sessions and resume work.
+
+## Patterns
+
+### 1. Find Recent Sessions
+
+Query the `sessions` table filtered by time window. Include the last checkpoint to understand where the session stopped:
+
+```sql
+SELECT
+  s.id,
+  s.summary,
+  s.cwd,
+  s.branch,
+  s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.updated_at >= datetime('now', '-24 hours')
+ORDER BY s.updated_at DESC;
+```
+
+### 2. Filter Out Automated Sessions
+
+Automated agents (monitors, keep-alive, heartbeat) create high-volume sessions that obscure human-initiated work. Exclude them:
+
+```sql
+SELECT s.id, s.summary, s.cwd, s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.updated_at >= datetime('now', '-24 hours')
+  AND s.id NOT IN (
+    SELECT DISTINCT t.session_id FROM turns t
+    WHERE t.turn_index = 0
+      AND (LOWER(t.user_message) LIKE '%keep-alive%'
+           OR LOWER(t.user_message) LIKE '%heartbeat%')
+  )
+ORDER BY s.updated_at DESC;
+```
+
+### 3. Search by Topic (FTS5)
+
+Use the `search_index` FTS5 table for keyword search. Expand queries with synonyms since this is keyword-based, not semantic:
+
+```sql
+SELECT DISTINCT s.id, s.summary, s.cwd, s.updated_at
+FROM search_index si
+JOIN sessions s ON si.session_id = s.id
+WHERE search_index MATCH 'auth OR login OR token OR JWT'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC
+LIMIT 10;
+```
+
+### 4. Search by Working Directory
+
+```sql
+SELECT s.id, s.summary, s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.cwd LIKE '%my-project%'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC;
+```
+
+### 5. Get Full Session Context Before Resuming
+
+Before resuming, inspect what the session was doing:
+
+```sql
+-- Conversation turns
+SELECT turn_index, substr(user_message, 1, 200) AS ask, timestamp
+FROM turns WHERE session_id = 'SESSION_ID' ORDER BY turn_index;
+
+-- Checkpoint progress
+SELECT checkpoint_number, title, overview
+FROM checkpoints WHERE session_id = 'SESSION_ID' ORDER BY checkpoint_number;
+
+-- Files touched
+SELECT file_path, tool_name
+FROM session_files WHERE session_id = 'SESSION_ID';
+
+-- Linked PRs/issues/commits
+SELECT ref_type, ref_value
+FROM session_refs WHERE session_id = 'SESSION_ID';
+```
+
+### 6. Detect Orphaned Issue Work
+
+Find sessions that were working on issues but may not have completed:
+
+```sql
+SELECT DISTINCT s.id, s.branch, s.summary, s.updated_at,
+  sr.ref_type, sr.ref_value
+FROM sessions s
+JOIN session_refs sr ON s.id = sr.session_id
+WHERE sr.ref_type = 'issue'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC;
+```
+
+Cross-reference with `gh issue list --label "status:in-progress"` to find issues that are marked in-progress but have no active session.
+
+### 7. Resume a Session
+
+Once you have the session ID:
+
+```bash
+# Resume directly
+copilot --resume SESSION_ID
+```
+
+## Examples
+
+**Recovering from a crash during PR creation:**
+1. Query recent sessions filtered by branch name
+2. Find the session that was working on the PR
+3. Check its last checkpoint — was the code committed? Was the PR created?
+4. Resume or manually complete the remaining steps
+
+**Finding yesterday's work on a feature:**
+1. Use FTS5 search with feature keywords
+2. Filter to the relevant working directory
+3. Review checkpoint progress to see how far the session got
+4. Resume if work remains, or start fresh with the context
+
+## Anti-Patterns
+
+- ❌ Searching by partial session IDs — always use full UUIDs
+- ❌ Resuming sessions that completed successfully — they have no pending work
+- ❌ Using `MATCH` with special characters without escaping — wrap paths in double quotes
+- ❌ Skipping the automated-session filter — high-volume automated sessions will flood results
+- ❌ Assuming FTS5 is semantic search — it's keyword-based; always expand queries with synonyms
+- ❌ Ignoring checkpoint data — checkpoints show exactly where the session stopped

--- a/.agents/skills/squad-conventions/SKILL.md
+++ b/.agents/skills/squad-conventions/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: "squad-conventions"
+description: "Core conventions and patterns used in the Squad codebase"
+domain: "project-conventions"
+confidence: "high"
+source: "manual"
+---
+
+## Context
+These conventions apply to all work on the Squad CLI tool (`create-squad`). Squad is a zero-dependency Node.js package that adds AI agent teams to any project. Understanding these patterns is essential before modifying any Squad source code.
+
+## Patterns
+
+### Zero Dependencies
+Squad has zero runtime dependencies. Everything uses Node.js built-ins (`fs`, `path`, `os`, `child_process`). Do not add packages to `dependencies` in `package.json`. This is a hard constraint, not a preference.
+
+### Node.js Built-in Test Runner
+Tests use `node:test` and `node:assert/strict` — no test frameworks. Run with `npm test`. Test files live in `test/`. The test command is `node --test test/`.
+
+### Error Handling — `fatal()` Pattern
+All user-facing errors use the `fatal(msg)` function which prints a red `✗` prefix and exits with code 1. Never throw unhandled exceptions or print raw stack traces. The global `uncaughtException` handler calls `fatal()` as a safety net.
+
+### ANSI Color Constants
+Colors are defined as constants at the top of `index.js`: `GREEN`, `RED`, `DIM`, `BOLD`, `RESET`. Use these constants — do not inline ANSI escape codes.
+
+### File Structure
+- `.squad/` — Team state (user-owned, never overwritten by upgrades)
+- `.squad/templates/` — Template files copied from `templates/` (Squad-owned, overwritten on upgrade)
+- `.github/agents/squad.agent.md` — Coordinator prompt (Squad-owned, overwritten on upgrade)
+- `templates/` — Source templates shipped with the npm package
+- `.squad/skills/` — Team skills in SKILL.md format (user-owned)
+- `.squad/decisions/inbox/` — Drop-box for parallel decision writes
+
+### Windows Compatibility
+Always use `path.join()` for file paths — never hardcode `/` or `\` separators. Squad must work on Windows, macOS, and Linux. All tests must pass on all platforms.
+
+### Init Idempotency
+The init flow uses a skip-if-exists pattern: if a file or directory already exists, skip it and report "already exists." Never overwrite user state during init. The upgrade flow overwrites only Squad-owned files.
+
+### Copy Pattern
+`copyRecursive(src, target)` handles both files and directories. It creates parent directories with `{ recursive: true }` and uses `fs.copyFileSync` for files.
+
+## Examples
+
+```javascript
+// Error handling
+function fatal(msg) {
+  console.error(`${RED}✗${RESET} ${msg}`);
+  process.exit(1);
+}
+
+// File path construction (Windows-safe)
+const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
+
+// Skip-if-exists pattern
+if (!fs.existsSync(ceremoniesDest)) {
+  fs.copyFileSync(ceremoniesSrc, ceremoniesDest);
+  console.log(`${GREEN}✓${RESET} .squad/ceremonies.md`);
+} else {
+  console.log(`${DIM}ceremonies.md already exists — skipping${RESET}`);
+}
+```
+
+## Anti-Patterns
+- **Adding npm dependencies** — Squad is zero-dep. Use Node.js built-ins only.
+- **Hardcoded path separators** — Never use `/` or `\` directly. Always `path.join()`.
+- **Overwriting user state on init** — Init skips existing files. Only upgrade overwrites Squad-owned files.
+- **Raw stack traces** — All errors go through `fatal()`. Users see clean messages, not stack traces.
+- **Inline ANSI codes** — Use the color constants (`GREEN`, `RED`, `DIM`, `BOLD`, `RESET`).

--- a/.agents/skills/test-discipline/SKILL.md
+++ b/.agents/skills/test-discipline/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: "test-discipline"
+description: "Update tests when changing APIs — no exceptions"
+domain: "quality"
+confidence: "high"
+source: "earned (Fenster/Hockney incident, test assertion sync violations)"
+---
+
+## Context
+
+When APIs or public interfaces change, tests must be updated in the same commit. When test assertions reference file counts or expected arrays, they must be kept in sync with disk reality. Stale tests block CI for other contributors.
+
+## Patterns
+
+- **API changes → test updates (same commit):** If you change a function signature, public interface, or exported API, update the corresponding tests before committing
+- **Test assertions → disk reality:** When test files contain expected counts (e.g., `EXPECTED_FEATURES`, `EXPECTED_SCENARIOS`), they must match the actual files on disk
+- **Add files → update assertions:** When adding docs pages, features, or any counted resource, update the test assertion array in the same commit
+- **CI failures → check assertions first:** Before debugging complex failures, verify test assertion arrays match filesystem state
+
+## Examples
+
+✓ **Correct:**
+- Changed auth API signature → updated auth.test.ts in same commit
+- Added `distributed-mesh.md` to features/ → added `'distributed-mesh'` to EXPECTED_FEATURES array
+- Deleted two scenario files → removed entries from EXPECTED_SCENARIOS
+
+✗ **Incorrect:**
+- Changed spawn parameters → committed without updating casting.test.ts (CI breaks for next person)
+- Added `built-in-roles.md` → left EXPECTED_FEATURES at old count (PR blocked)
+- Test says "expected 7 files" but disk has 25 (assertion staleness)
+
+## Anti-Patterns
+
+- Committing API changes without test updates ("I'll fix tests later")
+- Treating test assertion arrays as static (they evolve with content)
+- Assuming CI passing means coverage is correct (stale assertions can pass while being wrong)
+- Leaving gaps for other agents to discover

--- a/.agents/skills/testing-patterns/SKILL.md
+++ b/.agents/skills/testing-patterns/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "testing-patterns"
+description: "Table-driven tests, -race flag, stub patterns"
+domain: "quality"
+confidence: "high"
+source: "hyoka/internal/*_test.go files"
+---
+
+## Context
+
+Hyoka test suite follows Go idioms: table-driven tests for comprehensive coverage, `-race` flag for detecting concurrency issues, and stub patterns for mocking external dependencies (Copilot SDK, file system).
+
+## Table-Driven Tests
+
+Use table-driven tests to test multiple scenarios with the same logic:
+
+**✓ Correct:**
+```go
+func TestBehaviorGrader_ConstraintValidation(t *testing.T) {
+    tests := []struct {
+        name      string
+        config    map[string]any
+        actionLog []ActionEvent
+        expect    bool
+        wantErr   string
+    }{
+        {
+            name: "required tools present",
+            config: map[string]any{
+                "required_tools": []any{"read_file", "edit_file"},
+            },
+            actionLog: []ActionEvent{
+                {Tool: "read_file", TurnNumber: 1},
+                {Tool: "edit_file", TurnNumber: 2},
+            },
+            expect: true,
+        },
+        {
+            name: "required tool missing",
+            config: map[string]any{
+                "required_tools": []any{"read_file"},
+            },
+            actionLog: []ActionEvent{
+                {Tool: "bash", TurnNumber: 1},
+            },
+            expect: false,
+            wantErr: "required tool not found",
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            g, _ := NewBehaviorGrader("test", tt.config)
+            result, err := g.Grade(context.Background(), GraderInput{
+                ActionLog: tt.actionLog,
+            })
+            if (err != nil) != (tt.wantErr != "") {
+                t.Fatalf("unexpected error: %v", err)
+            }
+            if result.Pass != tt.expect {
+                t.Errorf("expected Pass=%v, got %v", tt.expect, result.Pass)
+            }
+        })
+    }
+}
+```
+
+## Race Condition Detection
+
+Always run tests with `-race` flag:
+
+```bash
+go test -race ./hyoka/...
+```
+
+The `-race` detector catches unsynchronized access to shared memory in concurrent code. This is critical for:
+- Parallel grader execution
+- Multi-worker prompt evaluation
+- Action timeline appends
+
+## Stub Patterns for External Dependencies
+
+### Grader Stubs
+
+When testing engine behavior without real graders:
+
+```go
+type StubGrader struct {
+    gradeFn func(context.Context, GraderInput) (GraderResult, error)
+}
+
+func (sg *StubGrader) Grade(ctx context.Context, input GraderInput) (GraderResult, error) {
+    return sg.gradeFn(ctx, input)
+}
+
+// Usage in test
+stubGrader := &StubGrader{
+    gradeFn: func(_ context.Context, _ GraderInput) (GraderResult, error) {
+        return GraderResult{Pass: true, Score: 1.0}, nil
+    },
+}
+```
+
+### File System Stubs
+
+Mock file operations without touching disk:
+
+```go
+type stubFileReader struct {
+    readFn func(path string) (string, error)
+}
+
+func (s *stubFileReader) Read(path string) (string, error) {
+    return s.readFn(path)
+}
+
+// Usage
+stubFS := &stubFileReader{
+    readFn: func(path string) (string, error) {
+        if path == "/test/main.py" {
+            return "# Generated code", nil
+        }
+        return "", os.ErrNotExist
+    },
+}
+```
+
+## Test Organization
+
+- **Unit tests:** Test single function/method (`*_test.go` in same package)
+- **Integration tests:** Test multi-package workflows (`*_integration_test.go`)
+- **Fixtures:** Use `testdata/` directory for test files
+
+## Running Tests
+
+```bash
+# All tests
+go test ./hyoka/...
+
+# With race detector
+go test -race ./hyoka/...
+
+# Specific test
+go test -run TestBehaviorGrader ./hyoka/internal/graders
+
+# Verbose with coverage
+go test -v -cover ./hyoka/...
+```
+
+## Anti-Patterns
+
+- Not using table-driven tests for multiple scenarios
+- Ignoring `-race` failures (concurrency bugs are subtle)
+- Mocking internal types instead of using interfaces
+- Test files that modify package state between runs
+- Hardcoding file paths (use testdata or stubs)
+
+## Related Code Locations
+
+- **Example table-driven tests:** `hyoka/internal/graders/*_test.go`
+- **Stub patterns:** `hyoka/internal/eval/*_test.go`
+- **Test fixtures:** `hyoka/testdata/`

--- a/.agents/skills/windows-compatibility/SKILL.md
+++ b/.agents/skills/windows-compatibility/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: "windows-compatibility"
+description: "Cross-platform path handling and command patterns"
+domain: "platform"
+confidence: "high"
+source: "earned (multiple Windows-specific bugs: colons in filenames, git -C failures, path separators)"
+---
+
+## Context
+
+Squad runs on Windows, macOS, and Linux. Several bugs have been traced to platform-specific assumptions: ISO timestamps with colons (illegal on Windows), `git -C` with Windows paths (unreliable), forward-slash paths in Node.js on Windows.
+
+> **Status (fixed):** All 17 existing `.squad/` files with colons in timestamps have been renamed to use hyphens. Templates now instruct agents to use hyphenated timestamps in filenames (e.g., `2026-04-04T03-55-26Z`).
+
+## Patterns
+
+### Filenames & Timestamps
+- **Never use colons in filenames:** ISO 8601 format `2026-03-15T05:30:00Z` is illegal on Windows
+- **Use `safeTimestamp()` utility:** Replaces colons with hyphens → `2026-03-15T05-30-00Z`
+- **Centralize formatting:** Don't inline `.toISOString().replace(/:/g, '-')` — use the utility
+
+### Git Commands
+- **Never use `git -C {path}`:** Unreliable with Windows paths (backslashes, spaces, drive letters)
+- **Always `cd` first:** Change directory, then run git commands
+- **Check for changes before commit:** `git diff --cached --quiet` (exit 0 = no changes)
+
+### Commit Messages
+- **Never embed newlines in `-m` flag:** Backtick-n (`\n`) fails silently in PowerShell
+- **Use temp file + `-F` flag:** Write message to file, commit with `git commit -F $msgFile`
+
+### Paths
+- **Never assume CWD is repo root:** Always use `TEAM ROOT` from spawn prompt or run `git rev-parse --show-toplevel`
+- **Use path.join() or path.resolve():** Don't manually concatenate with `/` or `\`
+
+## Examples
+
+✓ **Correct:**
+```javascript
+// Timestamp utility
+const safeTimestamp = () => new Date().toISOString().replace(/:/g, '-').split('.')[0] + 'Z';
+
+// Git workflow (PowerShell)
+cd $teamRoot
+git add .squad/
+if ($LASTEXITCODE -eq 0) {
+  $msg = @"
+docs(ai-team): session log
+
+Changes:
+- Added decisions
+"@
+  $msgFile = [System.IO.Path]::GetTempFileName()
+  Set-Content -Path $msgFile -Value $msg -Encoding utf8
+  git commit -F $msgFile
+  Remove-Item $msgFile
+}
+```
+
+✗ **Incorrect:**
+```javascript
+// Colon in filename
+const logPath = `.squad/log/${new Date().toISOString()}.md`; // ILLEGAL on Windows
+
+// git -C with Windows path
+exec('git -C C:\\src\\squad add .squad/'); // UNRELIABLE
+
+// Inline newlines in commit message
+exec('git commit -m "First line\nSecond line"'); // FAILS silently in PowerShell
+```
+
+## Anti-Patterns
+
+- Testing only on one platform (bugs ship to other platforms)
+- Assuming Unix-style paths work everywhere
+- Using `git -C` because it "looks cleaner" (it doesn't work)
+- Skipping `git diff --cached --quiet` check (creates empty commits)


### PR DESCRIPTION
## Summary

Move 14 hyoka project-specific skills from `skills/hyoka/` to `.agents/skills/` so the Copilot CLI automatically discovers them alongside the existing 30 squad skills.

## Changes

- Copied all 14 skills from `skills/hyoka/` into `.agents/skills/` (merged with existing skills)
- Removed `skills/hyoka/` directory
- Updated `.gitignore` to track `.agents/skills/` while keeping rest of `.agents/` ignored
- Build and tests pass (pre-existing clean test failure unrelated)

## Verification

```
ls .agents/skills/ | wc -l  # 44 total (30 existing + 14 moved)
go build ./hyoka/...        # ✅
go test ./hyoka/...         # ✅ (1 pre-existing failure in clean_test.go)
```

Closes #241