### PR TITLE
fix: add skill frontmatter + cleanup unused config fields

### DIFF
--- a/.agents/skills/model-selection/SKILL.md
+++ b/.agents/skills/model-selection/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "model-selection"
+description: "Determines which LLM model to use for each agent spawn based on 4-layer hierarchy"
+domain: "orchestration"
+confidence: "high"
+source: "squad.agent.md — Per-Agent Model Selection section"
+---
+
 # Model Selection
 
 > Determines which LLM model to use for each agent spawn.

--- a/.agents/skills/nap/SKILL.md
+++ b/.agents/skills/nap/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "nap"
+description: "Context hygiene — compress, prune, archive .squad/ state"
+domain: "team-optimization"
+confidence: "medium"
+source: "manual — Squad maintenance workflow"
+---
+
 # Skill: nap
 
 > Context hygiene — compress, prune, archive .squad/ state

--- a/.agents/skills/personal-squad/SKILL.md
+++ b/.agents/skills/personal-squad/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "personal-squad"
+description: "User-level personal agents that travel across projects via Ghost Protocol"
+domain: "orchestration"
+confidence: "medium"
+source: "squad.agent.md — Personal Squad section"
+---
+
 # Personal Squad — Skill Document
 
 ## What is a Personal Squad?

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "model-selection"
+description: "Determines which LLM model to use for each agent spawn based on 4-layer hierarchy"
+domain: "orchestration"
+confidence: "high"
+source: "squad.agent.md — Per-Agent Model Selection section"
+---
+
 # Model Selection
 
 > Determines which LLM model to use for each agent spawn.

--- a/.copilot/skills/nap/SKILL.md
+++ b/.copilot/skills/nap/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "nap"
+description: "Context hygiene — compress, prune, archive .squad/ state"
+domain: "team-optimization"
+confidence: "medium"
+source: "manual — Squad maintenance workflow"
+---
+
 # Skill: nap
 
 > Context hygiene — compress, prune, archive .squad/ state

--- a/.copilot/skills/personal-squad/SKILL.md
+++ b/.copilot/skills/personal-squad/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "personal-squad"
+description: "User-level personal agents that travel across projects via Ghost Protocol"
+domain: "orchestration"
+confidence: "medium"
+source: "squad.agent.md — Personal Squad section"
+---
+
 # Personal Squad — Skill Document
 
 ## What is a Personal Squad?

--- a/.squad/templates/skills/model-selection/SKILL.md
+++ b/.squad/templates/skills/model-selection/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "model-selection"
+description: "Determines which LLM model to use for each agent spawn based on 4-layer hierarchy"
+domain: "orchestration"
+confidence: "high"
+source: "squad.agent.md — Per-Agent Model Selection section"
+---
+
 # Model Selection
 
 > Determines which LLM model to use for each agent spawn.

--- a/.squad/templates/skills/nap/SKILL.md
+++ b/.squad/templates/skills/nap/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "nap"
+description: "Context hygiene — compress, prune, archive .squad/ state"
+domain: "team-optimization"
+confidence: "medium"
+source: "manual — Squad maintenance workflow"
+---
+
 # Skill: nap
 
 > Context hygiene — compress, prune, archive .squad/ state

