### PR TITLE
fix: wire SPA, docs, and prompts dirs into serve command

### DIFF
--- a/.copilot/mcp-config.json
+++ b/.copilot/mcp-config.json
@@ -9,6 +9,12 @@
       "env": {
         "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       }
+    },
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@anthropic-ai/mcp-server-playwright"
+      ]
     }
   }
 }

--- a/hyoka/cmd/serve.go
+++ b/hyoka/cmd/serve.go
@@ -1,29 +1,49 @@
 package cmd
 
 import (
-"github.com/ronniegeraghty/hyoka/internal/serve"
-"github.com/spf13/cobra"
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/serve"
+	"github.com/spf13/cobra"
 )
 
 func serveCmd() *cobra.Command {
-var port int
-var reportsDir string
+	var port int
+	var reportsDir string
+	var siteDir string
+	var docsDir string
+	var promptsDir string
 
-cmd := &cobra.Command{
-Use:   "serve",
-Short: "Start a local web server to browse evaluation reports",
-Long:  "Starts an HTTP server that provides a web UI for browsing past evaluation runs, viewing summaries, and individual report pages.",
-RunE: func(cmd *cobra.Command, args []string) error {
-reportsDir = resolveOutputFile(cmd, []string{"./reports", "../reports"})
-return serve.Start(serve.Options{
-ReportsDir: reportsDir,
-Port:       port,
-})
-},
-}
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start a local web server to browse evaluation reports",
+		Long:  "Starts an HTTP server that provides a web UI for browsing past evaluation runs, viewing summaries, and individual report pages.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			proj := discoverProject()
 
-cmd.Flags().IntVar(&port, "port", 8080, "Port to serve on")
-cmd.Flags().StringVar(&reportsDir, "output", "./reports", "Directory containing evaluation reports")
+			reportsDir = resolvePathFlag(cmd, "output",
+				config.ResolveCandidates(proj, "reports", "./reports", "../reports"))
+			siteDir = resolvePathFlag(cmd, "site-dir",
+				config.ResolveCandidates(proj, "site/dist", "./site/dist", "../site/dist"))
+			docsDir = resolvePathFlag(cmd, "docs-dir",
+				config.ResolveCandidates(proj, "docs", "./docs", "../docs"))
+			promptsDir = resolvePathFlag(cmd, "prompts",
+				config.ResolveCandidates(proj, "prompts", "./prompts", "../prompts"))
 
-return cmd
+			return serve.Start(serve.Options{
+				ReportsDir: reportsDir,
+				SiteDir:    siteDir,
+				DocsDir:    docsDir,
+				PromptsDir: promptsDir,
+				Port:       port,
+			})
+		},
+	}
+
+	cmd.Flags().IntVar(&port, "port", 8080, "Port to serve on")
+	cmd.Flags().StringVar(&reportsDir, "output", "./reports", "Directory containing evaluation reports")
+	cmd.Flags().StringVar(&siteDir, "site-dir", "", "Directory containing the built React site (default: auto-detect site/dist)")
+	cmd.Flags().StringVar(&docsDir, "docs-dir", "", "Directory containing documentation markdown files")
+	cmd.Flags().StringVar(&promptsDir, "prompts", "", "Directory containing evaluation prompts")
+
+	return cmd
 }


### PR DESCRIPTION
## Summary

The serve backend already had full SPA support (`spaHandler` correctly serves static files and falls back to `index.html` for client-side routing), but `cmd/serve.go` never passed `SiteDir`, `DocsDir`, or `PromptsDir` to `serve.Options` — so the React SPA was never actually served.

## Changes

- **`hyoka/cmd/serve.go`**: Wire up all `serve.Options` fields using `resolvePathFlag` + `config.ResolveCandidates` for auto-detection of `site/dist/`, `docs/`, and `prompts/` directories
- Add `--site-dir`, `--docs-dir`, and `--prompts` CLI flags for explicit overrides
- **`.copilot/mcp-config.json`**: Add Playwright MCP server config for browser testing

## How it works

When `hyoka serve` runs, it now:
1. Auto-detects `site/dist/` (the built React SPA) via the same `ResolveCandidates` pattern used by other commands
2. Serves SPA assets (JS/CSS bundles) from that directory
3. Falls back to `index.html` for unknown routes (client-side routing)
4. Keeps all `/api/*` routes working as before
5. If `site/dist/` doesn't exist, falls back to a 404 message (no SPA available)

## Testing

- All existing serve tests pass (42 tests including SPA fallback, CORS, path traversal)
- All cmd tests pass
- Build verified clean

Closes #243

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>