### PR TITLE
Fix prompt category bug and add feature examples

### DIFF
--- a/examples/configs/example-conditional-tools.yaml
+++ b/examples/configs/example-conditional-tools.yaml
@@ -1,0 +1,22 @@
+configs:
+  - name: example/conditional-tools
+    description: "Example showing conditional tool activation by prompt properties"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        - name: create
+          always_on: true
+        - name: edit
+          always_on: true
+        - name: azure_mcp
+          when:
+            language: python
+        - name: dotnet_analyzer
+          when:
+            language: dotnet
+            plane: data-plane
+      excluded_tools:
+        - web_fetch
+    reviewer:
+      models:
+        - "gpt-4.1"

--- a/examples/configs/example-with-limits.yaml
+++ b/examples/configs/example-with-limits.yaml
@@ -1,0 +1,13 @@
+configs:
+  - name: example/with-limits
+    description: "Example showing session guardrail limits"
+    generator:
+      model: "claude-opus-4.6"
+    reviewer:
+      models:
+        - "gpt-4.1"
+    limits:
+      max_turns: 15
+      max_files: 30
+      max_output_size: 524288
+      max_session_actions: 40

--- a/examples/configs/example-with-system-prompt.yaml
+++ b/examples/configs/example-with-system-prompt.yaml
@@ -1,0 +1,10 @@
+configs:
+  - name: example/with-system-prompt
+    description: "Example showing custom system prompts"
+    generator:
+      model: "claude-opus-4.6"
+      system_prompt: "You are an Azure SDK expert. Always use the latest stable API versions and follow Azure SDK design guidelines."
+    reviewer:
+      models:
+        - "gpt-4.1"
+      system_prompt: "Review code for Azure SDK best practices. Focus on error handling, retry policies, and credential management."

