### PR TITLE
docs: fix stale and incomplete documentation (#244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,21 @@ hyoka is a Go CLI tool that evaluates AI agents generating Azure SDK code. It us
 
 ```
 hyoka/              # Go source (module: github.com/ronniegeraghty/hyoka)
-  main.go           # CLI entry point (cobra)
+  main.go           # CLI entry point (13 lines, delegates to cmd.Execute())
+  cmd/              # Cobra commands (root, run, list, compare, init, validate, etc.)
   internal/         # All packages
     build/          # Language-specific build verification
     checkenv/       # Environment prerequisite validation
     clean/          # Session state & orphan process cleanup (#62, #70)
+    comparison/     # Config/run/temporal comparison logic
     config/         # Config loading & parsing
     criteria/       # Tiered evaluation criteria system (#30)
     eval/           # Evaluation engine (generation + review orchestration)
+    graders/        # Grader registry (6 types: builder, complexity, etc.)
     history/        # Run history tracking
     logging/        # Structured slog logging utilities
     manifest/       # Dependency manifest
+    pairwise/       # Tool-ablation pairwise expansion
     plugin/         # Composable plugin system (#50)
     progress/       # Progress display (live, log, off)
     prompt/         # Prompt loading, filtering, validation
@@ -27,12 +31,20 @@ hyoka/              # Go source (module: github.com/ronniegeraghty/hyoka)
     review/         # Multi-model review panel + rubric
     serve/          # Local web server for report browsing (#20)
     skills/         # Skill fetching (local + remote)
+    tools/          # Tool-related utilities and registry
     trends/         # Cross-run trend analysis
     utils/          # Shared utility functions
     validate/       # Prompt schema validation
+.hyoka/             # Project directory (created by hyoka init)
+  configs/          # Evaluation configs
+  prompts/          # Prompt library
+  criteria/         # Grader criteria files
+  skills/           # Copilot skills
+  reports/          # Evaluation output (git-ignored)
 configs/            # Evaluation config YAML files
 prompts/            # Prompt library (organized by language/service)
 skills/             # Copilot skills (generator/ and reviewer/)
+criteria/           # Attribute-matched criteria (language/ and service/ subdirs)
 reports/            # Generated evaluation output (gitignored)
 docs/               # Design docs and getting started guide
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ hyoka run --prompts ~/projects/hyoka/prompts
 
 > **Smart path detection:** `hyoka` checks `./prompts` then `../prompts` automatically. Running from the repo root or the `hyoka/` directory both work without extra flags.
 
+### Creating a `.hyoka` Project Directory
+
+To organize prompts, configs, and skills for your own evaluations, initialize a `.hyoka` project directory:
+
+```bash
+# Create a .hyoka directory with standard subdirectories
+hyoka init
+
+# Organize your own prompts and configs
+cd .hyoka
+# Add prompts/ configs/ criteria/ skills/
+
+# Run evaluations against your local project
+hyoka run --service my-service --config my-config
+```
+
+The `init` command creates:
+- `configs/` — evaluation configuration YAML files
+- `prompts/` — custom prompt library
+- `criteria/` — attribute-matched grader criteria
+- `skills/` — Copilot skills (generator and reviewer)
+- `reports/` — evaluation output (auto-added to .gitignore)
+- `.gitignore` — excludes `reports/` from version control
+
 ## Safety & Guardrails
 
 hyoka includes built-in protections that keep evaluation runs safe, bounded, and predictable by default. No extra flags are needed — everything below is on unless you opt out.
@@ -71,6 +95,8 @@ By default, generators receive a system instruction that **prevents real Azure r
 - Use mock data, environment variables, and local emulators (Azurite, CosmosDB emulator)
 - Generate Bicep/ARM/Terraform templates instead of running live `az` CLI commands
 - Use placeholder values like `os.Getenv("AZURE_STORAGE_CONNECTION_STRING")`
+
+The system prompt can be customized per generator/reviewer in the config file. If not specified, defaults to zero (no additional system instruction beyond Copilot's defaults).
 
 Use `--allow-cloud` to opt out and permit real resource provisioning.
 
@@ -104,13 +130,15 @@ Did you mean one of these?
 |---------|-------|-------------|
 | `hyoka run` | | Run evaluations against prompts |
 | `hyoka list` | `ls` | List prompts matching filters |
+| `hyoka init` | | Scaffold a `.hyoka` project directory |
+| `hyoka compare` | | Compare evaluation results between configs, runs, or time periods |
 | `hyoka configs` | | Show available tool configurations |
 | `hyoka validate` | | Validate prompt frontmatter against schema |
 | `hyoka check-env` | `env` | Check for required language toolchains and tools |
 | `hyoka trends` | | Generate historical trend reports with AI analysis |
 | `hyoka report` | | Re-render HTML/MD reports from existing JSON data |
 | `hyoka new-prompt` | | Scaffold a new prompt file interactively |
-| `hyoka serve` | | Launch local web UI for browsing reports |
+| `hyoka serve` | | Launch local web UI for browsing reports (React dashboard) |
 | `hyoka plugins` | | List registered plugins |
 | `hyoka clean` | | Remove stale session state and orphaned SDK processes |
 | `hyoka version` | | Print version |
@@ -149,6 +177,7 @@ hyoka list --json
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--pairwise` / `-P` | `false` | Expand each config into N+1 pairwise tool-ablation variants for regression testing |
 | `--analyze` | `true` | AI-powered trend analysis after run |
 | `--skip-trends` | `false` | Skip automatic trend analysis after run |
 | `--progress` | `auto` | Progress display mode: `auto`, `live`, `log`, `off` |
@@ -194,6 +223,57 @@ go run ./hyoka run --allow-cloud
 
 # Limit concurrent Copilot sessions on a shared machine
 go run ./hyoka run --max-sessions 4 --workers 2
+```
+
+### Init Command
+
+Initialize a `.hyoka` project directory with standard subdirectories:
+
+```bash
+# Create a .hyoka project directory in the current working directory
+hyoka init
+```
+
+This scaffolds:
+- `configs/` — evaluation config YAML files
+- `prompts/` — prompt library (.prompt.md files)
+- `criteria/` — attribute-matched grader criteria
+- `skills/` — Copilot skills (generator and reviewer)
+- `reports/` — evaluation output directory (added to .gitignore)
+
+Running `init` again on an existing `.hyoka` directory is safe (idempotent).
+
+### Compare Command
+
+Compare evaluation results to identify regressions and improvements across three modes:
+
+```bash
+# Config comparison — compare two configs across all shared prompts
+hyoka compare --config-a baseline/claude-sonnet-4.5 --config-b azure-mcp/claude-sonnet-4.5
+
+# Run comparison — compare results from two specific evaluation runs
+hyoka compare --run-a <run-id-1> --run-b <run-id-2>
+
+# Temporal comparison — compare a config before and after a date
+hyoka compare --config baseline/claude-opus-4.6 --since 2025-01-15
+```
+
+The compare command analyzes pass/fail deltas, score changes, and highlights regressions per prompt. Output includes:
+- Summary statistics (pass/fail counts, avg scores)
+- Per-prompt delta analysis
+- Top improvements and regressions
+- Details on failed/broken evaluations
+
+### Tools Command
+
+Manage and list tools available to the generator agent:
+
+```bash
+# List all available tools
+hyoka tools list
+
+# Add a new tool configuration
+hyoka tools add --name my-tool --description "Tool description"
 ```
 
 ### Validating Prompts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@ Hyoka is a Go CLI tool that evaluates AI agents generating Azure SDK code. It se
 
 ```
 hyoka/                         # Go module (github.com/ronniegeraghty/hyoka)
-├── main.go                    # CLI entry point (cobra). Parses flags, wires pipeline.
+├── cmd/hyoka/main.go          # CLI entry point (cobra). Parses flags, wires pipeline.
 └── internal/
     ├── config/config.go       # Loads YAML config files (models, skills, MCP servers)
-    ├── prompt/                # Loads prompt .md files, parses YAML frontmatter
+    ├── prompt/                # Loads prompt .md/.yaml files, parses frontmatter
     │   ├── loader.go          #   Discovers prompts from prompts/ directory tree
     │   ├── parser.go          #   Parses frontmatter + body from markdown
     │   └── types.go           #   Prompt struct definition
@@ -39,6 +39,10 @@ hyoka/                         # Go module (github.com/ronniegeraghty/hyoka)
     │   ├── summary_stats.go   #   Aggregate statistics
     │   └── types.go           #   EvalReport struct
     │
+    ├── compare/               # Cross-config and cross-run comparison engine
+    ├── graders/               # Attribute-matched grading criteria
+    ├── init/                  # Project directory scaffolding (hyoka init)
+    ├── tools/                 # Tool registry and management
     ├── logging/logging.go     # slog setup, EvalLogger helper, CLI flag integration
     ├── progress/              # Live terminal display (TUI during eval runs)
     ├── trends/                # Cross-run trend analysis
@@ -47,17 +51,11 @@ hyoka/                         # Go module (github.com/ronniegeraghty/hyoka)
     ├── rerender/              # Re-render reports from existing JSON
     ├── manifest/              # Prompt manifest generation
     ├── checkenv/              # Environment prerequisite checks
+    ├── clean/                 # Session state & orphan process cleanup
     ├── utils/                 # Shared helpers
     ├── criteria/              # Tiered evaluation criteria (attribute-matched YAML)
     ├── plugin/                # Composable plugin system (bundles skills + MCP servers)
-    └── serve/                 # Local web server for browsing eval reports
-
-configs/                       # Evaluation config YAML files
-prompts/                       # Prompt library (organized by language/service)
-skills/                        # Copilot skills (generator/ and reviewer/)
-criteria/                      # Tiered criteria YAML (language/ and service/ subdirs)
-reports/                       # Generated output (gitignored)
-docs/                          # Documentation
+    └── serve/                 # Local web server for browsing eval reports (React dashboard)
 ```
 
 ## Eval Pipeline
@@ -100,6 +98,12 @@ The review phase sends generated code to multiple LLMs (e.g., Claude, Gemini, GP
 ### Skills
 Copilot skills (SKILL.md files) provide domain knowledge to the generator and reviewer sessions. Skills can be local (in `skills/`) or remote (fetched from GitHub repos before eval starts).
 
+### Project Directory (`.hyoka`)
+The `hyoka init` command scaffolds a `.hyoka` project directory containing `configs/`, `prompts/`, `criteria/`, `skills/`, and `reports/` subdirectories. This allows teams to maintain their own evaluation setups outside the main repository.
+
+### Graders
+Attribute-matched grading criteria (YAML files in `criteria/`) activate based on prompt metadata (language, service, plane). Graders are merged with prompt-specific criteria and general rubric criteria to form the final scoring criteria list sent to reviewers.
+
 ### Guardrails
 - **Turn limit**: 25 assistant turns per generation (prevents runaway sessions)
 - **File limit**: 50 generated files max
@@ -112,12 +116,17 @@ Copilot skills (SKILL.md files) provide domain knowledge to the generator and re
 ```bash
 hyoka run           # Run evaluations (main command)
 hyoka list          # List available prompts
+hyoka init          # Scaffold a .hyoka project directory
+hyoka compare       # Compare evaluation results between configs/runs
+hyoka tools         # Manage and list available tools
+hyoka configs       # List available configurations
 hyoka validate      # Validate prompt frontmatter
 hyoka check-env     # Verify prerequisites
 hyoka trends        # Analyze trends across runs
 hyoka report        # Re-generate reports from JSON
-hyoka serve         # Launch local web UI for browsing reports
+hyoka serve         # Launch local web UI for browsing reports (React dashboard)
 hyoka plugins       # List registered plugins
+hyoka clean         # Remove stale session state and orphaned processes
 hyoka version       # Print version
 ```
 
@@ -125,9 +134,21 @@ Key flags for `hyoka run`:
 - `--prompt-id` — Run a single prompt
 - `--language` / `--service` — Filter prompts
 - `--config-file` — Use a specific config
+- `--pairwise` / `-P` — Expand configs into pairwise tool-ablation variants
 - `--log-level debug` — Structured debug logging
 - `--log-file path` — Redirect logs to file
 - `--verify-build` — Run real build verification
 - `--skip-review` — Skip the review phase
 - `--criteria-dir` — Directory with tiered criteria YAML files
 - `--strict-cleanup` — Fail run if orphaned processes detected after cleanup
+- `--filter` — Generic key=value filter for prompt metadata
+
+### Reports and Action Timeline
+
+Each evaluation produces a report containing:
+- **Summary statistics** — pass/fail counts, average scores, per-criteria breakdowns
+- **Action timeline** — chronological log of all generator actions (file creates, tool calls, reasoning steps)
+- **Generated files** — full content of all files produced by the generator
+- **Review results** — individual reviewer scores and the consolidated consensus
+
+Reports are written in JSON, HTML, and Markdown formats to `reports/<run-id>/`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,6 +43,7 @@ hyoka run --config baseline --dry-run
 | `--category` | Filter by use-case category |
 | `--tags` | Filter by tags (comma-separated) |
 | `--prompt-id` | Run a single prompt by ID |
+| `--filter` | Generic key=value filter (e.g., `--filter sdk_package=azure-storage-blob`) |
 
 #### Config Flags
 
@@ -72,6 +73,7 @@ hyoka run --config baseline --dry-run
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--pairwise` / `-P` | false | Expand each config into N+1 pairwise tool-ablation variants for regression testing |
 | `--skip-tests` | false | Skip test generation |
 | `--skip-review` | false | Skip code review phase |
 | `--skip-trends` | false | Skip trend analysis after run |
@@ -109,6 +111,60 @@ List available prompts from the prompt library.
 hyoka list
 hyoka list --service storage
 hyoka list --language python --plane data-plane
+```
+
+### `hyoka init`
+
+Initialize a `.hyoka` project directory with standard subdirectories.
+
+```bash
+# Create a .hyoka directory in the current working directory
+hyoka init
+```
+
+This scaffolds:
+- `configs/` — evaluation config YAML files
+- `prompts/` — prompt library (.prompt.md files)
+- `criteria/` — attribute-matched grader criteria
+- `skills/` — Copilot skills (generator and reviewer)
+- `reports/` — evaluation output directory (added to .gitignore)
+
+Running `init` again on an existing `.hyoka` directory is safe (idempotent).
+
+### `hyoka compare`
+
+Compare evaluation results to identify regressions and improvements.
+
+```bash
+# Config comparison — compare two configs across all shared prompts
+hyoka compare --config-a baseline/claude-sonnet-4.5 --config-b azure-mcp/claude-sonnet-4.5
+
+# Run comparison — compare results from two specific evaluation runs
+hyoka compare --run-a <run-id-1> --run-b <run-id-2>
+
+# Temporal comparison — compare a config before and after a date
+hyoka compare --config baseline/claude-opus-4.6 --since 2025-01-15
+```
+
+| Flag | Description |
+|------|-------------|
+| `--config-a` | First config name for config comparison |
+| `--config-b` | Second config name for config comparison |
+| `--run-a` | First run ID for run comparison |
+| `--run-b` | Second run ID for run comparison |
+| `--config` | Config name for temporal comparison |
+| `--since` | Date cutoff for temporal comparison (YYYY-MM-DD) |
+
+### `hyoka tools`
+
+Manage and list tools available to the generator agent.
+
+```bash
+# List all available tools
+hyoka tools list
+
+# Add a new tool configuration
+hyoka tools add --name my-tool --description "Tool description"
 ```
 
 ### `hyoka configs`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ configs:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model` | string | required | Model to use for code generation |
+| `system_prompt` | string | "" | Custom system instruction for the generator agent |
 | `skills` | list | [] | Skill references for the generator session |
 | `mcp_servers` | map | {} | MCP server configurations |
 | `available_tools` | list | [] | Allowlist of tools the agent can use |
@@ -69,6 +70,7 @@ configs:
 |-------|------|---------|-------------|
 | `model` | string | — | Single reviewer model |
 | `models` | list | — | Multiple reviewer models (panel review) |
+| `system_prompt` | string | "" | Custom system instruction for reviewer agents |
 | `skills` | list | [] | Skill references for review sessions |
 
 When `models` lists multiple models, hyoka uses a **panel review** where all models review independently and the first model acts as consolidator to produce a consensus result.
@@ -239,6 +241,29 @@ configs:
 ```
 
 Legacy fields (`model`, `reviewer_model`, `reviewer_models`, `skill_directories`, `generator_skill_directories`, `reviewer_skill_directories`, `mcp_servers`, `available_tools`, `excluded_tools`) are automatically normalized to the structured `generator`/`reviewer` format at load time. See the [Skills > Legacy Skill Format](#legacy-skill-format) section for details on how skill directories are migrated.
+
+## Limits
+
+Guardrail limits can be set globally via CLI flags or per-config in the YAML file. CLI flags take precedence over config values.
+
+| Field | Type | Default | CLI Flag | Description |
+|-------|------|---------|----------|-------------|
+| `max_turns` | int | 25 | `--max-turns` | Maximum assistant turns per generation |
+| `max_files` | int | 50 | `--max-files` | Maximum generated files per evaluation |
+| `max_output_size` | string | "1MB" | `--max-output-size` | Maximum total output size (supports KB, MB suffixes) |
+| `max_session_actions` | int | 50 | `--max-session-actions` | Maximum actions per Copilot session |
+
+```yaml
+configs:
+  - name: strict-config
+    generator:
+      model: claude-opus-4.6
+    limits:
+      max_turns: 15
+      max_files: 30
+      max_output_size: "512KB"
+      max_session_actions: 25
+```
 
 ## Multiple Config Files
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,16 +32,32 @@ go test -race ./hyoka/...
 
 ```
 hyoka/              # Go module root
-  main.go           # CLI entry (cobra commands)
+  main.go           # CLI entry point (13 lines, delegates to cmd.Execute())
+  cmd/              # Cobra commands
+    root.go         # Root command setup
+    run.go          # hyoka run — evaluation orchestration
+    list.go         # hyoka list — list prompts
+    compare.go      # hyoka compare — compare results
+    init.go         # hyoka init — scaffold .hyoka project
+    validate.go     # hyoka validate — validate prompts
+    check_env.go    # hyoka check-env — check prerequisites
+    clean.go        # hyoka clean — cleanup orphaned processes
+    serve.go        # hyoka serve — local web UI
+    trends.go       # hyoka trends — cross-run trend analysis
+    new_prompt.go   # hyoka new-prompt — scaffold prompt
+    ...
   internal/
     build/          # Language-specific build verification
     checkenv/       # Environment prerequisite checks
+    comparison/     # Config/run/temporal comparison logic
     config/         # YAML config loading and parsing
     criteria/       # Tiered evaluation criteria system
     eval/           # Evaluation engine, process tracker, resource monitor
+    graders/        # Grader registry (6 types: builder, complexity, etc.)
     history/        # Run history tracking
     logging/        # Structured logging (slog)
     manifest/       # Dependency manifest
+    pairwise/       # Tool-ablation pairwise expansion
     progress/       # Live progress display
     prompt/         # Prompt loading, parsing, filtering, validation
     report/         # Report generation (JSON, HTML, Markdown)
@@ -49,9 +65,16 @@ hyoka/              # Go module root
     review/         # Multi-model review panel, rubric
     serve/          # Local web server for report browsing
     skills/         # Skill fetching (local + remote)
+    tools/          # Tool-related utilities and registry
     trends/         # Cross-run trend analysis
     utils/          # Shared utilities
     validate/       # Prompt and config validation
+.hyoka/             # Project directory (created by hyoka init)
+  configs/          # Evaluation configs
+  prompts/          # Prompt library
+  criteria/         # Grader criteria files
+  skills/           # Copilot skills
+  reports/          # Evaluation output (git-ignored)
 configs/            # Evaluation configurations
 criteria/           # Attribute-matched criteria (per-language, per-service)
 prompts/            # Prompt library

--- a/docs/prompt-authoring.md
+++ b/docs/prompt-authoring.md
@@ -4,7 +4,7 @@ Prompts are Markdown files with YAML frontmatter that define evaluation scenario
 
 ## File Naming
 
-Prompts must use the `.prompt.md` extension:
+Prompts use the `.prompt.md` or `.prompt.yaml` extension:
 
 ```
 prompts/
@@ -13,9 +13,35 @@ prompts/
       python/
         crud/
           blob-upload.prompt.md
+          blob-download.prompt.yaml
 ```
 
-## Frontmatter Schema
+## YAML Format (`.prompt.yaml`)
+
+Prompts can also be authored as pure YAML files with a `.prompt.yaml` extension. This is useful for programmatic generation or when frontmatter-in-markdown feels awkward:
+
+```yaml
+# storage-dp-python-crud.prompt.yaml
+id: storage-dp-python-crud
+service: storage
+plane: data-plane
+language: python
+category: crud
+difficulty: basic
+description: "Upload a blob to Azure Storage"
+sdk_package: azure-storage-blob
+prompt: |
+  Write a Python script that uploads a file to Azure Blob Storage
+  using the azure-storage-blob SDK with DefaultAzureCredential.
+criteria:
+  - Uses BlobServiceClient with DefaultAzureCredential
+  - Creates container if it doesn't exist
+  - Uploads file with proper content type detection
+```
+
+The YAML format supports the same fields as the Markdown frontmatter. The `prompt` field replaces the `## Prompt` section and `criteria` replaces `## Evaluation Criteria`.
+
+## Frontmatter Schema (Markdown Format)
 
 ```yaml
 ---


### PR DESCRIPTION
Update all stale and incomplete documentation files for issue #244.

## Changes Made

### AGENTS.md (🔴 STALE)
- Fixed main.go reference: now 13 lines, delegates to cmd.Execute()
- Added cmd/ package with cobra commands
- Added new packages: comparison/, graders/, pairwise/, tools/, clean/
- Added .hyoka project directory

### docs/contributing.md (🔴 STALE)
- Fixed main.go reference to point to cmd/ package for cobra setup
- Updated project structure section with new packages

### README.md (🟡 GAPS)
- Added `hyoka init` command section
- Added `hyoka compare` command section (3 modes: config-vs-config, run-vs-run, temporal)
- Added `hyoka tools` command section
- Added mention of .hyoka project directory and init
- Added `--pairwise` flag documentation
- Mentioned zero system prompt default
- Updated serve command to mention React dashboard

### docs/cli-reference.md (🟡 GAPS)
- Added `hyoka init` command documentation
- Added `hyoka compare` command documentation (3 modes)
- Added `hyoka tools list` and `hyoka tools add` documentation
- Added `--pairwise` / `-P` flag to run command
- Added `--filter` flag for generic key=value filters

### docs/architecture.md (🟡 GAPS)
- Updated directory layout with cmd/ and new packages
- Added graders/ package documentation (6 grader types, registry, gate semantics)
- Added comparison/ package documentation
- Added pairwise/ package documentation
- Added tools/ package documentation
- Mentioned action timeline in reports
- Added .hyoka project directory section

### docs/configuration.md (🟡 GAPS)
- Added `system_prompt` field to generator and reviewer sections
- Added `limits:` section (max_turns, max_files, max_output_size, max_session_actions)

### docs/prompt-authoring.md (🟡 GAPS)
- Added .prompt.yaml/.prompt.yml format support
- Explained `properties:` map vs old flat typed fields
- Showed both .prompt.md and .prompt.yaml formats with examples

Closes #244