--- a/.squad/templates/skills/personal-squad/SKILL.md
+++ b/.squad/templates/skills/personal-squad/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "personal-squad"
+description: "User-level personal agents that travel across projects via Ghost Protocol"
+domain: "orchestration"
+confidence: "medium"
+source: "squad.agent.md — Personal Squad section"
+---
+
 # Personal Squad — Skill Document
 
 ## What is a Personal Squad?

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -43,7 +43,6 @@ type GeneratorConfig struct {
 
 // ReviewerConfig holds all configuration for the review/grading plane.
 type ReviewerConfig struct {
-	Model        string   `yaml:"model,omitempty" json:"model,omitempty"`
 	Models       []string `yaml:"models,omitempty" json:"models,omitempty"`
 	SystemPrompt string   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
 	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -120,16 +120,6 @@ func NewEngine(evaluator CopilotEvaluator, opts EngineOptions) *Engine {
 	return NewEngineWithReviewerFactory(evaluator, nil, opts)
 }
 
-// NewEngineWithReviewer creates a new Engine with an evaluator and reviewer.
-// Deprecated: Use NewEngineWithReviewerFactory instead.
-func NewEngineWithReviewer(evaluator CopilotEvaluator, reviewer review.Reviewer, opts EngineOptions) *Engine {
-	// Backward compatibility: wrap the single reviewer in a factory
-	factory := func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
-		return reviewer, nil, nil
-	}
-	return NewEngineWithReviewerFactory(evaluator, factory, opts)
-}
-
 // NewEngineWithReviewerFactory creates a new Engine with an evaluator and reviewer factory.
 func NewEngineWithReviewerFactory(evaluator CopilotEvaluator, factory ReviewerFactory, opts EngineOptions) *Engine {
 	if opts.Workers <= 0 {
@@ -239,16 +229,6 @@ func (e *Engine) mergedCriteria(p *prompt.Prompt) string {
 		return p.EvaluationCriteria
 	}
 	return merged
-}
-
-// SetPanelReviewer configures a multi-model review panel.
-// Deprecated: Use NewEngineWithReviewerFactory instead.
-func (e *Engine) SetPanelReviewer(pr *review.PanelReviewer) {
-	// Backward compatibility: wrap the panel reviewer in a factory
-	e.reviewerFactory = func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
-		pr.SetSessionTimeout(e.opts.SessionTimeout)
-		return nil, pr, nil
-	}
 }
 
 // EvalTask represents a single prompt+config evaluation to run.

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -806,7 +806,10 @@ graders:
 `), 0644)
 
 	reviewer := &capturingReviewer{}
-	engine := NewEngineWithReviewer(&StubEvaluator{}, reviewer, quietOpts(EngineOptions{
+	reviewerFactory := func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
+		return reviewer, nil, nil
+	}
+	engine := NewEngineWithReviewerFactory(&StubEvaluator{}, reviewerFactory, quietOpts(EngineOptions{
 		Workers:     1,
 		OutputDir:   t.TempDir(),
 		CriteriaDir: criteriaDir,
@@ -857,7 +860,10 @@ func TestCriteriaDirNotExist(t *testing.T) {
 func TestCriteriaDirEmpty(t *testing.T) {
 	// Empty criteria dir should work fine — no criteria matched
 	reviewer := &capturingReviewer{}
-	engine := NewEngineWithReviewer(&StubEvaluator{}, reviewer, quietOpts(EngineOptions{
+	reviewerFactory := func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
+		return reviewer, nil, nil
+	}
+	engine := NewEngineWithReviewerFactory(&StubEvaluator{}, reviewerFactory, quietOpts(EngineOptions{
 		Workers:     1,
 		OutputDir:   t.TempDir(),
 		CriteriaDir: t.TempDir(), // empty dir

--- a/hyoka/internal/eval/integration_test.go
+++ b/hyoka/internal/eval/integration_test.go
@@ -18,7 +18,10 @@ import (
 // summary.json are written to disk.
 func TestIntegrationStubEvalReviewPipeline(t *testing.T) {
 outputDir := t.TempDir()
-engine := NewEngineWithReviewer(&StubEvaluator{}, &review.StubReviewer{}, quietOpts(EngineOptions{
+stubFactory := func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
+	return &review.StubReviewer{}, nil, nil
+}
+engine := NewEngineWithReviewerFactory(&StubEvaluator{}, stubFactory, quietOpts(EngineOptions{
 Workers:   1,
 OutputDir: outputDir,
 }))
@@ -40,7 +43,7 @@ configs := []config.ToolConfig{
 {
 Name:      "test-config",
 Generator: &config.GeneratorConfig{Model: "gpt-4"},
-Reviewer:  &config.ReviewerConfig{Model: "gpt-4"},
+Reviewer:  &config.ReviewerConfig{Models: []string{"gpt-4"}},
 },
 }
 
@@ -137,7 +140,10 @@ t.Errorf("summary RunID mismatch: disk=%q, memory=%q", diskSummary.RunID, summar
 // produces a valid report on disk.
 func TestIntegrationMultiPromptMultiConfigWithReview(t *testing.T) {
 outputDir := t.TempDir()
-engine := NewEngineWithReviewer(&StubEvaluator{}, &review.StubReviewer{}, quietOpts(EngineOptions{
+stubFactory := func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
+	return &review.StubReviewer{}, nil, nil
+}
+engine := NewEngineWithReviewerFactory(&StubEvaluator{}, stubFactory, quietOpts(EngineOptions{
 Workers:   2,
 OutputDir: outputDir,
 }))
@@ -155,8 +161,8 @@ Properties: map[string]string{"service": "storage", "plane": "data-plane", "lang
 },
 }
 configs := []config.ToolConfig{
-{Name: "cfg-alpha", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Reviewer: &config.ReviewerConfig{Model: "gpt-4"}},
-{Name: "cfg-beta", Generator: &config.GeneratorConfig{Model: "claude-sonnet-4.5"}, Reviewer: &config.ReviewerConfig{Model: "claude-sonnet-4.5"}},
+{Name: "cfg-alpha", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Reviewer: &config.ReviewerConfig{Models: []string{"gpt-4"}}},
+{Name: "cfg-beta", Generator: &config.GeneratorConfig{Model: "claude-sonnet-4.5"}, Reviewer: &config.ReviewerConfig{Models: []string{"claude-sonnet-4.5"}}},
 }
 
 summary, err := engine.Run(context.Background(), prompts, configs)
@@ -234,8 +240,8 @@ Properties: map[string]string{"service": "identity", "plane": "data-plane", "lan
 },
 }
 configs := []config.ToolConfig{
-{Name: "cfg-1", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Reviewer: &config.ReviewerConfig{Model: "gpt-4"}},
-{Name: "cfg-2", Generator: &config.GeneratorConfig{Model: "claude-sonnet-4.5"}, Reviewer: &config.ReviewerConfig{Model: "claude-sonnet-4.5"}},
+{Name: "cfg-1", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Reviewer: &config.ReviewerConfig{Models: []string{"gpt-4"}}},
+{Name: "cfg-2", Generator: &config.GeneratorConfig{Model: "claude-sonnet-4.5"}, Reviewer: &config.ReviewerConfig{Models: []string{"claude-sonnet-4.5"}}},
 }
 
 summary, err := engine.Run(context.Background(), prompts, configs)

--- a/hyoka/internal/eval/reviewer_factory_test.go
+++ b/hyoka/internal/eval/reviewer_factory_test.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"context"
-	"io"
 	"testing"
 
 	"github.com/ronniegeraghty/hyoka/internal/config"
@@ -92,34 +91,6 @@ func TestReviewerFactoryPerConfig(t *testing.T) {
 		t.Error("expected factory to be called for config-sonnet")
 	} else if len(sonnetModels) != 1 || sonnetModels[0] != "claude-sonnet-4.5" {
 		t.Errorf("expected config-sonnet to have sonnet model, got %v", sonnetModels)
-	}
-}
-
-// TestReviewerFactoryBackwardCompat verifies that the deprecated
-// NewEngineWithReviewer still works (backward compatibility).
-func TestReviewerFactoryBackwardCompat(t *testing.T) {
-	// Create a stub reviewer
-	reviewer := &review.StubReviewer{}
-
-	// Create engine using deprecated method
-	engine := NewEngineWithReviewer(&StubEvaluator{}, reviewer, quietOpts(EngineOptions{
-		OutputDir:    t.TempDir(),
-		SkipTests:    true,
-		SkipReview:   false,
-		DryRun:       false,
-		Workers:      1,
-		ProgressMode: "off",
-		Stdout:       io.Discard,
-	}))
-
-	// Verify engine was created
-	if engine == nil {
-		t.Fatal("expected engine to be created")
-	}
-
-	// Verify factory was set (even though we used the old constructor)
-	if engine.reviewerFactory == nil {
-		t.Error("expected reviewerFactory to be set for backward compat")
 	}
 }
 


### PR DESCRIPTION
## Summary

Batch cleanup from codebase audit (P2-P3 items).

### Part 1: Skill YAML frontmatter
Added missing YAML frontmatter to 3 skills × 3 locations (9 files):
- `model-selection/SKILL.md`
- `nap/SKILL.md`
- `personal-squad/SKILL.md`

Synced across `.agents/`, `.copilot/`, and `.squad/templates/`.

### Part 2: Remove unused ReviewerConfig.Model
Removed the singular `Model string` field from `ReviewerConfig` — only `Models []string` is used. Updated 3 test literals that referenced the old field.

### Part 3: EventWaiting — kept
`EventWaiting` is actively used in `display.go` switch case. Left as-is.

### Part 4: Remove deprecated constructors
- Removed `NewEngineWithReviewer()` (deprecated, replaced by `NewEngineWithReviewerFactory`)
- Removed `SetPanelReviewer()` (deprecated, never called)
- Kept `NewEngine()` (not deprecated, convenience constructor)
- Updated 5 test call sites to use `NewEngineWithReviewerFactory` directly
- Removed backward-compat test that tested the deleted constructor

### Verification
- `go build ./hyoka/...` ✅
- `go test ./hyoka/... -count=1` — all 27 packages pass ✅
- Net: +93 / -59 lines (14 files)