### PR TITLE
feat: treat action limit as soft cap — review partial results instead of erroring

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -929,7 +929,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			lg.Warn("Guardrail triggered", "reason", reason, "turns", turnCount, "max_turns", lim.maxTurns)
 		}
 
-		// Check action count (count reasoning, message, and tool_execution_start events as actions)
+		// Check action count — soft cap: note but don't error, let review decide pass/fail
 		actionCount := 0
 		for _, ev := range evalReport.SessionEvents {
 			if ev.Type == "assistant.reasoning" || ev.Type == "assistant.message" || ev.Type == "tool.execution_start" {
@@ -937,11 +937,10 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 			}
 		}
 		if actionCount > lim.maxSessionActions {
-			reason := fmt.Sprintf("guardrail: action count %d exceeded limit of %d", actionCount, lim.maxSessionActions)
-			evalReport.GuardrailAbortReason = reason
-			evalReport.Error = reason
-			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "actions", actionCount, "max_session_actions", lim.maxSessionActions)
+			evalReport.ActionLimitReached = true
+			evalReport.ActionCount = actionCount
+			lg.Warn("Action limit reached (soft cap — review will proceed with partial results)",
+				"actions", actionCount, "max_session_actions", lim.maxSessionActions)
 		}
 
 		// Check file count

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -324,11 +324,11 @@ func TestGuardrailMaxFiles(t *testing.T) {
 
 func TestGuardrailMaxTurns(t *testing.T) {
 	outputDir := t.TempDir()
+	// 30 assistant.message events exceeds the default MaxTurns=25.
 	engine := NewEngine(&manyTurnsEvaluator{turnCount: 30}, quietOpts(EngineOptions{
-		Workers:   1,
-		OutputDir: outputDir,
+		Workers:    1,
+		OutputDir:  outputDir,
 		SkipReview: true,
-		MaxSessionActions:  5,
 	}))
 
 	prompts := []*prompt.Prompt{
@@ -349,8 +349,64 @@ func TestGuardrailMaxTurns(t *testing.T) {
 	if r.Success {
 		t.Error("expected guardrail to fail the eval")
 	}
-	if !strings.Contains(r.GuardrailAbortReason, "action count") {
-		t.Errorf("expected guardrail abort reason about action count, got %q", r.GuardrailAbortReason)
+	if !strings.Contains(r.GuardrailAbortReason, "turn count") {
+		t.Errorf("expected guardrail abort reason about turn count, got %q", r.GuardrailAbortReason)
+	}
+}
+
+// TestActionLimitSoftCap verifies that exceeding the session action limit is
+// treated as a soft cap: the eval is NOT counted as an error, and the review
+// phase determines pass/fail. The report records action_limit_reached and
+// action_count for transparency.
+func TestActionLimitSoftCap(t *testing.T) {
+	outputDir := t.TempDir()
+	// 10 events with MaxSessionActions=5 triggers the soft cap.
+	// MaxTurns=999 prevents the turn-count hard guardrail from firing.
+	engine := NewEngine(&manyTurnsEvaluator{turnCount: 10}, quietOpts(EngineOptions{
+		Workers:           1,
+		OutputDir:         outputDir,
+		SkipReview:        true,
+		MaxTurns:          999,
+		MaxSessionActions: 5,
+	}))
+
+	prompts := []*prompt.Prompt{
+		{ID: "soft-cap-test", Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "auth"}},
+	}
+	configs := []config.ToolConfig{
+		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	}
+
+	summary, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(summary.Results))
+	}
+	r := summary.Results[0]
+
+	// Soft cap: no error set, so the eval is NOT counted as "Errors".
+	if r.Error != "" {
+		t.Errorf("expected no error for action limit soft cap, got %q", r.Error)
+	}
+	// With SkipReview, Success stays as returned by evaluator (true).
+	if !r.Success {
+		t.Error("expected success=true when action limit is soft cap with no review")
+	}
+	// The report records that the action limit was reached.
+	if !r.ActionLimitReached {
+		t.Error("expected ActionLimitReached=true")
+	}
+	if r.ActionCount != 10 {
+		t.Errorf("expected ActionCount=10, got %d", r.ActionCount)
+	}
+	// Summary: counted as Passed (not Error).
+	if summary.Passed != 1 {
+		t.Errorf("expected Passed=1, got %d", summary.Passed)
+	}
+	if summary.Errors != 0 {
+		t.Errorf("expected Errors=0, got %d", summary.Errors)
 	}
 }
 

--- a/hyoka/internal/report/types.go
+++ b/hyoka/internal/report/types.go
@@ -267,6 +267,9 @@ type EvalReport struct {
 	GuardrailMaxOutputSize     int64  `json:"guardrail_max_output_size,omitempty"`
 	GuardrailMaxSessionActions int    `json:"guardrail_max_session_actions,omitempty"`
 	GuardrailAbortReason       string `json:"guardrail_abort_reason,omitempty"`
+	// Action limit soft cap — generation stopped but review proceeds with partial results
+	ActionLimitReached bool `json:"action_limit_reached,omitempty"`
+	ActionCount        int  `json:"action_count,omitempty"`
 }
 
 // ToolLoadResult records the outcome of loading a single tool, skill, or MCP server.


### PR DESCRIPTION
## Summary

When the generator agent hits the `max_session_actions` limit, the evaluation now proceeds to the review phase with whatever files were created, instead of being reported as an error.

### Before
- Action limit hit → `result.Error` set → eval counted as **Errors: 1** in summary
- Review phase skipped (no files reviewed)

### After
- Action limit hit → generation stops, partial files collected
- Review phase runs on the partial output
- Pass/fail determined by review score, not by the guardrail
- Summary shows **Passed** or **Failed** (not **Errors**)
- Report JSON includes `action_limit_reached: true` and `action_count: N` for transparency

### Changes
| File | Change |
|------|--------|
| `hyoka/internal/eval/engine.go` | Action count guardrail no longer sets `Error` or `Success=false`; sets `ActionLimitReached` and `ActionCount` instead |
| `hyoka/internal/report/types.go` | Added `ActionLimitReached` (bool) and `ActionCount` (int) fields to `EvalReport` |
| `hyoka/internal/eval/engine_test.go` | Fixed `TestGuardrailMaxTurns` to test turn-count directly; added `TestActionLimitSoftCap` |

### Testing
- All existing tests pass (`go test ./hyoka/...`)
- New `TestActionLimitSoftCap` verifies: no error set, success determined by evaluator/review, fields populated, summary counts as Passed not Error
- Build and vet clean