--- a/examples/filtering-and-flags.md
+++ b/examples/filtering-and-flags.md
@@ -1,0 +1,310 @@
+# Filtering and CLI Flags Guide
+
+## Overview
+
+hyoka provides powerful filtering and control flags to run evaluations at any scale — from a single prompt to the entire library. This guide covers all the ways to select, filter, and control evaluation runs.
+
+## Prompt Selection
+
+### Single Prompt by ID
+
+```bash
+# Run exactly one prompt
+go run ./hyoka run --prompt-id identity-dp-python-default-credential \
+  --config baseline/claude-opus-4.6
+```
+
+**Important:** `--prompt-id` accepts a **single** prompt ID only (not comma-separated).
+
+### Filter by Service
+
+```bash
+# Run all Key Vault prompts
+go run ./hyoka run --service key-vault \
+  --config azure-mcp/claude-opus-4.6
+
+# Run all Identity prompts
+go run ./hyoka run --service identity \
+  --config baseline/claude-opus-4.6
+```
+
+Available services: `identity`, `key-vault`, `storage`, `cosmos-db`, `event-hubs`, `service-bus`, `app-config`, etc.
+
+### Filter by Language
+
+```bash
+# Run all Python prompts
+go run ./hyoka run --language python \
+  --config azure-mcp/claude-opus-4.6
+
+# Run all .NET prompts
+go run ./hyoka run --language dotnet \
+  --config baseline/claude-opus-4.6
+```
+
+Available languages: `python`, `dotnet`, `java`, `js-ts`, `go`, `rust`, `cpp`
+
+### Filter by Plane
+
+```bash
+# Data-plane prompts only
+go run ./hyoka run --plane data-plane \
+  --config azure-mcp/claude-opus-4.6
+
+# Management-plane prompts only
+go run ./hyoka run --plane management-plane \
+  --config baseline/claude-opus-4.6
+```
+
+### Filter by Category
+
+```bash
+# Authentication prompts
+go run ./hyoka run --category auth \
+  --config azure-mcp/claude-opus-4.6
+
+# CRUD operations
+go run ./hyoka run --category crud \
+  --config baseline/claude-opus-4.6
+
+# Pagination prompts
+go run ./hyoka run --category pagination \
+  --config azure-mcp/claude-opus-4.6
+```
+
+### Filter by Tags
+
+```bash
+# Prompts tagged with specific keywords (comma-separated, must quote)
+go run ./hyoka run --tags "getting-started,crud" \
+  --config azure-mcp/claude-opus-4.6
+```
+
+### Filter by Difficulty
+
+```bash
+# Basic difficulty only
+go run ./hyoka run --difficulty basic \
+  --config baseline/claude-opus-4.6
+
+# Advanced prompts
+go run ./hyoka run --difficulty advanced \
+  --config azure-mcp/claude-opus-4.6
+```
+
+Difficulty levels: `basic`, `intermediate`, `advanced`
+
+### Combine Multiple Filters
+
+```bash
+# Python + Key Vault + data-plane + auth
+go run ./hyoka run --service key-vault \
+  --language python \
+  --plane data-plane \
+  --category auth \
+  --config azure-mcp/claude-opus-4.6
+```
+
+Filters are applied with AND logic — all must match.
+
+## Config Selection
+
+### Single Config
+
+```bash
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config baseline/claude-opus-4.6
+```
+
+### Multiple Configs (Comma-Separated)
+
+**Important:** Comma-separated config names **MUST** be quoted.
+
+```bash
+# Compare baseline vs azure-mcp configs
+go run ./hyoka run --prompt-id identity-dp-python-default-credential \
+  --config "baseline/claude-opus-4.6,azure-mcp/claude-opus-4.6"
+
+# Run across three configs
+go run ./hyoka run --service key-vault --language python \
+  --config "baseline/claude-opus-4.6,baseline/gpt-5.3-codex,azure-mcp/claude-opus-4.6"
+```
+
+### All Configs
+
+**Important:** Requires explicit `--all-configs` flag.
+
+```bash
+# Run one prompt on every config in configs/
+go run ./hyoka run --prompt-id identity-dp-python-default-credential \
+  --all-configs
+```
+
+### Config Name Format
+
+Config names come from the `name:` field **inside** the YAML file, not the filename.
+
+Example: `configs/azure-mcp-opus.yaml` contains:
+```yaml
+configs:
+  - name: azure-mcp/claude-opus-4.6
+```
+
+So use `--config azure-mcp/claude-opus-4.6`, not `--config azure-mcp-opus`.
+
+## Run Control Flags
+
+### Dry Run
+
+Preview what prompts would run without executing:
+
+```bash
+go run ./hyoka run --service storage --language dotnet \
+  --config azure-mcp/claude-opus-4.6 --dry-run
+```
+
+Outputs matching prompts with their IDs, descriptions, and filters.
+
+### Progress Display Modes
+
+Control how evaluation progress is displayed:
+
+```bash
+# Live progress bar (default)
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config baseline/claude-opus-4.6 --progress live
+
+# Log-only output (no progress bar, just timestamped events)
+go run ./hyoka run --service identity --language python \
+  --config azure-mcp/claude-opus-4.6 --progress log
+
+# No progress output (silent except errors)
+go run ./hyoka run --service key-vault --language python \
+  --config baseline/claude-opus-4.6 --progress off
+```
+
+**Tip:** Use `--progress off` when you need clean stderr output, or `--progress log` for CI environments where live updates don't render well.
+
+### Resource Monitoring
+
+Track CPU, memory, and disk usage during evaluations:
+
+```bash
+go run ./hyoka run --service key-vault --language python \
+  --config azure-mcp/claude-opus-4.6 --monitor-resources
+```
+
+Resource metrics appear in the JSON report and HTML dashboard.
+
+### Session Action Limits
+
+Control how many actions a Copilot session can take:
+
+```bash
+# Increase action limit for complex prompts
+go run ./hyoka run --prompt-id cosmos-db-dp-python-pagination \
+  --config azure-mcp/claude-opus-4.6 --max-session-actions 75
+```
+
+Default: 50 actions per session.
+
+## Logging Flags
+
+### Log Level
+
+Control verbosity of diagnostic logs:
+
+```bash
+# Debug logging for troubleshooting
+go run ./hyoka run --service identity --language python \
+  --config azure-mcp/claude-opus-4.6 --log-level debug
+
+# Info logging (default)
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config baseline/claude-opus-4.6 --log-level info
+
+# Warn or error only
+go run ./hyoka run --service storage --language python \
+  --config azure-mcp/claude-opus-4.6 --log-level warn
+```
+
+Levels: `debug`, `info`, `warn`, `error`
+
+### Log to File
+
+Write logs to a file (in addition to stderr):
+
+```bash
+go run ./hyoka run --service key-vault --language python \
+  --config azure-mcp/claude-opus-4.6 \
+  --log-level debug --log-file hyoka-debug.log
+```
+
+**Note:** Logs are written to **both** the file and stderr, so you see output in real-time.
+
+## Tool Ablation
+
+### Pairwise Testing
+
+Generate tool-ablation variants (baseline + N "without-tool" configs):
+
+```bash
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config azure-mcp/claude-opus-4.6 --pairwise
+```
+
+See `examples/pairwise-testing.md` for full details.
+
+## Example Workflows
+
+### Quick Single-Prompt Test
+
+```bash
+go run ./hyoka run --prompt-id identity-dp-python-default-credential \
+  --config baseline/claude-opus-4.6
+```
+
+### Compare Two Configs on Key Vault + Python
+
+```bash
+go run ./hyoka run --service key-vault --language python \
+  --config "baseline/claude-opus-4.6,azure-mcp/claude-opus-4.6"
+```
+
+### Full Language Suite (All Python Prompts, All Configs)
+
+```bash
+go run ./hyoka run --language python --all-configs
+```
+
+### Debug a Failing Prompt
+
+```bash
+go run ./hyoka run --prompt-id cosmos-db-dp-python-pagination \
+  --config azure-mcp/claude-opus-4.6 \
+  --log-level debug --log-file debug.log --progress log
+```
+
+### Pairwise Tool Impact Analysis with Resource Monitoring
+
+```bash
+go run ./hyoka run --service identity --language python \
+  --config azure-mcp/claude-opus-4.6 \
+  --pairwise --monitor-resources
+```
+
+## Tips
+
+- **Always quote comma-separated values:** `--config "cfg1,cfg2"`, `--tags "tag1,tag2"`
+- **Use dry-run first:** Preview matches before running expensive evaluations
+- **Filter early:** Run on a subset (one service, one language) before scaling to all prompts
+- **Python prompts are fast:** Use Python prompts for quick iteration when testing hyoka changes
+- **Monitor first runs:** Use `--monitor-resources` and `--log-level debug` on unfamiliar prompts to catch issues early
+
+## See Also
+
+- `examples/configs/` — Example config files demonstrating all features
+- `examples/prompts/` — Example prompts with various frontmatter fields
+- `examples/pairwise-testing.md` — Deep dive on tool ablation testing
+- `docs/configuration.md` — Full configuration reference
+- `docs/prompt-authoring.md` — Prompt frontmatter and structure guide

