### PR TITLE
feat: wire system_prompt config to generator and reviewer sessions

### DIFF
--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -317,6 +317,9 @@ panelReviewer.SetSessionTimeout(sessionTimeout)
 if len(reviewerSkillsDirs) > 0 {
 panelReviewer.SetSkillDirectories(reviewerSkillsDirs)
 }
+if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
+panelReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
+}
 slog.Debug("Created review panel for config", "config", cfg.Name, "models", reviewerModels)
 return nil, panelReviewer, nil
 }
@@ -330,6 +333,9 @@ copilotReviewer := review.NewCopilotReviewer(reviewClient, reviewerModels[0], f.
 copilotReviewer.SetSessionTimeout(sessionTimeout)
 if len(reviewerSkillsDirs) > 0 {
 copilotReviewer.SetSkillDirectories(reviewerSkillsDirs)
+}
+if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
+copilotReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
 }
 slog.Debug("Created single reviewer for config", "config", cfg.Name, "model", reviewerModels[0])
 return copilotReviewer, nil, nil

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -755,6 +755,15 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 		slog.Debug("No MCP servers configured")
 	}
 
+	// Wire generator system prompt to Copilot SDK session.
+	if cfg.Generator.SystemPrompt != "" {
+		sc.SystemMessage = &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: cfg.Generator.SystemPrompt,
+		}
+		slog.Info("Generator system prompt configured", "length", len(cfg.Generator.SystemPrompt))
+	}
+
 	return sc
 }
 

--- a/hyoka/internal/eval/copilot_test.go
+++ b/hyoka/internal/eval/copilot_test.go
@@ -436,3 +436,36 @@ func TestIntegration_DuplicateToolEntries(t *testing.T) {
 		t.Errorf("expected [create edit], got %v", sc.AvailableTools)
 	}
 }
+
+func TestBuildSessionConfig_SystemPromptSet(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model:        "gpt-4",
+			SystemPrompt: "You are a helpful Azure SDK assistant.",
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if sc.SystemMessage == nil {
+		t.Fatal("expected SystemMessage to be set when generator.system_prompt is configured")
+	}
+	if sc.SystemMessage.Mode != "append" {
+		t.Errorf("expected SystemMessage.Mode 'append', got %q", sc.SystemMessage.Mode)
+	}
+	if sc.SystemMessage.Content != "You are a helpful Azure SDK assistant." {
+		t.Errorf("expected SystemMessage.Content to match system_prompt, got %q", sc.SystemMessage.Content)
+	}
+}
+
+func TestBuildSessionConfig_SystemPromptEmpty(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name:      "test",
+		Generator: &config.GeneratorConfig{Model: "gpt-4"},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if sc.SystemMessage != nil {
+		t.Errorf("expected SystemMessage nil when no system_prompt set, got %+v", sc.SystemMessage)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the existing `system_prompt` config fields on `GeneratorConfig` and `ReviewerConfig` through to the Copilot SDK sessions.

### Changes

**Generator** (`hyoka/internal/eval/copilot.go`):
- In `buildSessionConfig()`, set `SessionConfig.SystemMessage` when `generator.system_prompt` is configured
- Uses `Mode: "append"` to match the reviewer pattern

**Reviewer** (`hyoka/cmd/run.go`):
- Call `SetSystemPrompt()` on `PanelReviewer` and `CopilotReviewer` when `reviewer.system_prompt` is set in config
- The `SetSystemPrompt()` methods already existed but were never called from the run command

### Tests
- `TestBuildSessionConfig_SystemPromptSet` — verifies SystemMessage is populated with correct Mode and Content
- `TestBuildSessionConfig_SystemPromptEmpty` — verifies SystemMessage stays nil when no system_prompt
- All 26 packages pass

Closes part of P1 from codebase audit.