--- a/examples/pairwise-testing.md
+++ b/examples/pairwise-testing.md
@@ -1,0 +1,96 @@
+# Pairwise Tool Ablation Testing
+
+## Overview
+
+Pairwise testing is a tool-ablation feature that measures the individual impact of each tool in a config on code generation quality. When you run hyoka with `--pairwise`, it generates **N+1 config variants**:
+
+1. **Baseline:** The original config with all tools enabled
+2. **N variants:** One config per tool, with that tool removed
+
+The evaluation runs all variants and reports the score difference between baseline and each "without-X" variant, showing you which tools provide the most value.
+
+## When to Use Pairwise Testing
+
+- **Measuring tool impact:** Determine which MCP servers or Copilot tools contribute most to code quality
+- **Cost optimization:** Identify low-value tools that can be removed to reduce latency/cost
+- **Tool validation:** Verify that a new tool actually improves generated code
+- **Comparative analysis:** Understand tool interactions (does removing tool A affect tool B's utility?)
+
+## Example Commands
+
+### Run pairwise with a single prompt
+
+```bash
+# Evaluate one prompt with tool ablation
+go run ./hyoka run --prompt-id key-vault-dp-python-crud \
+  --config azure-mcp/claude-opus-4.6 --pairwise
+```
+
+This generates configs:
+- `azure-mcp/claude-opus-4.6` (baseline)
+- `azure-mcp/claude-opus-4.6-without-azure-mcp`
+- `azure-mcp/claude-opus-4.6-without-web-fetch`
+- etc.
+
+### Run pairwise with filtered prompts
+
+```bash
+# Test tool impact across multiple identity+Python prompts
+go run ./hyoka run --service identity --language python \
+  --config azure-mcp/claude-opus-4.6 --pairwise
+```
+
+### Run pairwise with multiple configs
+
+```bash
+# Compare tool impact across baseline and azure-mcp configs
+go run ./hyoka run --prompt-id identity-dp-python-default-credential \
+  --config "baseline/claude-opus-4.6,azure-mcp/claude-opus-4.6" --pairwise
+```
+
+Each config spawns its own N+1 variants.
+
+## Interpreting Results
+
+The HTML report shows:
+
+- **Baseline score:** The score achieved with all tools enabled
+- **Without-X scores:** Score for each variant with one tool removed
+- **Impact:** `baseline_score - without_X_score`
+  - **Positive impact:** Removing the tool decreased quality (tool is valuable)
+  - **Negative impact:** Removing the tool increased quality (tool may be harmful or redundant)
+  - **Zero impact:** Tool had no measurable effect on this prompt
+
+Example:
+```
+Config: azure-mcp/claude-opus-4.6
+Baseline: 85.2
+
+azure-mcp/claude-opus-4.6-without-azure-mcp: 72.1  (impact: +13.1) ← azure-mcp is very valuable
+azure-mcp/claude-opus-4.6-without-web-fetch: 84.8  (impact: +0.4)  ← web-fetch has minimal impact
+```
+
+## Important Notes
+
+- **`always_on: true` tools are never toggled:** Tools marked as always-on (like `create`, `edit`) are excluded from pairwise variants since they're essential for code generation.
+- **Pairwise multiplies run time:** If your config has 5 toggleable tools, you'll run 6 evaluations (1 baseline + 5 variants). Plan accordingly.
+- **Use with focused prompts:** Pairwise is most useful on representative prompts that exercise the tools you're testing.
+
+## Advanced: Combining with Other Flags
+
+```bash
+# Pairwise with resource monitoring and debug logging
+go run ./hyoka run --service key-vault --language python \
+  --config azure-mcp/claude-opus-4.6 --pairwise \
+  --monitor-resources --log-level debug --log-file pairwise-debug.log
+
+# Dry run to see what configs would be generated
+go run ./hyoka run --prompt-id cosmos-db-dp-python-pagination \
+  --config azure-mcp/claude-opus-4.6 --pairwise --dry-run
+```
+
+## See Also
+
+- `examples/configs/example-conditional-tools.yaml` — Shows how to configure tools with `when` conditions and `always_on`
+- `docs/configuration.md` — Full tool configuration reference
+- `examples/filtering-and-flags.md` — All hyoka CLI flags and filtering options

--- a/examples/prompts/example-with-expected-packages.prompt.md
+++ b/examples/prompts/example-with-expected-packages.prompt.md
@@ -1,0 +1,52 @@
+---
+id: example-expected-packages
+properties:
+  service: cosmos-db
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: intermediate
+  description: 'Example prompt demonstrating expected_packages and expected_tools fields'
+  sdk_package: azure-cosmos
+  doc_url: https://learn.microsoft.com/python/api/azure-cosmos
+  created: '2025-04-04'
+  author: hyoka-examples
+tags:
+- example
+- expected-validation
+expected_packages:
+- azure-cosmos>=4.5.0
+- azure-identity>=1.15.0
+expected_tools:
+- pip
+- python3
+---
+
+# Example: Expected Packages and Tools
+
+## Prompt
+
+Create a Python script that connects to Azure Cosmos DB and performs basic CRUD operations
+on a container. Use the azure-cosmos SDK with DefaultAzureCredential for authentication.
+
+The script should:
+- Install required packages using pip
+- Create a database client with credential authentication
+- Perform create, read, update, delete operations on items
+
+## Evaluation Criteria
+
+The generated code should:
+- Install `azure-cosmos` and `azure-identity` packages
+- Use Python 3.9+ features
+- Include proper error handling
+- Use DefaultAzureCredential for authentication
+
+## Context
+
+This example demonstrates how `expected_packages` and `expected_tools` can be used
+to validate that the generator:
+1. Installs the correct SDK packages with appropriate version constraints
+2. Uses the expected development tools (pip, python3)
+
+These fields help measure whether the AI agent correctly identified required dependencies.

--- a/examples/prompts/example-with-starter-project.prompt.md
+++ b/examples/prompts/example-with-starter-project.prompt.md
@@ -1,0 +1,51 @@
+---
+id: example-starter-project
+properties:
+  service: key-vault
+  plane: data-plane
+  language: python
+  category: crud
+  difficulty: basic
+  description: 'Example prompt demonstrating starter_project frontmatter field'
+  sdk_package: azure-keyvault-secrets
+  doc_url: https://learn.microsoft.com/python/api/azure-keyvault-secrets
+  created: '2025-04-04'
+  author: hyoka-examples
+tags:
+- example
+- starter-project
+starter_project: |
+  # Starter project files
+  src/
+    __init__.py
+    main.py  # Contains boilerplate KeyVault client setup
+  requirements.txt  # Has azure-keyvault-secrets==4.8.0
+  .env.example  # Shows AZURE_KEY_VAULT_URL format
+---
+
+# Example: CRUD Operations with Starter Project
+
+## Prompt
+
+I have a Python project already set up with the Azure Key Vault Secrets SDK.
+Extend the existing `main.py` to add functions for:
+- Creating a secret
+- Reading a secret
+- Updating a secret value
+- Deleting a secret
+
+Use the existing KeyVault client that's already initialized in the starter code.
+
+## Evaluation Criteria
+
+The generated code should:
+- Work with the existing project structure
+- Add CRUD functions without breaking existing initialization
+- Include error handling for each operation
+- Use async/await if the starter project uses async patterns
+
+## Context
+
+This example demonstrates how the `starter_project` field provides context
+about existing project structure. The generator should extend rather than
+create from scratch.

--- a/prompts/storage/data-plane/dotnet/authentication.prompt.md
+++ b/prompts/storage/data-plane/dotnet/authentication.prompt.md
@@ -4,7 +4,7 @@ properties:
   service: storage
   plane: data-plane
   language: dotnet
-  category: authentication
+  category: auth
   difficulty: basic
   description: 'Can a developer authenticate to Azure Blob Storage using DefaultAzureCredential in .NET?
 


### PR DESCRIPTION
## Overview

Fixes one prompt category bug (audit item 3) and creates 7 example files for features that had zero examples.

## Changes

### Part 1: Prompt Category Fix
- **File:** prompts/storage/data-plane/dotnet/authentication.prompt.md
- **Change:** category: authentication → category: auth
- **Reason:** This was the only prompt using authentication as a category; all 22 other auth prompts use auth for consistency.

### Part 2: Feature Examples
Created 7 new example files to demonstrate features that had no working examples:

1. examples/configs/example-with-limits.yaml — Session guardrail limits
2. examples/configs/example-with-system-prompt.yaml — Custom system prompts
3. examples/configs/example-conditional-tools.yaml — Conditional tool activation
4. examples/prompts/example-with-starter-project.prompt.md — Starter project frontmatter
5. examples/prompts/example-with-expected-packages.prompt.md — Expected packages/tools fields
6. examples/pairwise-testing.md — Tool ablation testing guide
7. examples/filtering-and-flags.md — Complete CLI usage guide

## Validation

✅ All 89 prompts validated with go run ./hyoka validate
✅ All example configs use valid YAML structure
✅ Example prompts follow hyoka conventions