### PR TITLE
feat: unify mcp_servers, skills, and available_tools into tools[] (#252)

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -90,3 +90,18 @@ Implemented P0 config hardening from codebase audit (#252, items 1-2):
 
 **Files:** hyoka/internal/config/config.go, hyoka/internal/config/config_test.go
 
+
+### Session 2026-04-08 (Config Unification #252)
+
+**Status:** COMPLETE
+
+Unified generator/reviewer tooling into a single `tools` array with typed entries (`tool`, `mcp`, `skill`). Updated config validation, tool resolution, MCP wiring, pairwise ablation logic, plugin merging, and skill path resolution to operate on typed ToolEntry records.
+
+**Implementation:**
+- Extended `ToolEntry` with MCP and skill metadata plus type normalization
+- Reworked eval/session setup to derive MCP servers, skills, and available tools from `generator.tools`
+- Updated configs and docs to the unified `tools` schema and migrated tests
+
+**Testing:** `go build ./hyoka/...`, `go vet ./hyoka/...`, `go test ./hyoka/... -count=1`
+
+**Key Learning:** Centralizing tool configuration simplifies downstream consumers — filter by type once and reuse the same entries for MCP, skills, and tool allowlists without duplicating schema fields.

--- a/README.md
+++ b/README.md
@@ -317,35 +317,36 @@ configs:
     description: "My custom evaluation config"
     generator:
       model: "claude-sonnet-4.5"
-      skills:
-        - type: remote
-          name: azure-keyvault-py
+      tools:
+        - name: azure-keyvault-py
+          type: skill
+          source: remote
           repo: microsoft/skills
-        - type: local
+        - name: generator-skills
+          type: skill
+          source: local
           path: "./skills/generator"
-      mcp_servers:
-        azure:
-          type: local
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest"]
-          tools: ["*"]
     reviewer:
       models:
         - "claude-opus-4.6"
         - "gemini-3-pro-preview"
         - "gpt-4.1"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"
 ```
 
 Then run with: `hyoka run --config-file configs/my-custom-config.yaml`
 
-> **Backward compatibility:** Legacy top-level fields (`model`, `reviewer_models`, `skill_directories`, `generator_skill_directories`, etc.) still work. They are automatically migrated to the `generator`/`reviewer` sub-structs at parse time.
+#### Skills in `tools`
 
-#### Unified Skills
-
-Skills give agents domain-specific knowledge (SDK patterns, API examples, acceptance criteria) that improve code generation and review quality. The unified `skills:` list replaces the old `skill_directories`, `generator_skill_directories`, and `reviewer_skill_directories` fields.
+Skills give agents domain-specific knowledge (SDK patterns, API examples, acceptance criteria) that improve code generation and review quality. They are configured as `tools` entries with `type: skill` in the generator or reviewer section.
 
 Each skill has a `type`:
 
@@ -359,11 +360,14 @@ Each skill has a `type`:
 ```yaml
 generator:
   model: "claude-sonnet-4.5"
-  skills:
-    - type: remote
-      name: azure-keyvault-py
+  tools:
+    - name: azure-keyvault-py
+      type: skill
+      source: remote
       repo: microsoft/skills
-    - type: local
+    - name: generator-skills
+      type: skill
+      source: local
       path: "./skills/generator"
 ```
 
@@ -374,8 +378,10 @@ reviewer:
   models:
     - "claude-opus-4.6"
     - "gpt-4.1"
-  skills:
-    - type: local
+  tools:
+    - name: reviewer-skills
+      type: skill
+      source: local
       path: "./skills/reviewer"
 ```
 

--- a/configs/azure-mcp-codex.yaml
+++ b/configs/azure-mcp-codex.yaml
@@ -4,17 +4,19 @@ configs:
     description: "Azure MCP — GPT 5.3 Codex"
     generator:
       model: "gpt-5.3-codex"
-      mcp_servers:
-        azure:
-          type: local
+      tools:
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest", "server", "start"]
-          tools: ["*"]
+          mcp_tools: ["*"]
     reviewer:
       models:
         - "claude-opus-4.6"
         - "gemini-3-pro-preview"
         - "gpt-4.1"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"

--- a/configs/azure-mcp-opus.yaml
+++ b/configs/azure-mcp-opus.yaml
@@ -4,17 +4,19 @@ configs:
     description: "Azure MCP — Claude Opus 4.6"
     generator:
       model: "claude-opus-4.6"
-      mcp_servers:
-        azure:
-          type: local
+      tools:
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest", "server", "start"]
-          tools: ["*"]
+          mcp_tools: ["*"]
     reviewer:
       models:
         - "claude-opus-4.6"
         - "gemini-3-pro-preview"
         - "gpt-4.1"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"

--- a/configs/azure-mcp-sonnet.yaml
+++ b/configs/azure-mcp-sonnet.yaml
@@ -4,17 +4,19 @@ configs:
     description: "Azure MCP — Claude Sonnet 4.5"
     generator:
       model: "claude-sonnet-4.5"
-      mcp_servers:
-        azure:
-          type: local
+      tools:
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest", "server", "start"]
-          tools: ["*"]
+          mcp_tools: ["*"]
     reviewer:
       models:
         - "claude-opus-4.6"
         - "gemini-3-pro-preview"
         - "gpt-4.1"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"

--- a/configs/baseline-opus-skills.yaml
+++ b/configs/baseline-opus-skills.yaml
@@ -5,8 +5,10 @@ configs:
     description: "Baseline + Skills — Claude Opus 4.6 with generator skills"
     generator:
       model: "claude-opus-4.6"
-      skills:
-        - type: local
+      tools:
+        - name: generator-skills
+          type: skill
+          source: local
           path: "./skills/generator"
     reviewer:
       models:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-hyoka uses YAML configuration files to define evaluation setups. Each config specifies a generator model, reviewer models, skills, and MCP servers.
+hyoka uses YAML configuration files to define evaluation setups. Each config specifies a generator model, reviewer models, and tool entries (tools, skills, MCP servers).
 
 ## Config Directory
 
@@ -31,16 +31,20 @@ configs:
   - name: baseline/claude-opus-4.6
     generator:
       model: claude-opus-4.6
-      skills:
-        - type: local
+      tools:
+        - name: generator-skills
+          type: skill
+          source: local
           path: ../skills/generator
     reviewer:
       models:
         - claude-opus-4.6
         - gpt-5.3-codex
         - claude-sonnet-4.5
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: ../skills/reviewer
 ```
 
@@ -59,9 +63,7 @@ configs:
 |-------|------|---------|-------------|
 | `model` | string | required | Model to use for code generation |
 | `system_prompt` | string | "" | Custom system instruction for the generator agent |
-| `skills` | list | [] | Skill references for the generator session |
-| `mcp_servers` | map | {} | MCP server configurations |
-| `available_tools` | list | [] | Allowlist of tools the agent can use |
+| `tools` | list | [] | Tool entries (type: tool, skill, or mcp) |
 | `excluded_tools` | list | [] | Denylist of tools |
 
 ### Reviewer Section
@@ -71,7 +73,7 @@ configs:
 | `model` | string | — | Single reviewer model |
 | `models` | list | — | Multiple reviewer models (panel review) |
 | `system_prompt` | string | "" | Custom system instruction for reviewer agents |
-| `skills` | list | [] | Skill references for review sessions |
+| `tools` | list | [] | Tool entries (type: skill) for review sessions |
 
 When `models` lists multiple models, hyoka uses a **panel review** where all models review independently and the first model acts as consolidator to produce a consensus result.
 
@@ -79,7 +81,7 @@ When `models` lists multiple models, hyoka uses a **panel review** where all mod
 
 Skills are Copilot agent instructions packaged as directories containing a `SKILL.md` file. When attached to a generator or reviewer session, the agent receives the skill's content as additional context that guides its behavior.
 
-Skills can be attached to either the **generator** (code generation agent) or the **reviewer** (grading panel agents), or both. They are configured under the `generator.skills` and `reviewer.skills` fields respectively.
+Skills can be attached to either the **generator** (code generation agent) or the **reviewer** (grading panel agents), or both. They are configured as tool entries (`type: skill`) under the `generator.tools` and `reviewer.tools` fields respectively.
 
 #### Skill Types
 
@@ -92,23 +94,28 @@ Local skills reference a directory on disk. Paths can be absolute or relative to
 ```yaml
 generator:
   model: claude-opus-4.6
-  skills:
-    - type: local
+  tools:
+    - name: generator-skills
+      type: skill
+      source: local
       path: ./skills/generator
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `type` | yes | Must be `"local"` |
+| `type` | yes | Must be `"skill"` |
+| `source` | yes | Must be `"local"` |
 | `path` | yes | Path to a skill directory (absolute or relative) |
 
 **Glob patterns** are supported, letting you load multiple skill directories at once. Only directories are included — files are filtered out.
 
 ```yaml
 generator:
-  skills:
+  tools:
     # Loads every subdirectory under ./skills/generator/
-    - type: local
+    - name: generator-skills
+      type: skill
+      source: local
       path: "./skills/generator/*"
 ```
 
@@ -121,15 +128,17 @@ Remote skills are fetched from a GitHub repository using `npx skills add`. They 
 ```yaml
 generator:
   model: claude-sonnet-4.5
-  skills:
-    - type: remote
-      name: azure-keyvault-py
+  tools:
+    - name: azure-keyvault-py
+      type: skill
+      source: remote
       repo: microsoft/skills
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `type` | yes | Must be `"remote"` |
+| `type` | yes | Must be `"skill"` |
+| `source` | yes | Must be `"remote"` |
 | `repo` | yes | GitHub repository in `owner/repo` format |
 | `name` | no | Specific skill name within the repo |
 
@@ -149,18 +158,23 @@ configs:
   - name: my-eval/claude-opus-4.6
     generator:
       model: claude-opus-4.6
-      skills:
-        - type: local
+      tools:
+        - name: generator-skills
+          type: skill
+          source: local
           path: ./skills/generator
-        - type: remote
-          name: azure-keyvault-py
+        - name: azure-keyvault-py
+          type: skill
+          source: remote
           repo: microsoft/skills
     reviewer:
       models:
         - claude-opus-4.6
         - gpt-4.1
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer/*"
 ```
 
@@ -186,61 +200,29 @@ The `SKILL.md` file contains markdown instructions that the Copilot agent receiv
 
 #### Legacy Skill Format
 
-Older configs use flat `skill_directories`, `generator_skill_directories`, or `reviewer_skill_directories` fields. These are automatically normalized to the unified `skills` list at load time:
-
-```yaml
-# Legacy format (still supported)
-configs:
-  - name: old-style
-    model: claude-opus-4.6
-    skill_directories:              # → generator.skills (type: local)
-      - ../skills/generator
-    reviewer_skill_directories:     # → reviewer.skills (type: local)
-      - ../skills/reviewer
-```
-
-The precedence for legacy migration is:
-
-1. `generator_skill_directories` → `generator.skills`
-2. If absent, `skill_directories` → `generator.skills`
-3. `reviewer_skill_directories` → `reviewer.skills`
-
-New configs should use the structured `generator.skills` / `reviewer.skills` format.
+Legacy fields (`skill_directories`, `generator_skill_directories`, `reviewer_skill_directories`) are no longer supported. Migrate them to `generator.tools` / `reviewer.tools` entries with `type: skill`.
 
 ### MCP Servers
 
 ```yaml
-mcp_servers:
-  azure:
-    type: local
-    command: npx
-    args: ["-y", "@azure/mcp@latest", "server", "start"]
-    tools: ["*"]
+generator:
+  tools:
+    - name: azure
+      type: mcp
+      command: npx
+      args: ["-y", "@azure/mcp@latest", "server", "start"]
+      mcp_tools: ["*"]
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `type` | yes | `"local"` (stdio) or `"sse"` / `"http"` (remote) |
+| `name` | yes | MCP server identifier |
+| `type` | yes | Must be `"mcp"` |
 | `command` | yes | Command to launch the MCP server |
 | `args` | no | Arguments passed to the command |
-| `tools` | no | Tool filter — `["*"]` for all tools, or a list of specific tool names |
+| `mcp_tools` | no | Tool filter — `["*"]` for all tools, or a list of specific tool names |
 
-> **Important:** The `tools` field must be set (typically `["*"]`) for the MCP server's tools to be registered with the agent. Without it, the server starts but its tools won't be available.
-
-## Legacy Format
-
-hyoka also supports a flat legacy format for backward compatibility:
-
-```yaml
-configs:
-  - name: simple-config
-    model: claude-opus-4.6
-    reviewer_model: claude-sonnet-4.5
-    skill_directories:
-      - ../skills/generator
-```
-
-Legacy fields (`model`, `reviewer_model`, `reviewer_models`, `skill_directories`, `generator_skill_directories`, `reviewer_skill_directories`, `mcp_servers`, `available_tools`, `excluded_tools`) are automatically normalized to the structured `generator`/`reviewer` format at load time. See the [Skills > Legacy Skill Format](#legacy-skill-format) section for details on how skill directories are migrated.
+> **Important:** The `mcp_tools` field must be set (typically `["*"]`) for the MCP server's tools to be registered with the agent. Without it, the server starts but its tools won't be available.
 
 ## Limits
 

--- a/docs/eval-tool-plan.md
+++ b/docs/eval-tool-plan.md
@@ -216,46 +216,43 @@ Define configurations in a YAML file (`configs/default.yaml`):
 configs:
   - name: baseline
     description: "No MCP servers, no skills — just base Copilot"
-    model: "claude-sonnet-4.5"
-    mcp_servers: {}
-    skill_directories: []
-    available_tools: []    # empty = all built-in tools
-    excluded_tools: []
+    generator:
+      model: "claude-sonnet-4.5"
+      excluded_tools: []
 
   - name: azure-mcp
     description: "Azure MCP server attached"
-    model: "claude-sonnet-4.5"
-    mcp_servers:
-      azure:
-        type: local
-        command: npx
-        args: ["-y", "@azure/mcp@latest"]
-        tools: ["*"]
-    skill_directories: []
-    available_tools: []
-    excluded_tools: []
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        - name: azure
+          type: mcp
+          command: npx
+          args: ["-y", "@azure/mcp@latest"]
+          mcp_tools: ["*"]
+      excluded_tools: []
 
   - name: azure-mcp-plus-skills
     description: "Azure MCP + Azure SDK best-practices skills"
-    model: "claude-sonnet-4.5"
-    mcp_servers:
-      azure:
-        type: local
-        command: npx
-        args: ["-y", "@azure/mcp@latest"]
-        tools: ["*"]
-    skill_directories:
-      - ./skills/azure-sdk
-    available_tools: []
-    excluded_tools: []
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        - name: azure
+          type: mcp
+          command: npx
+          args: ["-y", "@azure/mcp@latest"]
+          mcp_tools: ["*"]
+        - name: azure-sdk-skill
+          type: skill
+          source: local
+          path: ./skills/azure-sdk
+      excluded_tools: []
 
   - name: no-web-search
     description: "All tools except web search"
-    model: "claude-sonnet-4.5"
-    mcp_servers: {}
-    skill_directories: []
-    available_tools: []
-    excluded_tools: ["web_search"]
+    generator:
+      model: "claude-sonnet-4.5"
+      excluded_tools: ["web_search"]
 ```
 
 ### 3.2 Mapping to SDK SessionConfig
@@ -264,11 +261,11 @@ Each config maps directly to `copilot.SessionConfig` fields:
 
 | Config YAML field | SessionConfig field | Type |
 |---|---|---|
-| `model` | `Model` | `string` |
-| `mcp_servers` | `MCPServers` | `map[string]MCPServerConfig` |
-| `skill_directories` | `SkillDirectories` | `[]string` |
-| `available_tools` | `AvailableTools` | `[]string` |
-| `excluded_tools` | `ExcludedTools` | `[]string` |
+| `generator.model` | `Model` | `string` |
+| `generator.tools` (`type: tool`) | `AvailableTools` | `[]string` |
+| `generator.tools` (`type: mcp`) | `MCPServers` | `map[string]MCPServerConfig` |
+| `generator.tools` (`type: skill`) | `SkillDirectories` | `[]string` |
+| `generator.excluded_tools` | `ExcludedTools` | `[]string` |
 
 ### 3.3 Cross-Product Execution
 

--- a/docs/tool-filter-schema.md
+++ b/docs/tool-filter-schema.md
@@ -4,15 +4,13 @@
 
 ## Problem
 
-Today, `generator.available_tools` and `generator.excluded_tools` are flat string
-lists that apply uniformly to every prompt evaluated under a config.  To support
-**pairwise testing** (for example, "give Python prompts the Azure MCP tools but
-don't give Go prompts `pip-tools`"), we need tool availability that adapts based
-on the prompt being evaluated.
+Tool availability used to be a flat allowlist (`generator.available_tools`). To support
+**pairwise testing** and language-specific tooling, the tool list now lives inside
+`generator.tools` entries that can be conditionally enabled per prompt.
 
 ## Schema
 
-### New `tools` field on `generator`
+### `tools` entries on `generator`
 
 ```yaml
 generator:
@@ -20,39 +18,35 @@ generator:
   tools:
     # No condition → always available
     - name: "bash"
+      type: tool
 
     # Include only when the prompt's language is python
     - name: "azure-mcp"
+      type: tool
       when:
         language: python
-
-    # Exclude when the prompt's language is go
-    - name: "pip-tools"
-      exclude_when:
-        language: go
 
     # Multiple conditions are ANDed
     - name: "cosmosdb-mcp"
+      type: tool
       when:
         language: python
         service: cosmos-db
-
-  # Legacy flat lists still work (backward compatible)
-  available_tools: ["bash", "azure-mcp"]
-  excluded_tools: ["dangerous-tool"]
 ```
 
-### `ToolEntry` definition
+Only entries with `type: tool` (or empty type) participate in tool filtering. `type: mcp`
+entries configure MCP servers, and `type: skill` entries configure skills.
 
-| Field          | Type                | Required | Description                                                       |
-|----------------|---------------------|----------|-------------------------------------------------------------------|
-| `name`         | `string`            | yes      | Tool name (must match SDK tool identifiers)                       |
-| `when`         | `map[string]string` | no       | Include this tool only when **all** key-value pairs match         |
-| `exclude_when` | `map[string]string` | no       | Exclude this tool when **all** key-value pairs match              |
+### `ToolEntry` (tool filtering fields)
 
-A `ToolEntry` with **neither** `when` nor `exclude_when` is unconditional (always included).
+| Field     | Type                | Required | Description |
+|-----------|---------------------|----------|-------------|
+| `name`    | `string`            | yes      | Tool name (must match SDK tool identifiers) |
+| `type`    | `string`            | no       | Defaults to `tool`; only `tool` entries are filtered |
+| `when`    | `map[string]string` | no       | Include this tool only when **all** key-value pairs match |
+| `always_on` | `bool`            | no       | Never toggled during pairwise tool ablation |
 
-Setting **both** `when` and `exclude_when` on the same entry is a validation error.
+A `ToolEntry` with no `when` clause is unconditional (always included).
 
 ### Matchable prompt properties
 
@@ -64,119 +58,32 @@ These are the `Prompt` struct fields available for matching:
 | `service`    | `identity`, `key-vault`, `storage` | `Service`        |
 | `plane`      | `data-plane`, `management-plane`   | `Plane`          |
 | `category`   | `auth`, `crud`, `pagination`       | `Category`       |
-| `difficulty`  | `easy`, `medium`, `hard`           | `Difficulty`     |
+| `difficulty` | `easy`, `medium`, `hard`           | `Difficulty`     |
 
-All comparisons are case-sensitive, exact string equality.
-
-Multiple conditions within a single `when` or `exclude_when` are **ANDed**:
-every key-value pair must match for the condition to apply.
+All comparisons are case-sensitive, exact string equality. Multiple conditions within a
+single `when` clause are **ANDed**: every key-value pair must match for the condition
+to apply.
 
 ## Resolution logic
 
-`ResolveTools` accepts a `GeneratorConfig` and a set of prompt properties and
-returns the final `(availableTools []string, excludedTools []string)` pair that
-is passed to the Copilot session.
+`ResolveTools` accepts the tool entries and prompt properties and returns the final
+`availableTools []string` slice passed to the Copilot session.
 
 ```
-1. Start with the legacy flat lists:
-     available = generator.available_tools   (may be nil → "all defaults")
-     excluded  = generator.excluded_tools    (may be nil → "exclude nothing")
-
-2. If generator.tools is present, iterate each entry:
-     a. Entries with neither when nor exclude_when
-        → append name to available
-     b. Entries with when:
-        → if ALL conditions match the prompt → append name to available
-     c. Entries with exclude_when:
-        → if ALL conditions match the prompt → append name to excluded
-
-3. Deduplicate both lists.
-
-4. If a tool appears in BOTH available and excluded, excluded wins
-   (defense-in-depth: explicit exclusion is always respected).
-
-5. Return (available, excluded). Nil semantics preserved:
-     - nil available  = "all default tools"
-     - empty available = "zero tools"
+1. Filter entries to type "tool" (or empty type).
+2. Include tools with no `when` clause.
+3. Include tools whose `when` map matches the prompt properties.
+4. Deduplicate tool names, preserving first-seen order.
 ```
 
-### Precedence summary
-
-| Scenario                                     | Result           |
-|----------------------------------------------|------------------|
-| Tool in legacy `available_tools` only        | Available        |
-| Tool in legacy `excluded_tools` only         | Excluded         |
-| Tool in `tools:` with matching `when:`       | Available        |
-| Tool in `tools:` with matching `exclude_when:` | Excluded      |
-| Tool in both available and excluded           | **Excluded**     |
-| `tools:` not set, legacy lists not set        | All defaults     |
-
-## Backward compatibility
-
-The existing flat `available_tools` and `excluded_tools` fields remain fully
-supported.  Configs that don't use the new `tools:` field behave identically to
-today.
-
-When both `tools:` and the legacy lists coexist, results are merged (see
-resolution logic above).  This allows incremental migration: teams can start
-adding conditional entries alongside their existing flat lists.
-
-## Interaction with `always_on: true` (Phase 2)
-
-In Phase 2, pairwise testing will introduce an `always_on: true` flag on
-`ToolEntry`.  Tools marked `always_on` bypass `when`/`exclude_when` evaluation
-and are always included — useful for baseline tools (like `bash`, `view`,
-`edit`) that every prompt needs regardless of properties.
-
-```yaml
-tools:
-  - name: "bash"
-    always_on: true    # Phase 2: never filtered out
-  - name: "azure-mcp"
-    when:
-      language: python
-```
-
-The `ResolveTools` function already handles unconditional entries (no
-`when`/`exclude_when`), so `always_on` is a semantic alias that also prevents
-the tool from being added to the excluded list during pairwise matrix
-generation.
-
-## Validation rules
+### Validation rules
 
 1. Every `ToolEntry` must have a non-empty `name`.
-2. `when` and `exclude_when` must not both be set on the same entry.
-3. Map keys in `when`/`exclude_when` must be recognized prompt property names
-   (`language`, `service`, `plane`, `category`, `difficulty`).
-4. Map values must be non-empty strings.
-
-Validation errors are returned from `config.Validate()` during config loading,
-consistent with existing validation patterns.
+2. `type` must be `tool`, `mcp`, or `skill` (empty defaults to `tool`).
+3. MCP entries must specify `command`.
+4. Skill entries must specify `path` (local) or `repo` (remote).
 
 ## Go types
 
 See [`hyoka/internal/config/tool_filter.go`](../hyoka/internal/config/tool_filter.go)
 for the implementation.
-
-```go
-// ToolEntry represents a tool with optional property-based conditions.
-type ToolEntry struct {
-    Name        string            `yaml:"name"                    json:"name"`
-    When        map[string]string `yaml:"when,omitempty"          json:"when,omitempty"`
-    ExcludeWhen map[string]string `yaml:"exclude_when,omitempty"  json:"exclude_when,omitempty"`
-}
-
-// PromptProperties holds the subset of prompt metadata used for tool filtering.
-type PromptProperties struct {
-    Language   string
-    Service    string
-    Plane      string
-    Category   string
-    Difficulty string
-}
-
-// ResolveTools evaluates conditional tool entries against prompt properties and
-// merges the result with legacy flat lists. Returns the final available and
-// excluded tool slices.
-func ResolveTools(gen *GeneratorConfig, props PromptProperties) (available, excluded []string)
-```

--- a/hyoka/README.md
+++ b/hyoka/README.md
@@ -264,7 +264,7 @@ Each prompt author lists what the generated code should include. These are evalu
 
 ### Review Panel
 
-Each config file defines a `reviewer_models` list (e.g., `[claude-opus-4.6, gemini-3-pro-preview, gpt-4.1]`). All reviewers run in parallel, then:
+Each config file defines a `reviewer.models` list (e.g., `[claude-opus-4.6, gemini-3-pro-preview, gpt-4.1]`). All reviewers run in parallel, then:
 
 1. The **first model** in the list acts as the **consolidator**, synthesizing all reviews into a consensus result
 2. For each criterion, it passes if the **majority** of reviewers marked it passed
@@ -327,7 +327,7 @@ Markdown reports contain the same information as HTML reports (criteria pass/fai
 
 ## Configuration Matrix
 
-Configurations live in the `configs/` directory at the repo root. Each file defines **one generator model** and a shared `reviewer_models` list. All configs are auto-discovered via `LoadDir()`:
+Configurations live in the `configs/` directory at the repo root. Each file defines **one generator model** and a shared `reviewer.models` list. All configs are auto-discovered via `LoadDir()`:
 
 | File | Generator Model | Description |
 |------|----------------|-------------|
@@ -339,7 +339,7 @@ Configurations live in the `configs/` directory at the repo root. Each file defi
 | `configs/azure-mcp-opus.yaml` | Claude Opus 4.6 | Azure MCP server attached |
 | `configs/azure-mcp-codex.yaml` | GPT Codex | Azure MCP server attached |
 
-All configs use the same review panel: `reviewer_models: [claude-opus-4.6, gemini-3-pro-preview, gpt-4.1]` (claude-opus-4.6 is the consolidator).
+All configs use the same review panel: `reviewer.models: [claude-opus-4.6, gemini-3-pro-preview, gpt-4.1]` (claude-opus-4.6 is the consolidator).
 
 **Sample config file:**
 
@@ -347,15 +347,18 @@ All configs use the same review panel: `reviewer_models: [claude-opus-4.6, gemin
 configs:
   - name: baseline/claude-sonnet-4.5
     description: "Baseline — raw Copilot with Claude Sonnet 4.5"
-    model: "claude-sonnet-4.5"
-    reviewer_models:
-      - "claude-opus-4.6"
-      - "gemini-3-pro-preview"
-      - "gpt-4.1"
-    mcp_servers: {}
-    skill_directories: []
-    available_tools: []
-    excluded_tools: []
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        - name: azure
+          type: mcp
+          command: npx
+          args: ["-y", "@azure/mcp@latest"]
+    reviewer:
+      models:
+        - "claude-opus-4.6"
+        - "gemini-3-pro-preview"
+        - "gpt-4.1"
 ```
 
 ### Config Fields
@@ -364,23 +367,19 @@ configs:
 |-------|------|-------------|-------------|
 | `name` | string | — | Unique config identifier |
 | `description` | string | — | Human-readable description |
-| `model` | string | `SessionConfig.Model` | Generator AI model |
-| `reviewer_models` | list | — | Review panel models (first is consolidator) |
-| `mcp_servers` | map | `SessionConfig.MCPServers` | MCP server definitions |
-| `generator_skill_directories` | list | `SessionConfig.SkillDirectories` | Skill directories for the generator agent (takes priority over `skill_directories`) |
-| `reviewer_skill_directories` | list | `SessionConfig.SkillDirectories` | Skill directories for the review panel agents |
-| `skill_directories` | list | `SessionConfig.SkillDirectories` | Shared fallback skill directories (used when role-specific fields are not set) |
-| `available_tools` | list | `SessionConfig.AvailableTools` | Allowed tool names |
-| `excluded_tools` | list | `SessionConfig.ExcludedTools` | Blocked tool names |
+| `generator.model` | string | `SessionConfig.Model` | Generator AI model |
+| `generator.tools` | list | `SessionConfig.AvailableTools` / `SessionConfig.MCPServers` / `SessionConfig.SkillDirectories` | Tool entries (type: tool, mcp, skill) |
+| `generator.excluded_tools` | list | `SessionConfig.ExcludedTools` | Blocked tool names |
+| `reviewer.models` | list | — | Review panel models (first is consolidator) |
+| `reviewer.tools` | list | `SessionConfig.SkillDirectories` | Reviewer skill entries (type: skill) |
 
-#### Skill Directory Resolution
+#### Tools entries
 
-The tool resolves skill directories per role:
+Tool entries live in `generator.tools` or `reviewer.tools` and require a `type`:
 
-- **Generator:** Uses `generator_skill_directories` if set, otherwise falls back to `skill_directories`
-- **Reviewers:** Uses `reviewer_skill_directories` if set, otherwise falls back to `skill_directories`
-
-This allows configs to load different skills for generation vs. review. For example, the generator might get SDK-specific coding skills while reviewers get build-verification and version-checking skills.
+- `tool` (default): named tool exposed to the agent, optionally conditional via `when`.
+- `mcp`: MCP server definition (`command`, `args`, optional `mcp_tools`).
+- `skill`: skill entry (`source: local|remote`, `path` or `repo`).
 
 **Adding skills:** Use `npx skills add microsoft/skills --directory skills/generator` to install skills from the [microsoft/skills](https://github.com/microsoft/skills) registry. See the main [README.md](../README.md#adding-skills-to-configs) for details.
 
@@ -390,15 +389,23 @@ This allows configs to load different skills for generation vs. review. For exam
 configs:
   - name: full-skills/claude-opus-4.6
     description: "Generator and reviewer skills"
-    model: "claude-opus-4.6"
-    reviewer_models:
-      - "claude-opus-4.6"
-      - "gemini-3-pro-preview"
-      - "gpt-4.1"
-    generator_skill_directories:
-      - "./skills/generator"
-    reviewer_skill_directories:
-      - "./skills/reviewer"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        - name: generator-skills
+          type: skill
+          source: local
+          path: "./skills/generator"
+    reviewer:
+      models:
+        - "claude-opus-4.6"
+        - "gemini-3-pro-preview"
+        - "gpt-4.1"
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
+          path: "./skills/reviewer"
 ```
 
 ## Smart Path Detection

--- a/hyoka/cmd/configs.go
+++ b/hyoka/cmd/configs.go
@@ -1,63 +1,63 @@
 package cmd
 
 import (
-"fmt"
-"strings"
+	"fmt"
+	"strings"
 
-"github.com/ronniegeraghty/hyoka/internal/config"
-"github.com/spf13/cobra"
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/spf13/cobra"
 )
 
 func configsCmd() *cobra.Command {
-var configFile string
-var configDir string
+	var configFile string
+	var configDir string
 
-cmd := &cobra.Command{
-Use:   "configs",
-Short: "List available configurations",
-RunE: func(cmd *cobra.Command, args []string) error {
-var cfgFile *config.ConfigFile
-if cmd.Flags().Changed("config-file") {
-configFile = resolveConfigFile(cmd)
-var err error
-cfgFile, err = config.Load(configFile)
-if err != nil {
-return fmt.Errorf("loading config: %w", err)
-}
-} else {
-configDir = resolveConfigDir(cmd)
-var err error
-cfgFile, err = config.LoadDir(configDir)
-if err != nil {
-return fmt.Errorf("loading configs from %s: %w", configDir, err)
-}
-}
+	cmd := &cobra.Command{
+		Use:   "configs",
+		Short: "List available configurations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var cfgFile *config.ConfigFile
+			if cmd.Flags().Changed("config-file") {
+				configFile = resolveConfigFile(cmd)
+				var err error
+				cfgFile, err = config.Load(configFile)
+				if err != nil {
+					return fmt.Errorf("loading config: %w", err)
+				}
+			} else {
+				configDir = resolveConfigDir(cmd)
+				var err error
+				cfgFile, err = config.LoadDir(configDir)
+				if err != nil {
+					return fmt.Errorf("loading configs from %s: %w", configDir, err)
+				}
+			}
 
-fmt.Printf("Available configurations (%d):\n\n", len(cfgFile.Configs))
-for _, c := range cfgFile.Configs {
-model := ""
-if c.Generator != nil {
-model = c.Generator.Model
-}
-fmt.Printf("  %-20s %s (model: %s)\n", c.Name, c.Description, model)
-var mcpServers map[string]*config.MCPServer
-if c.Generator != nil {
-mcpServers = c.Generator.MCPServers
-}
-if len(mcpServers) > 0 {
-fmt.Printf("  %-20s MCP servers: ", "")
-var names []string
-for name := range mcpServers {
-names = append(names, name)
-}
-fmt.Println(strings.Join(names, ", "))
-}
-}
-return nil
-},
-}
+			fmt.Printf("Available configurations (%d):\n\n", len(cfgFile.Configs))
+			for _, c := range cfgFile.Configs {
+				model := ""
+				if c.Generator != nil {
+					model = c.Generator.Model
+				}
+				fmt.Printf("  %-20s %s (model: %s)\n", c.Name, c.Description, model)
+				var mcpNames []string
+				if c.Generator != nil {
+					for _, entry := range c.Generator.Tools {
+						if entry.ResolvedType() == "mcp" {
+							mcpNames = append(mcpNames, entry.Name)
+						}
+					}
+				}
+				if len(mcpNames) > 0 {
+					fmt.Printf("  %-20s MCP servers: ", "")
+					fmt.Println(strings.Join(mcpNames, ", "))
+				}
+			}
+			return nil
+		},
+	}
 
-cmd.Flags().StringVar(&configFile, "config-file", "", "Path to a specific configuration YAML file")
-cmd.Flags().StringVar(&configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
-return cmd
+	cmd.Flags().StringVar(&configFile, "config-file", "", "Path to a specific configuration YAML file")
+	cmd.Flags().StringVar(&configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
+	return cmd
 }

--- a/hyoka/cmd/helpers.go
+++ b/hyoka/cmd/helpers.go
@@ -1,176 +1,179 @@
 package cmd
 
 import (
-"fmt"
-"log/slog"
-"os"
-"os/exec"
-"path/filepath"
-"runtime"
-"strconv"
-"strings"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 
-"github.com/ronniegeraghty/hyoka/internal/config"
-"github.com/spf13/cobra"
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/spf13/cobra"
 )
 
 // cachedProjectDir holds the lazily discovered .hyoka project directory.
 var cachedProjectDir *config.ProjectDir
 
 func discoverProject() *config.ProjectDir {
-if cachedProjectDir == nil {
-cachedProjectDir = config.DiscoverFromCWD()
-if cachedProjectDir.Found() {
-slog.Info("Using .hyoka project directory", "path", cachedProjectDir.Root)
-}
-}
-return cachedProjectDir
+	if cachedProjectDir == nil {
+		cachedProjectDir = config.DiscoverFromCWD()
+		if cachedProjectDir.Found() {
+			slog.Info("Using .hyoka project directory", "path", cachedProjectDir.Root)
+		}
+	}
+	return cachedProjectDir
 }
 
 // resolvePathFlag returns the flag value if explicitly set by the user,
 // otherwise tries the candidate paths in order, falling back to the default.
 func resolvePathFlag(cmd *cobra.Command, flagName string, candidates []string) string {
-if cmd.Flags().Changed(flagName) {
-val, _ := cmd.Flags().GetString(flagName)
-return val
-}
-for _, c := range candidates {
-if _, err := os.Stat(c); err == nil {
-return c
-}
-}
-val, _ := cmd.Flags().GetString(flagName)
-return val
+	if cmd.Flags().Changed(flagName) {
+		val, _ := cmd.Flags().GetString(flagName)
+		return val
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	val, _ := cmd.Flags().GetString(flagName)
+	return val
 }
 
 func resolvePromptsDir(cmd *cobra.Command) string {
-proj := discoverProject()
-candidates := config.ResolveCandidates(proj, "prompts", "./prompts", "../prompts")
-return resolvePathFlag(cmd, "prompts", candidates)
+	proj := discoverProject()
+	candidates := config.ResolveCandidates(proj, "prompts", "./prompts", "../prompts")
+	return resolvePathFlag(cmd, "prompts", candidates)
 }
 
 func resolveConfigFile(cmd *cobra.Command) string {
-proj := discoverProject()
-candidates := config.ResolveCandidates(proj, "configs", "./configs", "../configs")
-return resolvePathFlag(cmd, "config-file", candidates)
+	proj := discoverProject()
+	candidates := config.ResolveCandidates(proj, "configs", "./configs", "../configs")
+	return resolvePathFlag(cmd, "config-file", candidates)
 }
 
 func resolveConfigDir(cmd *cobra.Command) string {
-proj := discoverProject()
-candidates := config.ResolveCandidates(proj, "configs", "./configs", "../configs")
-return resolvePathFlag(cmd, "config-dir", candidates)
+	proj := discoverProject()
+	candidates := config.ResolveCandidates(proj, "configs", "./configs", "../configs")
+	return resolvePathFlag(cmd, "config-dir", candidates)
 }
 
 func resolveOutputDir(cmd *cobra.Command) string {
-proj := discoverProject()
-candidates := config.ResolveCandidates(proj, "reports", "./reports", "../reports")
-return resolvePathFlag(cmd, "output", candidates)
+	proj := discoverProject()
+	candidates := config.ResolveCandidates(proj, "reports", "./reports", "../reports")
+	return resolvePathFlag(cmd, "output", candidates)
 }
 
 func resolveOutputFile(cmd *cobra.Command, candidates []string) string {
-return resolvePathFlag(cmd, "output", candidates)
+	return resolvePathFlag(cmd, "output", candidates)
 }
 
 func resolveCriteriaDir(cmd *cobra.Command) string {
-proj := discoverProject()
-candidates := config.ResolveCandidates(proj, "criteria", "./criteria", "../criteria")
-return resolvePathFlag(cmd, "criteria-dir", candidates)
+	proj := discoverProject()
+	candidates := config.ResolveCandidates(proj, "criteria", "./criteria", "../criteria")
+	return resolvePathFlag(cmd, "criteria-dir", candidates)
 }
 
-// resolveConfigSkillDirs resolves relative skill_directories in loaded configs
+// resolveConfigSkillDirs resolves relative local skill paths in loaded configs
 // to absolute paths so they work regardless of which directory the tool is invoked from.
-// Handles both legacy top-level fields and new Generator/Reviewer sub-struct skills.
 func resolveConfigSkillDirs(configs []config.ToolConfig, promptsDir string) {
 
-resolveSkills := func(skills []config.Skill) {
-for j := range skills {
-if skills[j].Type == "local" && skills[j].Path != "" && !filepath.IsAbs(skills[j].Path) {
-candidates := []string{
-skills[j].Path,
-filepath.Join(filepath.Dir(promptsDir), skills[j].Path),
-}
-for _, c := range candidates {
-if info, err := os.Stat(c); err == nil && info.IsDir() {
-abs, absErr := filepath.Abs(c)
-if absErr != nil {
-slog.Warn("Failed to resolve absolute skill path", "path", c, "error", absErr)
-}
-skills[j].Path = abs
-break
-}
-}
-}
-}
-}
+	resolveSkills := func(entries []config.ToolEntry) {
+		for j := range entries {
+			if entries[j].ResolvedType() != "skill" || entries[j].SkillSource() != "local" || entries[j].Path == "" {
+				continue
+			}
+			if filepath.IsAbs(entries[j].Path) {
+				continue
+			}
+			candidates := []string{
+				entries[j].Path,
+				filepath.Join(filepath.Dir(promptsDir), entries[j].Path),
+			}
+			for _, c := range candidates {
+				if info, err := os.Stat(c); err == nil && info.IsDir() {
+					abs, absErr := filepath.Abs(c)
+					if absErr != nil {
+						slog.Warn("Failed to resolve absolute skill path", "path", c, "error", absErr)
+					}
+					entries[j].Path = abs
+					break
+				}
+			}
+		}
+	}
 
-for i := range configs {
-if configs[i].Generator != nil {
-resolveSkills(configs[i].Generator.Skills)
-}
-if configs[i].Reviewer != nil {
-resolveSkills(configs[i].Reviewer.Skills)
-}
-}
+	for i := range configs {
+		if configs[i].Generator != nil {
+			resolveSkills(configs[i].Generator.Tools)
+		}
+		if configs[i].Reviewer != nil {
+			resolveSkills(configs[i].Reviewer.Tools)
+		}
+	}
 }
 
 func humanSize(b int64) string {
-const (
-kb = 1024
-mb = kb * 1024
-gb = mb * 1024
-)
-switch {
-case b >= gb:
-return fmt.Sprintf("%.1fGB", float64(b)/float64(gb))
-case b >= mb:
-return fmt.Sprintf("%.1fMB", float64(b)/float64(mb))
-case b >= kb:
-return fmt.Sprintf("%.1fKB", float64(b)/float64(kb))
-default:
-return fmt.Sprintf("%dB", b)
-}
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1fGB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1fMB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1fKB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
 }
 
 // openInBrowser opens the given file path in the default browser.
 func openInBrowser(path string) {
-var cmd *exec.Cmd
-switch runtime.GOOS {
-case "darwin":
-cmd = exec.Command("open", path)
-case "linux":
-cmd = exec.Command("xdg-open", path)
-case "windows":
-cmd = exec.Command("cmd", "/c", "start", path)
-default:
-fmt.Printf("Open the report manually: %s\n", path)
-return
-}
-if err := cmd.Start(); err != nil {
-fmt.Printf("Could not open browser: %v\nOpen manually: %s\n", err, path)
-}
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "linux":
+		cmd = exec.Command("xdg-open", path)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", path)
+	default:
+		fmt.Printf("Open the report manually: %s\n", path)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		fmt.Printf("Could not open browser: %v\nOpen manually: %s\n", err, path)
+	}
 }
 
 // parseByteSize parses a human-readable byte size string (e.g., "1MB", "512KB", "1048576").
 func parseByteSize(s string) (int64, error) {
-s = strings.TrimSpace(strings.ToUpper(s))
-multipliers := map[string]int64{
-"KB": 1024,
-"MB": 1024 * 1024,
-"GB": 1024 * 1024 * 1024,
-}
-for suffix, mult := range multipliers {
-if strings.HasSuffix(s, suffix) {
-numStr := strings.TrimSuffix(s, suffix)
-num, err := strconv.ParseFloat(strings.TrimSpace(numStr), 64)
-if err != nil {
-return 0, fmt.Errorf("invalid number %q", numStr)
-}
-return int64(num * float64(mult)), nil
-}
-}
-num, err := strconv.ParseInt(s, 10, 64)
-if err != nil {
-return 0, fmt.Errorf("invalid size %q \u2014 use a number with optional KB/MB/GB suffix", s)
-}
-return num, nil
+	s = strings.TrimSpace(strings.ToUpper(s))
+	multipliers := map[string]int64{
+		"KB": 1024,
+		"MB": 1024 * 1024,
+		"GB": 1024 * 1024 * 1024,
+	}
+	for suffix, mult := range multipliers {
+		if strings.HasSuffix(s, suffix) {
+			numStr := strings.TrimSuffix(s, suffix)
+			num, err := strconv.ParseFloat(strings.TrimSpace(numStr), 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid number %q", numStr)
+			}
+			return int64(num * float64(mult)), nil
+		}
+	}
+	num, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q \u2014 use a number with optional KB/MB/GB suffix", s)
+	}
+	return num, nil
 }

--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -1,456 +1,456 @@
 package cmd
 
 import (
-"context"
-"fmt"
-"log/slog"
-"path/filepath"
-"strings"
-"time"
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
 
-copilot "github.com/github/copilot-sdk/go"
-"github.com/ronniegeraghty/hyoka/internal/config"
-"github.com/ronniegeraghty/hyoka/internal/eval"
-"github.com/ronniegeraghty/hyoka/internal/pairwise"
-"github.com/ronniegeraghty/hyoka/internal/prompt"
-"github.com/ronniegeraghty/hyoka/internal/report"
-"github.com/ronniegeraghty/hyoka/internal/review"
-"github.com/ronniegeraghty/hyoka/internal/trends"
-"github.com/spf13/cobra"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/eval"
+	"github.com/ronniegeraghty/hyoka/internal/pairwise"
+	"github.com/ronniegeraghty/hyoka/internal/prompt"
+	"github.com/ronniegeraghty/hyoka/internal/report"
+	"github.com/ronniegeraghty/hyoka/internal/review"
+	"github.com/ronniegeraghty/hyoka/internal/trends"
+	"github.com/spf13/cobra"
 )
 
 type runFlags struct {
-prompts      string
-service      string
-language     string
-plane        string
-category     string
-tags         string
-promptID     string
-configName   string
-configFile   string
-configDir    string
-workers         int
-maxSessions     int
-model           string
-output       string
-progressMode string
-skipTests    bool
-skipReview   bool
-skipTrends   bool
-dryRun       bool
-useStub      bool
-// Fan-out visibility (#34)
-autoConfirm bool
-allConfigs  bool
-// Generator guardrails (#35)
-maxSessionActions int
-maxFiles          int
-maxOutputSize string
-// Generator safety (#36)
-allowCloud bool
-// Resource monitoring (#45)
-monitorResources bool
-// Process lifecycle (#46)
-strictCleanup bool
-// Tiered criteria (#30)
-criteriaDir string
-// Directory exclusion (#63)
-excludeDirs string
-// Session timeout
-sessionTimeout string
-// Pairwise tool-ablation (#121)
-pairwiseMode bool
+	prompts      string
+	service      string
+	language     string
+	plane        string
+	category     string
+	tags         string
+	promptID     string
+	configName   string
+	configFile   string
+	configDir    string
+	workers      int
+	maxSessions  int
+	model        string
+	output       string
+	progressMode string
+	skipTests    bool
+	skipReview   bool
+	skipTrends   bool
+	dryRun       bool
+	useStub      bool
+	// Fan-out visibility (#34)
+	autoConfirm bool
+	allConfigs  bool
+	// Generator guardrails (#35)
+	maxSessionActions int
+	maxFiles          int
+	maxOutputSize     string
+	// Generator safety (#36)
+	allowCloud bool
+	// Resource monitoring (#45)
+	monitorResources bool
+	// Process lifecycle (#46)
+	strictCleanup bool
+	// Tiered criteria (#30)
+	criteriaDir string
+	// Directory exclusion (#63)
+	excludeDirs string
+	// Session timeout
+	sessionTimeout string
+	// Pairwise tool-ablation (#121)
+	pairwiseMode bool
 }
 
 func addFilterFlags(cmd *cobra.Command, f *runFlags) {
-cmd.Flags().StringVar(&f.prompts, "prompts", "./prompts", "Path to prompt library directory")
-cmd.Flags().StringVar(&f.service, "service", "", "Filter by Azure service")
-cmd.Flags().StringVar(&f.language, "language", "", "Filter by programming language")
-cmd.Flags().StringVar(&f.plane, "plane", "", "Filter by data-plane/management-plane")
-cmd.Flags().StringVar(&f.category, "category", "", "Filter by use-case category")
-cmd.Flags().StringVar(&f.tags, "tags", "", "Filter by tags (comma-separated)")
-cmd.Flags().StringVar(&f.promptID, "prompt-id", "", "Run a single prompt by ID")
-cmd.Flags().StringVar(&f.configName, "config", "", "Config name(s) from config file (comma-separated)")
-cmd.Flags().StringVar(&f.configFile, "config-file", "", "Path to a specific configuration YAML file (default: load all from configs/)")
-cmd.Flags().StringVar(&f.configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
-cmd.Flags().IntVar(&f.workers, "workers", 0, "Parallel evaluation workers (default: number of CPUs, max 8)")
-cmd.Flags().IntVar(&f.maxSessions, "max-sessions", 0, "Maximum concurrent Copilot sessions (default: workers \u00d7 3)")
-cmd.Flags().StringVar(&f.model, "model", "", "Override model for all configs")
-cmd.Flags().StringVar(&f.output, "output", "./reports", "Report output directory")
-cmd.Flags().BoolVar(&f.skipTests, "skip-tests", false, "Skip test generation")
-cmd.Flags().BoolVar(&f.skipReview, "skip-review", false, "Skip code review")
-cmd.Flags().StringVar(&f.progressMode, "progress", "auto", "Progress display mode: auto, live, log, off")
-cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "List matching prompts without running")
-cmd.Flags().BoolVar(&f.useStub, "stub", false, "Use stub evaluator (no Copilot SDK)")
-cmd.Flags().BoolVar(&f.skipTrends, "skip-trends", false, "Skip automatic trend analysis after run")
-// Fan-out visibility (#34)
-cmd.Flags().BoolVarP(&f.autoConfirm, "yes", "y", false, "Skip confirmation prompt for large runs (>10 evaluations)")
-cmd.Flags().BoolVar(&f.allConfigs, "all-configs", false, "Run all configs when no --config filter is specified (required for multi-config runs)")
-// Generator guardrails (#35)
-cmd.Flags().IntVar(&f.maxSessionActions, "max-session-actions", 50, "Maximum actions per Copilot session (reasoning, response, or tool call each count as 1)")
-cmd.Flags().IntVar(&f.maxFiles, "max-files", 50, "Maximum generated files per evaluation before aborting")
-cmd.Flags().StringVar(&f.maxOutputSize, "max-output-size", "1MB", "Maximum total output size per evaluation (e.g., 1MB, 512KB)")
-// Generator safety (#36)
-cmd.Flags().BoolVar(&f.allowCloud, "allow-cloud", false, "Allow generated code to provision real Azure resources (disables safety boundaries)")
-cmd.Flags().Bool("sandbox", true, "Enforce safety boundaries preventing real Azure resource provisioning (default, opposite of --allow-cloud)")
-cmd.Flags().MarkHidden("sandbox") // sandbox is the default; --allow-cloud is the opt-out
-// Resource monitoring (#45)
-cmd.Flags().BoolVar(&f.monitorResources, "monitor-resources", false, "Monitor CPU and memory usage of Copilot sessions during evaluation")
-// Process lifecycle (#46)
-cmd.Flags().BoolVar(&f.strictCleanup, "strict-cleanup", false, "Fail run with non-zero exit if orphaned Copilot processes remain after cleanup")
-// Tiered criteria (#30)
-cmd.Flags().StringVar(&f.criteriaDir, "criteria-dir", "", "Directory containing attribute-matched criteria YAML files (e.g., criteria/)")
-// Directory exclusion (#63)
-cmd.Flags().StringVar(&f.excludeDirs, "exclude-dirs", "", "Comma-separated directories to exclude from generated_files output (e.g., node_modules,target,dist)")
-// Session timeout
-cmd.Flags().StringVar(&f.sessionTimeout, "session-timeout", "10m", "Maximum duration for a single generation or review session (e.g., 10m, 30m, 1h)")
-// Pairwise tool-ablation (#121)
-cmd.Flags().BoolVarP(&f.pairwiseMode, "pairwise", "P", false, "Expand each config into N+1 pairwise tool-ablation variants")
+	cmd.Flags().StringVar(&f.prompts, "prompts", "./prompts", "Path to prompt library directory")
+	cmd.Flags().StringVar(&f.service, "service", "", "Filter by Azure service")
+	cmd.Flags().StringVar(&f.language, "language", "", "Filter by programming language")
+	cmd.Flags().StringVar(&f.plane, "plane", "", "Filter by data-plane/management-plane")
+	cmd.Flags().StringVar(&f.category, "category", "", "Filter by use-case category")
+	cmd.Flags().StringVar(&f.tags, "tags", "", "Filter by tags (comma-separated)")
+	cmd.Flags().StringVar(&f.promptID, "prompt-id", "", "Run a single prompt by ID")
+	cmd.Flags().StringVar(&f.configName, "config", "", "Config name(s) from config file (comma-separated)")
+	cmd.Flags().StringVar(&f.configFile, "config-file", "", "Path to a specific configuration YAML file (default: load all from configs/)")
+	cmd.Flags().StringVar(&f.configDir, "config-dir", "./configs", "Directory containing configuration YAML files")
+	cmd.Flags().IntVar(&f.workers, "workers", 0, "Parallel evaluation workers (default: number of CPUs, max 8)")
+	cmd.Flags().IntVar(&f.maxSessions, "max-sessions", 0, "Maximum concurrent Copilot sessions (default: workers \u00d7 3)")
+	cmd.Flags().StringVar(&f.model, "model", "", "Override model for all configs")
+	cmd.Flags().StringVar(&f.output, "output", "./reports", "Report output directory")
+	cmd.Flags().BoolVar(&f.skipTests, "skip-tests", false, "Skip test generation")
+	cmd.Flags().BoolVar(&f.skipReview, "skip-review", false, "Skip code review")
+	cmd.Flags().StringVar(&f.progressMode, "progress", "auto", "Progress display mode: auto, live, log, off")
+	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "List matching prompts without running")
+	cmd.Flags().BoolVar(&f.useStub, "stub", false, "Use stub evaluator (no Copilot SDK)")
+	cmd.Flags().BoolVar(&f.skipTrends, "skip-trends", false, "Skip automatic trend analysis after run")
+	// Fan-out visibility (#34)
+	cmd.Flags().BoolVarP(&f.autoConfirm, "yes", "y", false, "Skip confirmation prompt for large runs (>10 evaluations)")
+	cmd.Flags().BoolVar(&f.allConfigs, "all-configs", false, "Run all configs when no --config filter is specified (required for multi-config runs)")
+	// Generator guardrails (#35)
+	cmd.Flags().IntVar(&f.maxSessionActions, "max-session-actions", 50, "Maximum actions per Copilot session (reasoning, response, or tool call each count as 1)")
+	cmd.Flags().IntVar(&f.maxFiles, "max-files", 50, "Maximum generated files per evaluation before aborting")
+	cmd.Flags().StringVar(&f.maxOutputSize, "max-output-size", "1MB", "Maximum total output size per evaluation (e.g., 1MB, 512KB)")
+	// Generator safety (#36)
+	cmd.Flags().BoolVar(&f.allowCloud, "allow-cloud", false, "Allow generated code to provision real Azure resources (disables safety boundaries)")
+	cmd.Flags().Bool("sandbox", true, "Enforce safety boundaries preventing real Azure resource provisioning (default, opposite of --allow-cloud)")
+	cmd.Flags().MarkHidden("sandbox") // sandbox is the default; --allow-cloud is the opt-out
+	// Resource monitoring (#45)
+	cmd.Flags().BoolVar(&f.monitorResources, "monitor-resources", false, "Monitor CPU and memory usage of Copilot sessions during evaluation")
+	// Process lifecycle (#46)
+	cmd.Flags().BoolVar(&f.strictCleanup, "strict-cleanup", false, "Fail run with non-zero exit if orphaned Copilot processes remain after cleanup")
+	// Tiered criteria (#30)
+	cmd.Flags().StringVar(&f.criteriaDir, "criteria-dir", "", "Directory containing attribute-matched criteria YAML files (e.g., criteria/)")
+	// Directory exclusion (#63)
+	cmd.Flags().StringVar(&f.excludeDirs, "exclude-dirs", "", "Comma-separated directories to exclude from generated_files output (e.g., node_modules,target,dist)")
+	// Session timeout
+	cmd.Flags().StringVar(&f.sessionTimeout, "session-timeout", "10m", "Maximum duration for a single generation or review session (e.g., 10m, 30m, 1h)")
+	// Pairwise tool-ablation (#121)
+	cmd.Flags().BoolVarP(&f.pairwiseMode, "pairwise", "P", false, "Expand each config into N+1 pairwise tool-ablation variants")
 }
 
 func buildFilter(f *runFlags) prompt.Filter {
-var tags []string
-if f.tags != "" {
-tags = strings.Split(f.tags, ",")
-for i := range tags {
-tags[i] = strings.TrimSpace(tags[i])
-}
-}
-filters := make(map[string]string)
-if f.service != "" {
-filters["service"] = f.service
-}
-if f.plane != "" {
-filters["plane"] = f.plane
-}
-if f.language != "" {
-filters["language"] = f.language
-}
-if f.category != "" {
-filters["category"] = f.category
-}
-return prompt.Filter{
-Filters:  filters,
-Tags:     tags,
-PromptID: f.promptID,
-}
+	var tags []string
+	if f.tags != "" {
+		tags = strings.Split(f.tags, ",")
+		for i := range tags {
+			tags[i] = strings.TrimSpace(tags[i])
+		}
+	}
+	filters := make(map[string]string)
+	if f.service != "" {
+		filters["service"] = f.service
+	}
+	if f.plane != "" {
+		filters["plane"] = f.plane
+	}
+	if f.language != "" {
+		filters["language"] = f.language
+	}
+	if f.category != "" {
+		filters["category"] = f.category
+	}
+	return prompt.Filter{
+		Filters:  filters,
+		Tags:     tags,
+		PromptID: f.promptID,
+	}
 }
 
 func runCmd() *cobra.Command {
-f := &runFlags{}
-cmd := &cobra.Command{
-Use:   "run",
-Short: "Run evaluations",
-Long:  "Run evaluations with optional filters against the prompt library.",
-RunE: func(cmd *cobra.Command, args []string) error {
-// Backward compat: --debug upgrades log level to debug
-// When log-level is debug or info and progress mode is auto,
-// disable live progress so slog output is visible on stderr.
-if f.progressMode == "auto" {
-logLevel, _ := cmd.Root().PersistentFlags().GetString("log-level")
-if logLevel == "debug" || logLevel == "info" {
-f.progressMode = "log"
-}
-}
+	f := &runFlags{}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run evaluations",
+		Long:  "Run evaluations with optional filters against the prompt library.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Backward compat: --debug upgrades log level to debug
+			// When log-level is debug or info and progress mode is auto,
+			// disable live progress so slog output is visible on stderr.
+			if f.progressMode == "auto" {
+				logLevel, _ := cmd.Root().PersistentFlags().GetString("log-level")
+				if logLevel == "debug" || logLevel == "info" {
+					f.progressMode = "log"
+				}
+			}
 
-f.prompts = resolvePromptsDir(cmd)
-f.output = resolveOutputDir(cmd)
+			f.prompts = resolvePromptsDir(cmd)
+			f.output = resolveOutputDir(cmd)
 
-// Load config(s)
-var cfgFile *config.ConfigFile
-if cmd.Flags().Changed("config-file") {
-f.configFile = resolveConfigFile(cmd)
-var err error
-cfgFile, err = config.Load(f.configFile)
-if err != nil {
-return fmt.Errorf("loading config: %w", err)
-}
-} else {
-configDir := resolveConfigDir(cmd)
-var err error
-cfgFile, err = config.LoadDir(configDir)
-if err != nil {
-return fmt.Errorf("loading configs from %s: %w", configDir, err)
-}
-}
+			// Load config(s)
+			var cfgFile *config.ConfigFile
+			if cmd.Flags().Changed("config-file") {
+				f.configFile = resolveConfigFile(cmd)
+				var err error
+				cfgFile, err = config.Load(f.configFile)
+				if err != nil {
+					return fmt.Errorf("loading config: %w", err)
+				}
+			} else {
+				configDir := resolveConfigDir(cmd)
+				var err error
+				cfgFile, err = config.LoadDir(configDir)
+				if err != nil {
+					return fmt.Errorf("loading configs from %s: %w", configDir, err)
+				}
+			}
 
-// Get selected configs
-var configNames []string
-if f.configName != "" {
-configNames = strings.Split(f.configName, ",")
-for i := range configNames {
-configNames[i] = strings.TrimSpace(configNames[i])
-}
-}
-configs, err := cfgFile.GetConfigs(configNames)
-if err != nil {
-return err
-}
+			// Get selected configs
+			var configNames []string
+			if f.configName != "" {
+				configNames = strings.Split(f.configName, ",")
+				for i := range configNames {
+					configNames[i] = strings.TrimSpace(configNames[i])
+				}
+			}
+			configs, err := cfgFile.GetConfigs(configNames)
+			if err != nil {
+				return err
+			}
 
-// Require --all-configs when multiple configs exist and no --config filter is specified (#34)
-if f.configName == "" && len(configs) > 1 && !f.allConfigs {
-fmt.Printf("\u26a0\ufe0f  Found %d configs but no --config filter specified.\n", len(configs))
-fmt.Println("   Use --all-configs to run all configs, or --config <name> to select specific ones.")
-return fmt.Errorf("multiple configs found without --config or --all-configs flag")
-}
+			// Require --all-configs when multiple configs exist and no --config filter is specified (#34)
+			if f.configName == "" && len(configs) > 1 && !f.allConfigs {
+				fmt.Printf("\u26a0\ufe0f  Found %d configs but no --config filter specified.\n", len(configs))
+				fmt.Println("   Use --all-configs to run all configs, or --config <name> to select specific ones.")
+				return fmt.Errorf("multiple configs found without --config or --all-configs flag")
+			}
 
-// Override model if specified via CLI flag
-if f.model != "" {
-for i := range configs {
-if configs[i].Generator == nil {
-configs[i].Generator = &config.GeneratorConfig{}
-}
-configs[i].Generator.Model = f.model
-}
-}
+			// Override model if specified via CLI flag
+			if f.model != "" {
+				for i := range configs {
+					if configs[i].Generator == nil {
+						configs[i].Generator = &config.GeneratorConfig{}
+					}
+					configs[i].Generator.Model = f.model
+				}
+			}
 
-// Pairwise tool-ablation expansion (#121)
-if f.pairwiseMode {
-var expanded []config.ToolConfig
-for _, c := range configs {
-variants := pairwise.ExpandPairwise(c)
-slog.Info("Expanded config into pairwise variants", "config", c.Name, "variants", len(variants))
-fmt.Printf("Expanded config %q into %d pairwise variants\n", c.Name, len(variants))
-expanded = append(expanded, variants...)
-}
-configs = expanded
-}
+			// Pairwise tool-ablation expansion (#121)
+			if f.pairwiseMode {
+				var expanded []config.ToolConfig
+				for _, c := range configs {
+					variants := pairwise.ExpandPairwise(c)
+					slog.Info("Expanded config into pairwise variants", "config", c.Name, "variants", len(variants))
+					fmt.Printf("Expanded config %q into %d pairwise variants\n", c.Name, len(variants))
+					expanded = append(expanded, variants...)
+				}
+				configs = expanded
+			}
 
-// Resolve relative skill_directories in configs to absolute paths
-resolveConfigSkillDirs(configs, f.prompts)
+			// Resolve relative skill_directories in configs to absolute paths
+			resolveConfigSkillDirs(configs, f.prompts)
 
-// Install declared skills and plugins (npx skills add)
-if err := config.InstallSkillsAndPlugins(configs); err != nil {
-return fmt.Errorf("installing skills/plugins: %w", err)
-}
+			// Install declared skills and plugins (npx skills add)
+			if err := config.InstallSkillsAndPlugins(configs); err != nil {
+				return fmt.Errorf("installing skills/plugins: %w", err)
+			}
 
-// Load and filter prompts
-prompts, err := prompt.LoadPrompts(f.prompts)
-if err != nil {
-return fmt.Errorf("loading prompts: %w", err)
-}
+			// Load and filter prompts
+			prompts, err := prompt.LoadPrompts(f.prompts)
+			if err != nil {
+				return fmt.Errorf("loading prompts: %w", err)
+			}
 
-filter := buildFilter(f)
-filtered := prompt.FilterPrompts(prompts, filter)
+			filter := buildFilter(f)
+			filtered := prompt.FilterPrompts(prompts, filter)
 
-if len(filtered) == 0 {
-fmt.Println("\u2717 No prompts matched the given filters.")
-if len(prompts) > 0 {
-fmt.Printf("  (%d prompt(s) were loaded but none matched the specified filters)\n", len(prompts))
-}
-return fmt.Errorf("no prompts matched the given filters")
-}
+			if len(filtered) == 0 {
+				fmt.Println("\u2717 No prompts matched the given filters.")
+				if len(prompts) > 0 {
+					fmt.Printf("  (%d prompt(s) were loaded but none matched the specified filters)\n", len(prompts))
+				}
+				return fmt.Errorf("no prompts matched the given filters")
+			}
 
-fmt.Printf("Found %d prompt(s), %d config(s) \u2192 %d evaluation(s)\n",
-len(filtered), len(configs), len(filtered)*len(configs))
+			fmt.Printf("Found %d prompt(s), %d config(s) \u2192 %d evaluation(s)\n",
+				len(filtered), len(configs), len(filtered)*len(configs))
 
-// Select evaluator and reviewer
-var evaluator eval.CopilotEvaluator
-var reviewerFactory eval.ReviewerFactory
+			// Select evaluator and reviewer
+			var evaluator eval.CopilotEvaluator
+			var reviewerFactory eval.ReviewerFactory
 
-// Parse session-timeout flag early \u2014 needed for reviewer setup.
-sessionTimeout, err := time.ParseDuration(f.sessionTimeout)
-if err != nil {
-return fmt.Errorf("invalid --session-timeout %q: %w", f.sessionTimeout, err)
-}
+			// Parse session-timeout flag early \u2014 needed for reviewer setup.
+			sessionTimeout, err := time.ParseDuration(f.sessionTimeout)
+			if err != nil {
+				return fmt.Errorf("invalid --session-timeout %q: %w", f.sessionTimeout, err)
+			}
 
-if f.useStub {
-slog.Info("Using stub evaluator", "reason", "--stub flag")
-fmt.Println("Using stub evaluator (--stub flag)")
-evaluator = &eval.StubEvaluator{}
-} else {
-// Try to create a real Copilot SDK evaluator
-sdkEval := eval.NewCopilotSDKEvaluator(eval.CopilotEvalOptions{
-AllowCloud:        f.allowCloud,
-MaxSessionActions: f.maxSessionActions,
-})
-sdkEval.SetSessionTimeout(sessionTimeout)
-evaluator = sdkEval
+			if f.useStub {
+				slog.Info("Using stub evaluator", "reason", "--stub flag")
+				fmt.Println("Using stub evaluator (--stub flag)")
+				evaluator = &eval.StubEvaluator{}
+			} else {
+				// Try to create a real Copilot SDK evaluator
+				sdkEval := eval.NewCopilotSDKEvaluator(eval.CopilotEvalOptions{
+					AllowCloud:        f.allowCloud,
+					MaxSessionActions: f.maxSessionActions,
+				})
+				sdkEval.SetSessionTimeout(sessionTimeout)
+				evaluator = sdkEval
 
-// Verify Copilot CLI is available
-client := copilot.NewClient(&copilot.ClientOptions{
-Env: eval.HyokaBaseEnv(), // Tag verification process (#70)
-})
-if err := client.Start(context.Background()); err != nil {
-slog.Warn("Copilot SDK unavailable, falling back to stub", "error", err)
-fmt.Printf("\u26a0\ufe0f  Copilot SDK unavailable (%v), falling back to stub evaluator\n", err)
-evaluator = &eval.StubEvaluator{}
-} else {
-defer client.Stop() // #65: ensure cleanup on any exit path
-slog.Info("Using Copilot SDK evaluator")
-fmt.Println("Using Copilot SDK evaluator")
+				// Verify Copilot CLI is available
+				client := copilot.NewClient(&copilot.ClientOptions{
+					Env: eval.HyokaBaseEnv(), // Tag verification process (#70)
+				})
+				if err := client.Start(context.Background()); err != nil {
+					slog.Warn("Copilot SDK unavailable, falling back to stub", "error", err)
+					fmt.Printf("\u26a0\ufe0f  Copilot SDK unavailable (%v), falling back to stub evaluator\n", err)
+					evaluator = &eval.StubEvaluator{}
+				} else {
+					defer client.Stop() // #65: ensure cleanup on any exit path
+					slog.Info("Using Copilot SDK evaluator")
+					fmt.Println("Using Copilot SDK evaluator")
 
-clientOpts := &copilot.ClientOptions{
-Env: eval.HyokaBaseEnv(), // Tag reviewer processes (#70)
-}
-if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
-clientOpts.LogLevel = "debug"
-}
+					clientOpts := &copilot.ClientOptions{
+						Env: eval.HyokaBaseEnv(), // Tag reviewer processes (#70)
+					}
+					if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+						clientOpts.LogLevel = "debug"
+					}
 
-// Extract reviewer skill directories from configs
-var reviewerSkillsDirs []string
-for _, c := range configs {
-if c.Reviewer != nil {
-for _, s := range c.Reviewer.Skills {
-if s.Type == "local" && s.Path != "" {
-reviewerSkillsDirs = append(reviewerSkillsDirs, s.Path)
-}
-}
-}
-}
+					// Extract reviewer skill directories from configs
+					var reviewerSkillsDirs []string
+					for _, c := range configs {
+						if c.Reviewer != nil {
+							for _, entry := range c.Reviewer.Tools {
+								if entry.ResolvedType() == "skill" && entry.SkillSource() == "local" && entry.Path != "" {
+									reviewerSkillsDirs = append(reviewerSkillsDirs, entry.Path)
+								}
+							}
+						}
+					}
 
-// Create reviewer factory that builds a reviewer per config (#92)
-reviewerFactory = func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
-var reviewerModels []string
-if cfg.Reviewer != nil && len(cfg.Reviewer.Models) > 0 {
-reviewerModels = cfg.Reviewer.Models
-}
-if len(reviewerModels) == 0 {
-return nil, nil, nil
-}
+					// Create reviewer factory that builds a reviewer per config (#92)
+					reviewerFactory = func(cfg *config.ToolConfig) (review.Reviewer, *review.PanelReviewer, error) {
+						var reviewerModels []string
+						if cfg.Reviewer != nil && len(cfg.Reviewer.Models) > 0 {
+							reviewerModels = cfg.Reviewer.Models
+						}
+						if len(reviewerModels) == 0 {
+							return nil, nil, nil
+						}
 
-if len(reviewerModels) > 1 {
-// Multi-model panel
-panelReviewer := review.NewPanelReviewer(clientOpts, reviewerModels, f.maxSessionActions)
-panelReviewer.SetSessionTimeout(sessionTimeout)
-if len(reviewerSkillsDirs) > 0 {
-panelReviewer.SetSkillDirectories(reviewerSkillsDirs)
-}
-if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
-panelReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
-}
-slog.Debug("Created review panel for config", "config", cfg.Name, "models", reviewerModels)
-return nil, panelReviewer, nil
-}
+						if len(reviewerModels) > 1 {
+							// Multi-model panel
+							panelReviewer := review.NewPanelReviewer(clientOpts, reviewerModels, f.maxSessionActions)
+							panelReviewer.SetSessionTimeout(sessionTimeout)
+							if len(reviewerSkillsDirs) > 0 {
+								panelReviewer.SetSkillDirectories(reviewerSkillsDirs)
+							}
+							if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
+								panelReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
+							}
+							slog.Debug("Created review panel for config", "config", cfg.Name, "models", reviewerModels)
+							return nil, panelReviewer, nil
+						}
 
-// Single reviewer
-reviewClient := copilot.NewClient(clientOpts)
-if err := reviewClient.Start(context.Background()); err != nil {
-return nil, nil, fmt.Errorf("could not start reviewer client: %w", err)
-}
-copilotReviewer := review.NewCopilotReviewer(reviewClient, reviewerModels[0], f.maxSessionActions)
-copilotReviewer.SetSessionTimeout(sessionTimeout)
-if len(reviewerSkillsDirs) > 0 {
-copilotReviewer.SetSkillDirectories(reviewerSkillsDirs)
-}
-if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
-copilotReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
-}
-slog.Debug("Created single reviewer for config", "config", cfg.Name, "model", reviewerModels[0])
-return copilotReviewer, nil, nil
-}
+						// Single reviewer
+						reviewClient := copilot.NewClient(clientOpts)
+						if err := reviewClient.Start(context.Background()); err != nil {
+							return nil, nil, fmt.Errorf("could not start reviewer client: %w", err)
+						}
+						copilotReviewer := review.NewCopilotReviewer(reviewClient, reviewerModels[0], f.maxSessionActions)
+						copilotReviewer.SetSessionTimeout(sessionTimeout)
+						if len(reviewerSkillsDirs) > 0 {
+							copilotReviewer.SetSkillDirectories(reviewerSkillsDirs)
+						}
+						if cfg.Reviewer != nil && cfg.Reviewer.SystemPrompt != "" {
+							copilotReviewer.SetSystemPrompt(cfg.Reviewer.SystemPrompt)
+						}
+						slog.Debug("Created single reviewer for config", "config", cfg.Name, "model", reviewerModels[0])
+						return copilotReviewer, nil, nil
+					}
 
-}
-}
+				}
+			}
 
-if f.skipReview {
-reviewerFactory = nil
-}
+			if f.skipReview {
+				reviewerFactory = nil
+			}
 
-// Parse max-output-size flag (#35)
-maxOutputSize, err := parseByteSize(f.maxOutputSize)
-if err != nil {
-return fmt.Errorf("invalid --max-output-size %q: %w", f.maxOutputSize, err)
-}
+			// Parse max-output-size flag (#35)
+			maxOutputSize, err := parseByteSize(f.maxOutputSize)
+			if err != nil {
+				return fmt.Errorf("invalid --max-output-size %q: %w", f.maxOutputSize, err)
+			}
 
-// Create and run engine
-// Parse exclude-dirs (#63)
-var excludeDirs []string
-if f.excludeDirs != "" {
-for _, d := range strings.Split(f.excludeDirs, ",") {
-d = strings.TrimSpace(d)
-if d != "" {
-excludeDirs = append(excludeDirs, d)
-}
-}
-}
+			// Create and run engine
+			// Parse exclude-dirs (#63)
+			var excludeDirs []string
+			if f.excludeDirs != "" {
+				for _, d := range strings.Split(f.excludeDirs, ",") {
+					d = strings.TrimSpace(d)
+					if d != "" {
+						excludeDirs = append(excludeDirs, d)
+					}
+				}
+			}
 
-engine := eval.NewEngineWithReviewerFactory(evaluator, reviewerFactory, eval.EngineOptions{
-Workers:           f.workers,
-MaxSessions:       f.maxSessions,
-OutputDir:         f.output,
-SkipTests:         f.skipTests,
-SkipReview:        f.skipReview,
-DryRun:            f.dryRun,
-ProgressMode:      f.progressMode,
-ConfirmLargeRuns:  true,
-AutoConfirm:       f.autoConfirm,
-MaxSessionActions: f.maxSessionActions,
-MaxFiles:          f.maxFiles,
-MaxOutputSize:     maxOutputSize,
-MonitorResources:  f.monitorResources,
-StrictCleanup:     f.strictCleanup,
-CriteriaDir:       f.criteriaDir,
-ExcludeDirs:       excludeDirs,
-SessionTimeout:    sessionTimeout,
-})
+			engine := eval.NewEngineWithReviewerFactory(evaluator, reviewerFactory, eval.EngineOptions{
+				Workers:           f.workers,
+				MaxSessions:       f.maxSessions,
+				OutputDir:         f.output,
+				SkipTests:         f.skipTests,
+				SkipReview:        f.skipReview,
+				DryRun:            f.dryRun,
+				ProgressMode:      f.progressMode,
+				ConfirmLargeRuns:  true,
+				AutoConfirm:       f.autoConfirm,
+				MaxSessionActions: f.maxSessionActions,
+				MaxFiles:          f.maxFiles,
+				MaxOutputSize:     maxOutputSize,
+				MonitorResources:  f.monitorResources,
+				StrictCleanup:     f.strictCleanup,
+				CriteriaDir:       f.criteriaDir,
+				ExcludeDirs:       excludeDirs,
+				SessionTimeout:    sessionTimeout,
+			})
 
-summary, err := engine.Run(context.Background(), filtered, configs)
-if err != nil {
-return fmt.Errorf("evaluation failed: %w", err)
-}
+			summary, err := engine.Run(context.Background(), filtered, configs)
+			if err != nil {
+				return fmt.Errorf("evaluation failed: %w", err)
+			}
 
-fmt.Printf("\nRun Summary:\n")
-fmt.Printf("  Run ID:      %s\n", summary.RunID)
-fmt.Printf("  Evaluations: %d\n", summary.TotalEvals)
-fmt.Printf("  Passed:      %d\n", summary.Passed)
-fmt.Printf("  Failed:      %d\n", summary.Failed)
-fmt.Printf("  Errors:      %d\n", summary.Errors)
-fmt.Printf("  Duration:    %.2fs\n", summary.Duration)
+			fmt.Printf("\nRun Summary:\n")
+			fmt.Printf("  Run ID:      %s\n", summary.RunID)
+			fmt.Printf("  Evaluations: %d\n", summary.TotalEvals)
+			fmt.Printf("  Passed:      %d\n", summary.Passed)
+			fmt.Printf("  Failed:      %d\n", summary.Failed)
+			fmt.Printf("  Errors:      %d\n", summary.Errors)
+			fmt.Printf("  Duration:    %.2fs\n", summary.Duration)
 
-// Auto-run trend analysis unless opted out
-if !f.skipTrends && !f.dryRun {
-fmt.Printf("\n%s\n", strings.Repeat("\u2500", 60))
-fmt.Println("\U0001f4ca Generating trend analysis...")
+			// Auto-run trend analysis unless opted out
+			if !f.skipTrends && !f.dryRun {
+				fmt.Printf("\n%s\n", strings.Repeat("\u2500", 60))
+				fmt.Println("\U0001f4ca Generating trend analysis...")
 
-trendsOutputDir := filepath.Join(f.output, "trends")
-tr, err := trends.Generate(trends.TrendOptions{
-ReportsDir: f.output,
-OutputDir:  trendsOutputDir,
-Analyze:    false, // generate data first, analyze below
-})
-if err != nil {
-slog.Warn("Trend generation failed", "error", err)
-fmt.Printf("\u26a0\ufe0f  Trend generation failed: %v\n", err)
-} else if tr.TotalRuns > 0 {
-fmt.Println("\U0001f916 Running AI-powered trend analysis...")
-analysis, aErr := trends.AnalyzeTrends(context.Background(), tr)
-if aErr != nil {
-slog.Warn("AI trend analysis failed", "error", aErr)
-fmt.Printf("\u26a0\ufe0f  AI analysis failed: %v (continuing without analysis)\n", aErr)
-} else {
-tr.Analysis = analysis
-fmt.Println("\n--- AI Analysis ---")
-fmt.Println(analysis)
-fmt.Println("-------------------")
+				trendsOutputDir := filepath.Join(f.output, "trends")
+				tr, err := trends.Generate(trends.TrendOptions{
+					ReportsDir: f.output,
+					OutputDir:  trendsOutputDir,
+					Analyze:    false, // generate data first, analyze below
+				})
+				if err != nil {
+					slog.Warn("Trend generation failed", "error", err)
+					fmt.Printf("\u26a0\ufe0f  Trend generation failed: %v\n", err)
+				} else if tr.TotalRuns > 0 {
+					fmt.Println("\U0001f916 Running AI-powered trend analysis...")
+					analysis, aErr := trends.AnalyzeTrends(context.Background(), tr)
+					if aErr != nil {
+						slog.Warn("AI trend analysis failed", "error", aErr)
+						fmt.Printf("\u26a0\ufe0f  AI analysis failed: %v (continuing without analysis)\n", aErr)
+					} else {
+						tr.Analysis = analysis
+						fmt.Println("\n--- AI Analysis ---")
+						fmt.Println(analysis)
+						fmt.Println("-------------------")
 
-// Re-write summary HTML with AI analysis included (Issue 7)
-summary.Analysis = analysis
-if _, err := report.WriteSummaryHTML(summary, f.output); err != nil {
-slog.Warn("Failed to update summary with analysis", "error", err)
-fmt.Printf("\u26a0\ufe0f  Failed to update summary with analysis: %v\n", err)
-}
-}
+						// Re-write summary HTML with AI analysis included (Issue 7)
+						summary.Analysis = analysis
+						if _, err := report.WriteSummaryHTML(summary, f.output); err != nil {
+							slog.Warn("Failed to update summary with analysis", "error", err)
+							fmt.Printf("\u26a0\ufe0f  Failed to update summary with analysis: %v\n", err)
+						}
+					}
 
-mdPath, _ := trends.WriteMarkdown(tr, trendsOutputDir)
-htmlPath, _ := trends.WriteHTML(tr, trendsOutputDir)
-if mdPath != "" {
-fmt.Printf("Trend report (MD):   %s\n", mdPath)
-}
-if htmlPath != "" {
-fmt.Printf("Trend report (HTML): %s\n", htmlPath)
-}
-fmt.Printf("Analyzed %d evaluation(s) across %d prompt(s)\n", tr.TotalRuns, len(tr.PromptTrends))
-} else {
-fmt.Println("No historical data found for trend analysis.")
-}
-}
+					mdPath, _ := trends.WriteMarkdown(tr, trendsOutputDir)
+					htmlPath, _ := trends.WriteHTML(tr, trendsOutputDir)
+					if mdPath != "" {
+						fmt.Printf("Trend report (MD):   %s\n", mdPath)
+					}
+					if htmlPath != "" {
+						fmt.Printf("Trend report (HTML): %s\n", htmlPath)
+					}
+					fmt.Printf("Analyzed %d evaluation(s) across %d prompt(s)\n", tr.TotalRuns, len(tr.PromptTrends))
+				} else {
+					fmt.Println("No historical data found for trend analysis.")
+				}
+			}
 
-return nil
-},
-}
+			return nil
+		},
+	}
 
-addFilterFlags(cmd, f)
-return cmd
+	addFilterFlags(cmd, f)
+	return cmd
 }

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -12,40 +12,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// MCPServer represents an MCP server configuration.
-type MCPServer struct {
-	Type    string   `yaml:"type" json:"type"`
-	Command string   `yaml:"command" json:"command"`
-	Args    []string `yaml:"args" json:"args"`
-	Tools   []string `yaml:"tools" json:"tools"`
-}
-
-// Skill represents a unified skill entry supporting both local and remote sources.
-//   - type: local  → Path contains a local directory path (supports globs)
-//   - type: remote → Name + Repo identify a skill to fetch from a GitHub repo
-type Skill struct {
-	Type string `yaml:"type" json:"type"`
-	Name string `yaml:"name,omitempty" json:"name,omitempty"`
-	Repo string `yaml:"repo,omitempty" json:"repo,omitempty"`
-	Path string `yaml:"path,omitempty" json:"path,omitempty"`
-}
-
 // GeneratorConfig holds all configuration for the code generation agent.
 type GeneratorConfig struct {
-	Model          string                `yaml:"model" json:"model"`
-	SystemPrompt   string                `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
-	Skills         []Skill               `yaml:"skills,omitempty" json:"skills,omitempty"`
-	MCPServers     map[string]*MCPServer `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
-	Tools          []ToolEntry           `yaml:"tools,omitempty" json:"tools,omitempty"`
-	AvailableTools []string              `yaml:"available_tools,omitempty" json:"available_tools,omitempty"`
-	ExcludedTools  []string              `yaml:"excluded_tools,omitempty" json:"excluded_tools,omitempty"`
+	Model         string      `yaml:"model" json:"model"`
+	SystemPrompt  string      `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
+	Tools         []ToolEntry `yaml:"tools,omitempty" json:"tools,omitempty"`
+	ExcludedTools []string    `yaml:"excluded_tools,omitempty" json:"excluded_tools,omitempty"`
 }
 
 // ReviewerConfig holds all configuration for the review/grading plane.
 type ReviewerConfig struct {
-	Models       []string `yaml:"models,omitempty" json:"models,omitempty"`
-	SystemPrompt string   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
-	Skills       []Skill  `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Models       []string    `yaml:"models,omitempty" json:"models,omitempty"`
+	SystemPrompt string      `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
+	Tools        []ToolEntry `yaml:"tools,omitempty" json:"tools,omitempty"`
 }
 
 // SessionLimits configures per-config guardrail limits for evaluation sessions.
@@ -151,13 +130,7 @@ func (cf *ConfigFile) Validate() error {
 			return fmt.Errorf("duplicate config name %q at index %d and %d", c.Name, prev, i)
 		}
 		namesSeen[c.Name] = i
-		// Validate generator/reviewer skills have correct type
 		if c.Generator != nil {
-			for _, s := range c.Generator.Skills {
-				if err := validateSkill(s); err != nil {
-					return fmt.Errorf("config %q generator skill: %w", c.Name, err)
-				}
-			}
 			for j, te := range c.Generator.Tools {
 				if err := validateToolEntry(te, c.Name, j); err != nil {
 					return err
@@ -165,9 +138,9 @@ func (cf *ConfigFile) Validate() error {
 			}
 		}
 		if c.Reviewer != nil {
-			for _, s := range c.Reviewer.Skills {
-				if err := validateSkill(s); err != nil {
-					return fmt.Errorf("config %q reviewer skill: %w", c.Name, err)
+			for j, te := range c.Reviewer.Tools {
+				if err := validateToolEntry(te, c.Name, j); err != nil {
+					return err
 				}
 			}
 			// Check for duplicate reviewer models
@@ -194,23 +167,6 @@ func (cf *ConfigFile) Validate() error {
 				return fmt.Errorf("config %q: limits.max_session_actions must not be negative", c.Name)
 			}
 		}
-	}
-	return nil
-}
-
-// validateSkill checks that a Skill has valid type and required fields.
-func validateSkill(s Skill) error {
-	switch s.Type {
-	case "local":
-		if s.Path == "" {
-			return fmt.Errorf("local skill missing path")
-		}
-	case "remote":
-		if s.Repo == "" {
-			return fmt.Errorf("remote skill missing repo")
-		}
-	default:
-		return fmt.Errorf("unknown skill type %q (expected \"local\" or \"remote\")", s.Type)
 	}
 	return nil
 }

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -18,12 +18,12 @@ configs:
     description: "Second test"
     generator:
       model: "claude-sonnet-4.5"
-      mcp_servers:
-        azure:
-          type: local
+      tools:
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest"]
-          tools: ["*"]
+          mcp_tools: ["*"]
 `)
 	cfg, err := Parse(data)
 	if err != nil {
@@ -39,11 +39,19 @@ configs:
 		t.Errorf("expected model 'gpt-4', got %q", cfg.Configs[0].Generator.Model)
 	}
 	// Check MCP server on second config
-	if cfg.Configs[1].Generator.MCPServers == nil {
-		t.Fatal("expected MCP servers on second config")
+	if cfg.Configs[1].Generator == nil {
+		t.Fatal("expected generator on second config")
 	}
-	azure, ok := cfg.Configs[1].Generator.MCPServers["azure"]
-	if !ok {
+	var azure ToolEntry
+	found := false
+	for _, entry := range cfg.Configs[1].Generator.Tools {
+		if entry.ResolvedType() == "mcp" && entry.Name == "azure" {
+			azure = entry
+			found = true
+			break
+		}
+	}
+	if !found {
 		t.Fatal("expected 'azure' MCP server")
 	}
 	if azure.Command != "npx" {
@@ -286,11 +294,14 @@ configs:
     description: "Config with skills and plugins"
     generator:
       model: "gpt-4"
-      skills:
-        - type: local
+      tools:
+        - name: local-skill
+          type: skill
+          source: local
           path: "./skills/tool-use"
-        - type: remote
-          name: org-skill
+        - name: org-skill
+          type: skill
+          source: remote
           repo: "github:org/repo"
     plugins:
       - "@azure/functions"
@@ -300,14 +311,14 @@ configs:
 		t.Fatalf("unexpected error: %v", err)
 	}
 	c := cfg.Configs[0]
-	if len(c.Generator.Skills) != 2 {
-		t.Errorf("expected 2 skills, got %d", len(c.Generator.Skills))
+	if len(c.Generator.Tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(c.Generator.Tools))
 	}
-	if c.Generator.Skills[0].Type != "local" || c.Generator.Skills[0].Path != "./skills/tool-use" {
-		t.Errorf("expected local skill './skills/tool-use', got %+v", c.Generator.Skills[0])
+	if c.Generator.Tools[0].ResolvedType() != "skill" || c.Generator.Tools[0].Path != "./skills/tool-use" {
+		t.Errorf("expected local skill './skills/tool-use', got %+v", c.Generator.Tools[0])
 	}
-	if c.Generator.Skills[1].Type != "remote" || c.Generator.Skills[1].Repo != "github:org/repo" {
-		t.Errorf("expected remote skill 'github:org/repo', got %+v", c.Generator.Skills[1])
+	if c.Generator.Tools[1].ResolvedType() != "skill" || c.Generator.Tools[1].Repo != "github:org/repo" {
+		t.Errorf("expected remote skill 'github:org/repo', got %+v", c.Generator.Tools[1])
 	}
 	if len(c.Plugins) != 1 {
 		t.Errorf("expected 1 plugin, got %d", len(c.Plugins))
@@ -330,8 +341,8 @@ configs:
 		t.Fatalf("unexpected error: %v", err)
 	}
 	c := cfg.Configs[0]
-	if len(c.Generator.Skills) != 0 {
-		t.Errorf("expected 0 skills, got %d", len(c.Generator.Skills))
+	if len(c.Generator.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(c.Generator.Tools))
 	}
 	if len(c.Plugins) != 0 {
 		t.Errorf("expected 0 plugins, got %d", len(c.Plugins))
@@ -354,23 +365,27 @@ configs:
     description: "New format with generator/reviewer"
     generator:
       model: "claude-sonnet-4.5"
-      skills:
-        - type: local
+      tools:
+        - name: generator-skills
+          type: skill
+          source: local
           path: "./skills/generator"
-      mcp_servers:
-        azure:
-          type: local
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest"]
-          tools: ["*"]
-      available_tools: ["create", "edit"]
+          mcp_tools: ["*"]
+        - name: create
+        - name: edit
       excluded_tools: ["web_fetch"]
     reviewer:
       models:
         - "claude-opus-4.6"
         - "gemini-3-pro-preview"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"
 `)
 	cfg, err := Parse(data)
@@ -386,20 +401,26 @@ configs:
 	if len(models) != 2 || models[0] != "claude-opus-4.6" {
 		t.Errorf("expected reviewer models [claude-opus-4.6 gemini-3-pro-preview], got %v", models)
 	}
-	genSkills := c.Generator.Skills
-	if len(genSkills) != 1 || genSkills[0].Type != "local" {
-		t.Errorf("expected 1 generator skill (local), got %v", genSkills)
+	if len(c.Generator.Tools) != 4 {
+		t.Errorf("expected 4 generator tools, got %d", len(c.Generator.Tools))
 	}
-	revSkills := c.Reviewer.Skills
-	if len(revSkills) != 1 || revSkills[0].Path != "./skills/reviewer" {
-		t.Errorf("expected 1 reviewer skill, got %v", revSkills)
+	var hasSkill, hasMCP bool
+	for _, entry := range c.Generator.Tools {
+		if entry.ResolvedType() == "skill" && entry.Path == "./skills/generator" {
+			hasSkill = true
+		}
+		if entry.ResolvedType() == "mcp" && entry.Name == "azure" {
+			hasMCP = true
+		}
 	}
-	mcpServers := c.Generator.MCPServers
-	if len(mcpServers) != 1 {
-		t.Errorf("expected 1 MCP server, got %d", len(mcpServers))
+	if !hasSkill {
+		t.Error("expected generator skill entry with ./skills/generator")
 	}
-	if len(c.Generator.AvailableTools) != 2 {
-		t.Errorf("expected 2 available tools, got %d", len(c.Generator.AvailableTools))
+	if !hasMCP {
+		t.Error("expected generator MCP entry named azure")
+	}
+	if len(c.Reviewer.Tools) != 1 {
+		t.Errorf("expected 1 reviewer tool, got %d", len(c.Reviewer.Tools))
 	}
 	if len(c.Generator.ExcludedTools) != 1 {
 		t.Errorf("expected 1 excluded tool, got %d", len(c.Generator.ExcludedTools))
@@ -413,21 +434,24 @@ configs:
     description: "Full config with generator and reviewer"
     generator:
       model: "claude-opus-4.6"
-      mcp_servers:
-        azure:
-          type: local
+      tools:
+        - name: azure
+          type: mcp
           command: npx
           args: ["-y", "@azure/mcp@latest"]
-      skills:
-        - type: local
+        - name: generator-skills
+          type: skill
+          source: local
           path: "./skills/generator"
-      available_tools: ["create"]
+        - name: create
       excluded_tools: ["bash"]
     reviewer:
       models:
         - "gpt-4.1"
-      skills:
-        - type: local
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"
 `)
 	cfg, err := Parse(data)
@@ -448,17 +472,11 @@ configs:
 	if len(c.Reviewer.Models) != 1 || c.Reviewer.Models[0] != "gpt-4.1" {
 		t.Errorf("expected Reviewer.Models [gpt-4.1], got %v", c.Reviewer.Models)
 	}
-	if len(c.Generator.Skills) != 1 || c.Generator.Skills[0].Path != "./skills/generator" {
-		t.Errorf("expected 1 generator skill, got %v", c.Generator.Skills)
+	if len(c.Generator.Tools) != 3 {
+		t.Errorf("expected 3 generator tools, got %d", len(c.Generator.Tools))
 	}
-	if len(c.Reviewer.Skills) != 1 || c.Reviewer.Skills[0].Path != "./skills/reviewer" {
-		t.Errorf("expected 1 reviewer skill, got %v", c.Reviewer.Skills)
-	}
-	if len(c.Generator.MCPServers) != 1 {
-		t.Errorf("expected 1 MCP server, got %d", len(c.Generator.MCPServers))
-	}
-	if len(c.Generator.AvailableTools) != 1 {
-		t.Errorf("expected 1 available tool, got %d", len(c.Generator.AvailableTools))
+	if len(c.Reviewer.Tools) != 1 {
+		t.Errorf("expected 1 reviewer tool, got %d", len(c.Reviewer.Tools))
 	}
 }
 
@@ -469,11 +487,14 @@ configs:
     description: "Config with remote skill"
     generator:
       model: "gpt-4"
-      skills:
-        - type: remote
-          name: azure-keyvault-py
+      tools:
+        - name: azure-keyvault-py
+          type: skill
+          source: remote
           repo: microsoft/skills
-        - type: local
+        - name: local-skill
+          type: skill
+          source: local
           path: "./skills/local"
 `)
 	cfg, err := Parse(data)
@@ -481,32 +502,32 @@ configs:
 		t.Fatalf("unexpected error: %v", err)
 	}
 	c := cfg.Configs[0]
-	skills := c.Generator.Skills
-	if len(skills) != 2 {
-		t.Fatalf("expected 2 skills, got %d", len(skills))
+	tools := c.Generator.Tools
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
 	}
-	if skills[0].Type != "remote" || skills[0].Name != "azure-keyvault-py" || skills[0].Repo != "microsoft/skills" {
-		t.Errorf("unexpected remote skill: %+v", skills[0])
+	if tools[0].ResolvedType() != "skill" || tools[0].Name != "azure-keyvault-py" || tools[0].Repo != "microsoft/skills" {
+		t.Errorf("unexpected remote skill: %+v", tools[0])
 	}
-	if skills[1].Type != "local" || skills[1].Path != "./skills/local" {
-		t.Errorf("unexpected local skill: %+v", skills[1])
+	if tools[1].ResolvedType() != "skill" || tools[1].Path != "./skills/local" {
+		t.Errorf("unexpected local skill: %+v", tools[1])
 	}
 }
 
-func TestValidateRejectsInvalidSkillType(t *testing.T) {
+func TestValidateRejectsInvalidToolType(t *testing.T) {
 	data := []byte(`
 configs:
   - name: bad-skill
     description: "Bad skill type"
     generator:
       model: "gpt-4"
-      skills:
-        - type: invalid
-          path: "./foo"
+      tools:
+        - name: bad-tool
+          type: invalid
 `)
 	_, err := Parse(data)
 	if err == nil {
-		t.Fatal("expected error for invalid skill type")
+		t.Fatal("expected error for invalid tool type")
 	}
 }
 
@@ -517,8 +538,10 @@ configs:
     description: "Local skill missing path"
     generator:
       model: "gpt-4"
-      skills:
-        - type: local
+      tools:
+        - name: missing-path
+          type: skill
+          source: local
 `)
 	_, err := Parse(data)
 	if err == nil {
@@ -533,9 +556,10 @@ configs:
     description: "Remote skill missing repo"
     generator:
       model: "gpt-4"
-      skills:
-        - type: remote
-          name: some-skill
+      tools:
+        - name: some-skill
+          type: skill
+          source: remote
 `)
 	_, err := Parse(data)
 	if err == nil {

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -2,14 +2,50 @@ package config
 
 import "fmt"
 
-// ToolEntry represents a tool with optional property-based conditions.
-// When the When map is empty, the tool is unconditionally included.
+// ToolEntry represents a tool, MCP server, or skill with optional conditions.
+// When the When map is empty, the entry is unconditionally included.
 // When the When map has entries, all key-value pairs must match the
-// prompt's properties for the tool to be included.
+// prompt's properties for the entry to be included.
 type ToolEntry struct {
-Name     string            `yaml:"name" json:"name"`
-When     map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
-AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty"`
+	Name     string            `yaml:"name" json:"name"`
+	Type     string            `yaml:"type,omitempty" json:"type,omitempty"` // "tool" (default), "mcp", "skill"
+	When     map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
+	AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty"`
+	// MCP-specific fields
+	Command  string   `yaml:"command,omitempty" json:"command,omitempty"`
+	Args     []string `yaml:"args,omitempty" json:"args,omitempty"`
+	MCPTools []string `yaml:"mcp_tools,omitempty" json:"mcp_tools,omitempty"`
+	// Skill-specific fields
+	Source string `yaml:"source,omitempty" json:"source,omitempty"` // "local" or "remote"
+	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
+	Repo   string `yaml:"repo,omitempty" json:"repo,omitempty"`
+}
+
+func resolvedToolType(entry ToolEntry) string {
+	if entry.Type == "" {
+		return "tool"
+	}
+	return entry.Type
+}
+
+// ResolvedType returns the normalized entry type ("tool" by default).
+func (e ToolEntry) ResolvedType() string {
+	return resolvedToolType(e)
+}
+
+// SkillSource returns the normalized skill source ("local" or "remote").
+// If Source is unset, it infers from Path/Repo when possible.
+func (e ToolEntry) SkillSource() string {
+	if e.Source != "" {
+		return e.Source
+	}
+	if e.Path != "" {
+		return "local"
+	}
+	if e.Repo != "" {
+		return "remote"
+	}
+	return ""
 }
 
 // ResolveTools evaluates tool entries against prompt properties and returns
@@ -17,35 +53,55 @@ AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty
 // returns nil (meaning "all default tools"). Duplicate names are deduplicated
 // while preserving first-seen order.
 func ResolveTools(entries []ToolEntry, properties map[string]string) []string {
-if len(entries) == 0 {
-return nil
-}
-seen := make(map[string]bool, len(entries))
-var resolved []string
-for _, e := range entries {
-if matchesWhen(e.When, properties) && !seen[e.Name] {
-seen[e.Name] = true
-resolved = append(resolved, e.Name)
-}
-}
-return resolved
+	if len(entries) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(entries))
+	var resolved []string
+	for _, e := range entries {
+		if resolvedToolType(e) != "tool" {
+			continue
+		}
+		if matchesWhen(e.When, properties) && !seen[e.Name] {
+			seen[e.Name] = true
+			resolved = append(resolved, e.Name)
+		}
+	}
+	return resolved
 }
 
 // matchesWhen returns true when every key-value pair in when matches the
 // properties map. An empty when map always matches.
 func matchesWhen(when map[string]string, props map[string]string) bool {
-for k, v := range when {
-if props[k] != v {
-return false
-}
-}
-return true
+	for k, v := range when {
+		if props[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // validateToolEntry checks that a ToolEntry has valid fields.
 func validateToolEntry(entry ToolEntry, configName string, idx int) error {
-if entry.Name == "" {
-return fmt.Errorf("config %q: tools[%d] missing name", configName, idx)
-}
-return nil
+	if entry.Name == "" {
+		return fmt.Errorf("config %q: tools[%d] missing name", configName, idx)
+	}
+	switch resolvedToolType(entry) {
+	case "tool":
+		return nil
+	case "mcp":
+		if entry.Command == "" {
+			return fmt.Errorf("config %q: tools[%d] mcp entry missing command", configName, idx)
+		}
+	case "skill":
+		if entry.Path == "" && entry.Repo == "" {
+			return fmt.Errorf("config %q: tools[%d] skill entry missing path or repo", configName, idx)
+		}
+		if entry.Source != "" && entry.Source != "local" && entry.Source != "remote" {
+			return fmt.Errorf("config %q: tools[%d] skill entry has invalid source %q", configName, idx, entry.Source)
+		}
+	default:
+		return fmt.Errorf("config %q: tools[%d] has unknown type %q", configName, idx, entry.Type)
+	}
+	return nil
 }

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -1,154 +1,155 @@
 package config
 
 import (
-"testing"
+	"testing"
 )
 
 func TestResolveTools_EmptyEntries(t *testing.T) {
-result := ResolveTools(nil, map[string]string{"language": "python"})
-if result != nil {
-t.Errorf("expected nil for empty entries, got %v", result)
-}
+	result := ResolveTools(nil, map[string]string{"language": "python"})
+	if result != nil {
+		t.Errorf("expected nil for empty entries, got %v", result)
+	}
 }
 
 func TestResolveTools_UnconditionalTools(t *testing.T) {
-entries := []ToolEntry{
-{Name: "create"},
-{Name: "edit"},
-{Name: "bash"},
-}
-result := ResolveTools(entries, map[string]string{"language": "python"})
-if len(result) != 3 {
-t.Fatalf("expected 3 tools, got %d", len(result))
-}
-want := []string{"create", "edit", "bash"}
-for i, name := range want {
-if result[i] != name {
-t.Errorf("result[%d] = %q, want %q", i, result[i], name)
-}
-}
+	entries := []ToolEntry{
+		{Name: "create"},
+		{Name: "edit"},
+		{Name: "bash"},
+	}
+	result := ResolveTools(entries, map[string]string{"language": "python"})
+	if len(result) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(result))
+	}
+	want := []string{"create", "edit", "bash"}
+	for i, name := range want {
+		if result[i] != name {
+			t.Errorf("result[%d] = %q, want %q", i, result[i], name)
+		}
+	}
 }
 
 func TestResolveTools_ConditionalMatch(t *testing.T) {
-entries := []ToolEntry{
-{Name: "create"},
-{Name: "azure_mcp", When: map[string]string{"language": "python"}},
-}
-props := map[string]string{"language": "python", "service": "identity"}
-result := ResolveTools(entries, props)
-if len(result) != 2 {
-t.Fatalf("expected 2 tools, got %d: %v", len(result), result)
-}
-if result[0] != "create" || result[1] != "azure_mcp" {
-t.Errorf("unexpected result: %v", result)
-}
+	entries := []ToolEntry{
+		{Name: "create"},
+		{Name: "azure_mcp", When: map[string]string{"language": "python"}},
+	}
+	props := map[string]string{"language": "python", "service": "identity"}
+	result := ResolveTools(entries, props)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d: %v", len(result), result)
+	}
+	if result[0] != "create" || result[1] != "azure_mcp" {
+		t.Errorf("unexpected result: %v", result)
+	}
 }
 
 func TestResolveTools_ConditionalNoMatch(t *testing.T) {
-entries := []ToolEntry{
-{Name: "create"},
-{Name: "azure_mcp", When: map[string]string{"language": "python"}},
-}
-props := map[string]string{"language": "dotnet"}
-result := ResolveTools(entries, props)
-if len(result) != 1 {
-t.Fatalf("expected 1 tool, got %d: %v", len(result), result)
-}
-if result[0] != "create" {
-t.Errorf("expected 'create', got %q", result[0])
-}
+	entries := []ToolEntry{
+		{Name: "create"},
+		{Name: "azure_mcp", When: map[string]string{"language": "python"}},
+	}
+	props := map[string]string{"language": "dotnet"}
+	result := ResolveTools(entries, props)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d: %v", len(result), result)
+	}
+	if result[0] != "create" {
+		t.Errorf("expected 'create', got %q", result[0])
+	}
 }
 
 func TestResolveTools_MultipleConditions(t *testing.T) {
-entries := []ToolEntry{
-{Name: "bash"},
-{Name: "azure_mcp", When: map[string]string{
-"language": "python",
-"service":  "key-vault",
-}},
-}
+	entries := []ToolEntry{
+		{Name: "bash"},
+		{Name: "azure_mcp", When: map[string]string{
+			"language": "python",
+			"service":  "key-vault",
+		}},
+	}
 
-// Both match
-result := ResolveTools(entries, map[string]string{
-"language": "python", "service": "key-vault",
-})
-if len(result) != 2 {
-t.Errorf("expected 2 tools when both conditions match, got %d: %v", len(result), result)
-}
+	// Both match
+	result := ResolveTools(entries, map[string]string{
+		"language": "python", "service": "key-vault",
+	})
+	if len(result) != 2 {
+		t.Errorf("expected 2 tools when both conditions match, got %d: %v", len(result), result)
+	}
 
-// Only one condition matches
-result = ResolveTools(entries, map[string]string{
-"language": "python", "service": "identity",
-})
-if len(result) != 1 || result[0] != "bash" {
-t.Errorf("expected [bash] when only one condition matches, got %v", result)
-}
+	// Only one condition matches
+	result = ResolveTools(entries, map[string]string{
+		"language": "python", "service": "identity",
+	})
+	if len(result) != 1 || result[0] != "bash" {
+		t.Errorf("expected [bash] when only one condition matches, got %v", result)
+	}
 }
 
 func TestResolveTools_EmptyProperties(t *testing.T) {
-entries := []ToolEntry{
-{Name: "create"},
-{Name: "azure_mcp", When: map[string]string{"language": "python"}},
-}
-result := ResolveTools(entries, nil)
-if len(result) != 1 || result[0] != "create" {
-t.Errorf("expected [create] with nil properties, got %v", result)
-}
+	entries := []ToolEntry{
+		{Name: "create"},
+		{Name: "azure_mcp", When: map[string]string{"language": "python"}},
+	}
+	result := ResolveTools(entries, nil)
+	if len(result) != 1 || result[0] != "create" {
+		t.Errorf("expected [create] with nil properties, got %v", result)
+	}
 
-result = ResolveTools(entries, map[string]string{})
-if len(result) != 1 || result[0] != "create" {
-t.Errorf("expected [create] with empty properties, got %v", result)
-}
+	result = ResolveTools(entries, map[string]string{})
+	if len(result) != 1 || result[0] != "create" {
+		t.Errorf("expected [create] with empty properties, got %v", result)
+	}
 }
 
 func TestResolveTools_AllConditionalNoneMatch(t *testing.T) {
-entries := []ToolEntry{
-{Name: "tool-a", When: map[string]string{"language": "python"}},
-{Name: "tool-b", When: map[string]string{"language": "dotnet"}},
-}
-result := ResolveTools(entries, map[string]string{"language": "java"})
-if len(result) != 0 {
-t.Errorf("expected 0 tools, got %d: %v", len(result), result)
-}
+	entries := []ToolEntry{
+		{Name: "tool-a", When: map[string]string{"language": "python"}},
+		{Name: "tool-b", When: map[string]string{"language": "dotnet"}},
+	}
+	result := ResolveTools(entries, map[string]string{"language": "java"})
+	if len(result) != 0 {
+		t.Errorf("expected 0 tools, got %d: %v", len(result), result)
+	}
 }
 
 func TestMatchesWhen_EmptyWhen(t *testing.T) {
-if !matchesWhen(nil, map[string]string{"a": "b"}) {
-t.Error("nil when should always match")
-}
-if !matchesWhen(map[string]string{}, map[string]string{"a": "b"}) {
-t.Error("empty when should always match")
-}
+	if !matchesWhen(nil, map[string]string{"a": "b"}) {
+		t.Error("nil when should always match")
+	}
+	if !matchesWhen(map[string]string{}, map[string]string{"a": "b"}) {
+		t.Error("empty when should always match")
+	}
 }
 
 func TestMatchesWhen_MissingProperty(t *testing.T) {
-when := map[string]string{"language": "python"}
-if matchesWhen(when, map[string]string{"service": "identity"}) {
-t.Error("should not match when required property is missing")
-}
+	when := map[string]string{"language": "python"}
+	if matchesWhen(when, map[string]string{"service": "identity"}) {
+		t.Error("should not match when required property is missing")
+	}
 }
 
 func TestValidateToolEntry_Valid(t *testing.T) {
-cases := []ToolEntry{
-{Name: "bash"},
-{Name: "mcp", When: map[string]string{"language": "python"}},
-}
-for i, tc := range cases {
-if err := validateToolEntry(tc, "test", i); err != nil {
-t.Errorf("case %d: unexpected error: %v", i, err)
-}
-}
+	cases := []ToolEntry{
+		{Name: "bash"},
+		{Name: "azure", Type: "mcp", Command: "npx"},
+		{Name: "gen-skill", Type: "skill", Source: "local", Path: "./skills/generator"},
+	}
+	for i, tc := range cases {
+		if err := validateToolEntry(tc, "test", i); err != nil {
+			t.Errorf("case %d: unexpected error: %v", i, err)
+		}
+	}
 }
 
 func TestValidateToolEntry_MissingName(t *testing.T) {
-err := validateToolEntry(ToolEntry{}, "test", 0)
-if err == nil {
-t.Fatal("expected error for missing name")
-}
+	err := validateToolEntry(ToolEntry{}, "test", 0)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
 }
 
 func TestParseConfigWithTools(t *testing.T) {
-data := []byte(`
+	data := []byte(`
 configs:
   - name: with-tools
     description: "Config with conditional tools"
@@ -159,61 +160,60 @@ configs:
         - name: "azure-mcp"
           when:
             language: python
-      available_tools: ["view"]
       excluded_tools: ["dangerous"]
 `)
-cfg, err := Parse(data)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-c := cfg.Configs[0]
-if len(c.Generator.Tools) != 2 {
-t.Fatalf("expected 2 tool entries, got %d", len(c.Generator.Tools))
-}
-if c.Generator.Tools[0].Name != "bash" {
-t.Errorf("expected first tool 'bash', got %q", c.Generator.Tools[0].Name)
-}
-if c.Generator.Tools[1].When["language"] != "python" {
-t.Errorf("expected when language=python, got %v", c.Generator.Tools[1].When)
-}
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c := cfg.Configs[0]
+	if len(c.Generator.Tools) != 2 {
+		t.Fatalf("expected 2 tool entries, got %d", len(c.Generator.Tools))
+	}
+	if c.Generator.Tools[0].Name != "bash" {
+		t.Errorf("expected first tool 'bash', got %q", c.Generator.Tools[0].Name)
+	}
+	if c.Generator.Tools[1].When["language"] != "python" {
+		t.Errorf("expected when language=python, got %v", c.Generator.Tools[1].When)
+	}
 }
 
 func TestResolveTools_Deduplication(t *testing.T) {
-entries := []ToolEntry{
-{Name: "create"},
-{Name: "create", When: map[string]string{"language": "python"}},
-{Name: "edit"},
-}
-result := ResolveTools(entries, map[string]string{"language": "python"})
-if len(result) != 2 {
-t.Fatalf("expected 2 tools after dedup, got %d: %v", len(result), result)
-}
-if result[0] != "create" || result[1] != "edit" {
-t.Errorf("expected [create edit], got %v", result)
-}
+	entries := []ToolEntry{
+		{Name: "create"},
+		{Name: "create", When: map[string]string{"language": "python"}},
+		{Name: "edit"},
+	}
+	result := ResolveTools(entries, map[string]string{"language": "python"})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools after dedup, got %d: %v", len(result), result)
+	}
+	if result[0] != "create" || result[1] != "edit" {
+		t.Errorf("expected [create edit], got %v", result)
+	}
 }
 
 func TestResolveTools_DeduplicationPreservesOrder(t *testing.T) {
-entries := []ToolEntry{
-{Name: "bash"},
-{Name: "create", When: map[string]string{"language": "python"}},
-{Name: "bash", When: map[string]string{"language": "python"}},
-{Name: "edit"},
-}
-result := ResolveTools(entries, map[string]string{"language": "python"})
-want := []string{"bash", "create", "edit"}
-if len(result) != len(want) {
-t.Fatalf("expected %d tools, got %d: %v", len(want), len(result), result)
-}
-for i, name := range want {
-if result[i] != name {
-t.Errorf("result[%d] = %q, want %q", i, result[i], name)
-}
-}
+	entries := []ToolEntry{
+		{Name: "bash"},
+		{Name: "create", When: map[string]string{"language": "python"}},
+		{Name: "bash", When: map[string]string{"language": "python"}},
+		{Name: "edit"},
+	}
+	result := ResolveTools(entries, map[string]string{"language": "python"})
+	want := []string{"bash", "create", "edit"}
+	if len(result) != len(want) {
+		t.Fatalf("expected %d tools, got %d: %v", len(want), len(result), result)
+	}
+	for i, name := range want {
+		if result[i] != name {
+			t.Errorf("result[%d] = %q, want %q", i, result[i], name)
+		}
+	}
 }
 
 func TestParseConfigWithAlwaysOn(t *testing.T) {
-data := []byte(`
+	data := []byte(`
 configs:
   - name: always-on-test
     description: "Config with always_on tools"
@@ -227,35 +227,63 @@ configs:
             language: python
         - name: "edit"
 `)
-cfg, err := Parse(data)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-tools := cfg.Configs[0].Generator.Tools
-if len(tools) != 3 {
-t.Fatalf("expected 3 tools, got %d", len(tools))
-}
-if !tools[0].AlwaysOn {
-t.Error("expected bash to have always_on=true")
-}
-if tools[1].AlwaysOn {
-t.Error("expected azure-mcp to have always_on=false (default)")
-}
-if tools[2].AlwaysOn {
-t.Error("expected edit to have always_on=false (default)")
-}
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tools := cfg.Configs[0].Generator.Tools
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+	if !tools[0].AlwaysOn {
+		t.Error("expected bash to have always_on=true")
+	}
+	if tools[1].AlwaysOn {
+		t.Error("expected azure-mcp to have always_on=false (default)")
+	}
+	if tools[2].AlwaysOn {
+		t.Error("expected edit to have always_on=false (default)")
+	}
 }
 
 func TestToolEntryAlwaysOnDefault(t *testing.T) {
-entry := ToolEntry{Name: "bash"}
-if entry.AlwaysOn {
-t.Error("expected AlwaysOn to default to false")
-}
+	entry := ToolEntry{Name: "bash"}
+	if entry.AlwaysOn {
+		t.Error("expected AlwaysOn to default to false")
+	}
 }
 
 func TestValidateToolEntry_WithAlwaysOn(t *testing.T) {
-entry := ToolEntry{Name: "bash", AlwaysOn: true}
-if err := validateToolEntry(entry, "test", 0); err != nil {
-t.Errorf("unexpected error for always_on tool: %v", err)
+	entry := ToolEntry{Name: "bash", AlwaysOn: true}
+	if err := validateToolEntry(entry, "test", 0); err != nil {
+		t.Errorf("unexpected error for always_on tool: %v", err)
+	}
 }
+
+func TestValidateToolEntry_InvalidType(t *testing.T) {
+	entry := ToolEntry{Name: "bad", Type: "unknown"}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for unknown tool type")
+	}
+}
+
+func TestValidateToolEntry_MCPMissingCommand(t *testing.T) {
+	entry := ToolEntry{Name: "azure", Type: "mcp"}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for missing MCP command")
+	}
+}
+
+func TestValidateToolEntry_SkillMissingPathOrRepo(t *testing.T) {
+	entry := ToolEntry{Name: "skill", Type: "skill", Source: "local"}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for missing skill path or repo")
+	}
+}
+
+func TestValidateToolEntry_SkillInvalidSource(t *testing.T) {
+	entry := ToolEntry{Name: "skill", Type: "skill", Source: "bad", Path: "./skills"}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for invalid skill source")
+	}
 }

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -642,12 +642,12 @@ func mergePromptProperties(p *prompt.Prompt) map[string]string {
 }
 
 func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir string, configDir string, promptProps map[string]string) *copilot.SessionConfig {
-	// Build skill directories from the new Generator.Skills list
+	// Build skill directories from generator tool entries.
 	var skillDirs []string
 	if cfg.Generator != nil {
-		for _, s := range cfg.Generator.Skills {
-			if s.Type == "local" && s.Path != "" {
-				skillDirs = append(skillDirs, s.Path)
+		for _, entry := range cfg.Generator.Tools {
+			if entry.ResolvedType() == "skill" && entry.SkillSource() == "local" && entry.Path != "" {
+				skillDirs = append(skillDirs, entry.Path)
 			}
 		}
 	}
@@ -656,7 +656,7 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 	// system prompt — all behavioral instructions belong in the config YAML.
 
 	sc := &copilot.SessionConfig{
-		Model: cfg.Generator.Model,
+		Model:               cfg.Generator.Model,
 		ConfigDir:           configDir,
 		WorkingDirectory:    workDir,
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
@@ -706,20 +706,22 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 		SkillDirectories: skillDirs,
 	}
 
-	// Resolve tools: new conditional format (generator.tools) takes precedence
-	// over legacy flat lists (generator.available_tools / excluded_tools).
+	// Resolve tools: conditional tool entries are filtered by prompt properties.
 	// An empty slice serializes as JSON [] which tells the CLI "zero tools" —
 	// nil serializes as null which means "all default tools available."
-	var availableTools []string
-	if len(cfg.Generator.Tools) > 0 {
-		availableTools = config.ResolveTools(cfg.Generator.Tools, promptProps)
+	var toolEntries []config.ToolEntry
+	for _, entry := range cfg.Generator.Tools {
+		if entry.ResolvedType() == "tool" {
+			toolEntries = append(toolEntries, entry)
+		}
+	}
+	availableTools := config.ResolveTools(toolEntries, promptProps)
+	if len(toolEntries) > 0 {
 		slog.Debug("Resolved conditional tools",
-			"entries", len(cfg.Generator.Tools),
+			"entries", len(toolEntries),
 			"matched", len(availableTools),
 			"tools", availableTools,
 			"properties", promptProps)
-	} else {
-		availableTools = cfg.Generator.AvailableTools
 	}
 	excludedTools := cfg.Generator.ExcludedTools
 	if len(availableTools) > 0 {
@@ -730,25 +732,30 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 	}
 
 	// Map MCP servers
-	mcpServers := cfg.Generator.MCPServers
-	if len(mcpServers) > 0 {
-		sc.MCPServers = make(map[string]copilot.MCPServerConfig, len(mcpServers))
-		for name, srv := range mcpServers {
+	var mcpEntries []config.ToolEntry
+	for _, entry := range cfg.Generator.Tools {
+		if entry.ResolvedType() == "mcp" {
+			mcpEntries = append(mcpEntries, entry)
+		}
+	}
+	if len(mcpEntries) > 0 {
+		sc.MCPServers = make(map[string]copilot.MCPServerConfig, len(mcpEntries))
+		for _, entry := range mcpEntries {
 			mcpCfg := copilot.MCPServerConfig{
-				"type":    srv.Type,
-				"command": srv.Command,
-				"args":    srv.Args,
+				"type":    "local",
+				"command": entry.Command,
+				"args":    entry.Args,
 			}
-			if len(srv.Tools) > 0 {
-				mcpCfg["tools"] = srv.Tools
+			if len(entry.MCPTools) > 0 {
+				mcpCfg["tools"] = entry.MCPTools
 			}
-			sc.MCPServers[name] = mcpCfg
+			sc.MCPServers[entry.Name] = mcpCfg
 			slog.Info("MCP server configured",
-				"name", name,
-				"type", srv.Type,
-				"command", srv.Command,
-				"args", srv.Args,
-				"tools", srv.Tools,
+				"name", entry.Name,
+				"type", "local",
+				"command", entry.Command,
+				"args", entry.Args,
+				"tools", entry.MCPTools,
 			)
 		}
 	} else {

--- a/hyoka/internal/eval/copilot_test.go
+++ b/hyoka/internal/eval/copilot_test.go
@@ -1,263 +1,241 @@
 package eval
 
 import (
-"testing"
+	"testing"
 
-"github.com/ronniegeraghty/hyoka/internal/config"
-"github.com/ronniegeraghty/hyoka/internal/prompt"
+	"github.com/ronniegeraghty/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/internal/prompt"
 )
 
-func TestBuildSessionConfig_EmptyAvailableToolsIsNil(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model:          "gpt-4",
-AvailableTools: []string{},
-ExcludedTools:  []string{},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if sc.AvailableTools != nil {
-t.Errorf("expected AvailableTools nil (all tools), got %v", sc.AvailableTools)
-}
-if sc.ExcludedTools != nil {
-t.Errorf("expected ExcludedTools nil (no exclusions), got %v", sc.ExcludedTools)
-}
+func TestBuildSessionConfig_EmptyToolsIsNil(t *testing.T) {
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model:         "gpt-4",
+			Tools:         []config.ToolEntry{},
+			ExcludedTools: []string{},
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if sc.AvailableTools != nil {
+		t.Errorf("expected AvailableTools nil (all tools), got %v", sc.AvailableTools)
+	}
+	if sc.ExcludedTools != nil {
+		t.Errorf("expected ExcludedTools nil (no exclusions), got %v", sc.ExcludedTools)
+	}
 }
 
 func TestBuildSessionConfig_NilAvailableToolsIsNil(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name:      "test",
-Generator: &config.GeneratorConfig{Model: "gpt-4"},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if sc.AvailableTools != nil {
-t.Errorf("expected AvailableTools nil, got %v", sc.AvailableTools)
-}
-if sc.ExcludedTools != nil {
-t.Errorf("expected ExcludedTools nil, got %v", sc.ExcludedTools)
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name:      "test",
+		Generator: &config.GeneratorConfig{Model: "gpt-4"},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if sc.AvailableTools != nil {
+		t.Errorf("expected AvailableTools nil, got %v", sc.AvailableTools)
+	}
+	if sc.ExcludedTools != nil {
+		t.Errorf("expected ExcludedTools nil, got %v", sc.ExcludedTools)
+	}
 }
 
 func TestBuildSessionConfig_PopulatedAvailableToolsPreserved(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model:          "gpt-4",
-AvailableTools: []string{"create", "edit", "bash"},
-ExcludedTools:  []string{"web_fetch"},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if len(sc.AvailableTools) != 3 {
-t.Errorf("expected 3 AvailableTools, got %d", len(sc.AvailableTools))
-}
-if len(sc.ExcludedTools) != 1 {
-t.Errorf("expected 1 ExcludedTools, got %d", len(sc.ExcludedTools))
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{Name: "create"},
+				{Name: "edit"},
+				{Name: "bash"},
+			},
+			ExcludedTools: []string{"web_fetch"},
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if len(sc.AvailableTools) != 3 {
+		t.Errorf("expected 3 AvailableTools, got %d", len(sc.AvailableTools))
+	}
+	if len(sc.ExcludedTools) != 1 {
+		t.Errorf("expected 1 ExcludedTools, got %d", len(sc.ExcludedTools))
+	}
 }
 
 func TestBuildSessionConfig_WorkingDirectory(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "", nil)
-if sc.WorkingDirectory != "/workspace/eval-123" {
-t.Errorf("expected WorkingDirectory '/workspace/eval-123', got %q", sc.WorkingDirectory)
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "", nil)
+	if sc.WorkingDirectory != "/workspace/eval-123" {
+		t.Errorf("expected WorkingDirectory '/workspace/eval-123', got %q", sc.WorkingDirectory)
+	}
 }
 
 func TestBuildSessionConfig_ConfigDir(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "/isolated/config", nil)
-if sc.ConfigDir != "/isolated/config" {
-t.Errorf("expected ConfigDir '/isolated/config', got %q", sc.ConfigDir)
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "/isolated/config", nil)
+	if sc.ConfigDir != "/isolated/config" {
+		t.Errorf("expected ConfigDir '/isolated/config', got %q", sc.ConfigDir)
+	}
 }
 
 func TestBuildSessionConfig_PermissionHandler(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if sc.OnPermissionRequest == nil {
-t.Error("expected OnPermissionRequest to be set (ApproveAll)")
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if sc.OnPermissionRequest == nil {
+		t.Error("expected OnPermissionRequest to be set (ApproveAll)")
+	}
 }
 
 func TestBuildSessionConfig_MCPServers(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model: "gpt-4",
-MCPServers: map[string]*config.MCPServer{
-"azure": {Type: "local", Command: "npx", Args: []string{"-y", "@azure/mcp@latest"}},
-},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if len(sc.MCPServers) != 1 {
-t.Errorf("expected 1 MCP server, got %d", len(sc.MCPServers))
-}
-azure, ok := sc.MCPServers["azure"]
-if !ok {
-t.Fatal("expected 'azure' MCP server")
-}
-if azure["command"] != "npx" {
-t.Errorf("expected MCP command 'npx', got %v", azure["command"])
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{
+					Name:    "azure",
+					Type:    "mcp",
+					Command: "npx",
+					Args:    []string{"-y", "@azure/mcp@latest"},
+				},
+			},
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if len(sc.MCPServers) != 1 {
+		t.Errorf("expected 1 MCP server, got %d", len(sc.MCPServers))
+	}
+	azure, ok := sc.MCPServers["azure"]
+	if !ok {
+		t.Fatal("expected 'azure' MCP server")
+	}
+	if azure["command"] != "npx" {
+		t.Errorf("expected MCP command 'npx', got %v", azure["command"])
+	}
 }
 
 // --- Tool filter resolution tests ---
 
 func TestBuildSessionConfig_ToolEntryResolution(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model: "gpt-4",
-Tools: []config.ToolEntry{
-{Name: "create"},
-{Name: "edit"},
-{Name: "azure_mcp", When: map[string]string{"language": "python"}},
-},
-},
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{Name: "create"},
+				{Name: "edit"},
+				{Name: "azure_mcp", When: map[string]string{"language": "python"}},
+			},
+		},
+	}
 
-// Python prompt should get all 3 tools
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python", "service": "identity"})
-if len(sc.AvailableTools) != 3 {
-t.Fatalf("expected 3 AvailableTools for python, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
-}
+	// Python prompt should get all 3 tools
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python", "service": "identity"})
+	if len(sc.AvailableTools) != 3 {
+		t.Fatalf("expected 3 AvailableTools for python, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
+	}
 
-// Dotnet prompt should get only 2 tools (azure_mcp excluded)
-sc = e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
-if len(sc.AvailableTools) != 2 {
-t.Fatalf("expected 2 AvailableTools for dotnet, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
-}
-for _, tool := range sc.AvailableTools {
-if tool == "azure_mcp" {
-t.Error("azure_mcp should not be included for dotnet")
-}
-}
-}
-
-func TestBuildSessionConfig_ToolEntryOverridesAvailableTools(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model:          "gpt-4",
-Tools:          []config.ToolEntry{{Name: "create"}},
-AvailableTools: []string{"create", "edit", "bash"},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if len(sc.AvailableTools) != 1 || sc.AvailableTools[0] != "create" {
-t.Errorf("expected Tools to override AvailableTools, got %v", sc.AvailableTools)
-}
-}
-
-func TestBuildSessionConfig_LegacyAvailableToolsFallback(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model:          "gpt-4",
-AvailableTools: []string{"create", "edit"},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python"})
-if len(sc.AvailableTools) != 2 {
-t.Errorf("expected legacy AvailableTools [create edit], got %v", sc.AvailableTools)
-}
+	// Dotnet prompt should get only 2 tools (azure_mcp excluded)
+	sc = e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
+	if len(sc.AvailableTools) != 2 {
+		t.Fatalf("expected 2 AvailableTools for dotnet, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
+	}
+	for _, tool := range sc.AvailableTools {
+		if tool == "azure_mcp" {
+			t.Error("azure_mcp should not be included for dotnet")
+		}
+	}
 }
 
 func TestBuildSessionConfig_ToolEntryAllConditionalNoneMatch(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model: "gpt-4",
-Tools: []config.ToolEntry{
-{Name: "azure_mcp", When: map[string]string{"language": "python"}},
-},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
-if sc.AvailableTools != nil {
-t.Errorf("expected nil AvailableTools when no tools match, got %v", sc.AvailableTools)
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{Name: "azure_mcp", When: map[string]string{"language": "python"}},
+			},
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
+	if sc.AvailableTools != nil {
+		t.Errorf("expected nil AvailableTools when no tools match, got %v", sc.AvailableTools)
+	}
 }
 
 func TestBuildSessionConfig_ExcludedToolsWithToolEntries(t *testing.T) {
-e := &CopilotSDKEvaluator{}
-cfg := &config.ToolConfig{
-Name: "test",
-Generator: &config.GeneratorConfig{
-Model:         "gpt-4",
-Tools:         []config.ToolEntry{{Name: "create"}, {Name: "edit"}},
-ExcludedTools: []string{"web_fetch"},
-},
-}
-sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
-if len(sc.AvailableTools) != 2 {
-t.Errorf("expected 2 AvailableTools, got %d", len(sc.AvailableTools))
-}
-if len(sc.ExcludedTools) != 1 || sc.ExcludedTools[0] != "web_fetch" {
-t.Errorf("expected ExcludedTools [web_fetch], got %v", sc.ExcludedTools)
-}
+	e := &CopilotSDKEvaluator{}
+	cfg := &config.ToolConfig{
+		Name: "test",
+		Generator: &config.GeneratorConfig{
+			Model:         "gpt-4",
+			Tools:         []config.ToolEntry{{Name: "create"}, {Name: "edit"}},
+			ExcludedTools: []string{"web_fetch"},
+		},
+	}
+	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	if len(sc.AvailableTools) != 2 {
+		t.Errorf("expected 2 AvailableTools, got %d", len(sc.AvailableTools))
+	}
+	if len(sc.ExcludedTools) != 1 || sc.ExcludedTools[0] != "web_fetch" {
+		t.Errorf("expected ExcludedTools [web_fetch], got %v", sc.ExcludedTools)
+	}
 }
 
 func TestMergePromptProperties(t *testing.T) {
-tests := []struct {
-name string
-p    *prompt.Prompt
-want map[string]string
-}{
-{
-name: "all fields populated",
-p: &prompt.Prompt{
-Properties: map[string]string{
-"service": "identity", "language": "python", "plane": "data-plane",
-"category": "auth", "difficulty": "medium",
-},
-},
-want: map[string]string{
-"service": "identity", "language": "python", "plane": "data-plane",
-"category": "auth", "difficulty": "medium",
-},
-},
-{
-name: "partial fields",
-p: &prompt.Prompt{Properties: map[string]string{"service": "storage", "language": "dotnet"}},
-want: map[string]string{"service": "storage", "language": "dotnet"},
-},
-{
-name: "empty prompt",
-p:    &prompt.Prompt{},
-want: map[string]string{},
-},
-}
+	tests := []struct {
+		name string
+		p    *prompt.Prompt
+		want map[string]string
+	}{
+		{
+			name: "all fields populated",
+			p: &prompt.Prompt{
+				Properties: map[string]string{
+					"service": "identity", "language": "python", "plane": "data-plane",
+					"category": "auth", "difficulty": "medium",
+				},
+			},
+			want: map[string]string{
+				"service": "identity", "language": "python", "plane": "data-plane",
+				"category": "auth", "difficulty": "medium",
+			},
+		},
+		{
+			name: "partial fields",
+			p:    &prompt.Prompt{Properties: map[string]string{"service": "storage", "language": "dotnet"}},
+			want: map[string]string{"service": "storage", "language": "dotnet"},
+		},
+		{
+			name: "empty prompt",
+			p:    &prompt.Prompt{},
+			want: map[string]string{},
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-got := mergePromptProperties(tt.p)
-for k, v := range tt.want {
-if got[k] != v {
-t.Errorf("key %q: got %q, want %q", k, got[k], v)
-}
-}
-for k := range got {
-if _, ok := tt.want[k]; !ok {
-t.Errorf("unexpected key %q=%q in merged properties", k, got[k])
-}
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergePromptProperties(tt.p)
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+			for k := range got {
+				if _, ok := tt.want[k]; !ok {
+					t.Errorf("unexpected key %q=%q in merged properties", k, got[k])
+				}
+			}
+		})
+	}
 }
 
 func TestBuildSessionConfig_CustomSystemPrompt(t *testing.T) {
@@ -325,34 +303,34 @@ configs:
 	cfg := &cf.Configs[0]
 
 	tests := []struct {
-		name          string
-		prompt        *prompt.Prompt
-		wantAvail     []string
-		wantExcluded  []string
+		name         string
+		prompt       *prompt.Prompt
+		wantAvail    []string
+		wantExcluded []string
 	}{
 		{
-			name:          "python prompt gets azure_mcp",
-			prompt:        &prompt.Prompt{Properties: map[string]string{"language": "python", "service": "identity"}},
-			wantAvail:     []string{"create", "edit", "azure_mcp"},
-			wantExcluded:  []string{"web_fetch"},
+			name:         "python prompt gets azure_mcp",
+			prompt:       &prompt.Prompt{Properties: map[string]string{"language": "python", "service": "identity"}},
+			wantAvail:    []string{"create", "edit", "azure_mcp"},
+			wantExcluded: []string{"web_fetch"},
 		},
 		{
-			name:          "dotnet+identity prompt gets dotnet_tools",
-			prompt:        &prompt.Prompt{Properties: map[string]string{"language": "dotnet", "service": "identity"}},
-			wantAvail:     []string{"create", "edit", "dotnet_tools"},
-			wantExcluded:  []string{"web_fetch"},
+			name:         "dotnet+identity prompt gets dotnet_tools",
+			prompt:       &prompt.Prompt{Properties: map[string]string{"language": "dotnet", "service": "identity"}},
+			wantAvail:    []string{"create", "edit", "dotnet_tools"},
+			wantExcluded: []string{"web_fetch"},
 		},
 		{
-			name:          "dotnet+storage prompt gets only unconditional",
-			prompt:        &prompt.Prompt{Properties: map[string]string{"language": "dotnet", "service": "storage"}},
-			wantAvail:     []string{"create", "edit"},
-			wantExcluded:  []string{"web_fetch"},
+			name:         "dotnet+storage prompt gets only unconditional",
+			prompt:       &prompt.Prompt{Properties: map[string]string{"language": "dotnet", "service": "storage"}},
+			wantAvail:    []string{"create", "edit"},
+			wantExcluded: []string{"web_fetch"},
 		},
 		{
-			name:          "go prompt gets only unconditional",
-			prompt:        &prompt.Prompt{Properties: map[string]string{"language": "go", "service": "key-vault"}},
-			wantAvail:     []string{"create", "edit"},
-			wantExcluded:  []string{"web_fetch"},
+			name:         "go prompt gets only unconditional",
+			prompt:       &prompt.Prompt{Properties: map[string]string{"language": "go", "service": "key-vault"}},
+			wantAvail:    []string{"create", "edit"},
+			wantExcluded: []string{"web_fetch"},
 		},
 	}
 
@@ -380,38 +358,6 @@ configs:
 				}
 			}
 		})
-	}
-}
-
-func TestIntegration_LegacyYAMLFallback(t *testing.T) {
-	yamlData := `
-configs:
-  - name: legacy-test
-    description: "Legacy format test"
-    generator:
-      model: gpt-4
-      available_tools:
-        - create
-        - edit
-        - bash
-      excluded_tools:
-        - web_fetch
-`
-	cf, err := config.Parse([]byte(yamlData))
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
-	cfg := &cf.Configs[0]
-
-	e := &CopilotSDKEvaluator{}
-	props := mergePromptProperties(&prompt.Prompt{Properties: map[string]string{"language": "python", "service": "identity"}})
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", props)
-
-	if len(sc.AvailableTools) != 3 {
-		t.Fatalf("expected 3 AvailableTools from legacy format, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
-	}
-	if len(sc.ExcludedTools) != 1 || sc.ExcludedTools[0] != "web_fetch" {
-		t.Errorf("expected ExcludedTools [web_fetch], got %v", sc.ExcludedTools)
 	}
 }
 

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -25,16 +25,16 @@ import (
 
 // EvalResult holds the raw output from a Copilot evaluation.
 type EvalResult struct {
-	GeneratedFiles  []string
-	EventCount      int
-	ToolCalls       []string
-	SessionEvents   []report.SessionEventRecord
-	ActionTimeline  *ActionTimeline
-	Success         bool
-	Error           string
-	ErrorDetails    string
-	IsStub          bool
-	StarterFiles    []string
+	GeneratedFiles []string
+	EventCount     int
+	ToolCalls      []string
+	SessionEvents  []report.SessionEventRecord
+	ActionTimeline *ActionTimeline
+	Success        bool
+	Error          string
+	ErrorDetails   string
+	IsStub         bool
+	StarterFiles   []string
 }
 
 // CopilotEvaluator defines the interface for running evaluations.
@@ -589,7 +589,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		SchemaVersion: report.CurrentSchemaVersion,
 		PromptID:      task.Prompt.ID,
 		ConfigName:    task.Config.Name,
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Timestamp:     time.Now().UTC().Format(time.RFC3339),
 		PromptMeta: map[string]any{
 			"service":     task.Prompt.Service(),
 			"plane":       task.Prompt.Plane(),
@@ -804,19 +804,20 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Populate environment info from config and captured events
 	var skillDirectories []string
 	if task.Config.Generator != nil {
-		for _, s := range task.Config.Generator.Skills {
-			if s.Type == "local" && s.Path != "" {
-				skillDirectories = append(skillDirectories, s.Path)
+		for _, entry := range task.Config.Generator.Tools {
+			if entry.ResolvedType() == "skill" && entry.SkillSource() == "local" && entry.Path != "" {
+				skillDirectories = append(skillDirectories, entry.Path)
 			}
 		}
 	}
 	// Resolve tools for reporting — mirrors the resolution in buildSessionConfig.
-	var reportAvailableTools []string
-	if len(task.Config.Generator.Tools) > 0 {
-		reportAvailableTools = config.ResolveTools(task.Config.Generator.Tools, mergePromptProperties(task.Prompt))
-	} else {
-		reportAvailableTools = task.Config.Generator.AvailableTools
+	var toolEntries []config.ToolEntry
+	for _, entry := range task.Config.Generator.Tools {
+		if entry.ResolvedType() == "tool" {
+			toolEntries = append(toolEntries, entry)
+		}
 	}
+	reportAvailableTools := config.ResolveTools(toolEntries, mergePromptProperties(task.Prompt))
 	env := &report.EnvironmentInfo{
 		Model:            task.Config.Generator.Model,
 		SkillDirectories: skillDirectories,
@@ -827,8 +828,10 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		WorkingDirectory: ws.Dir,
 	}
 	// Extract MCP server names
-	for name := range task.Config.Generator.MCPServers {
-		env.MCPServers = append(env.MCPServers, name)
+	for _, entry := range task.Config.Generator.Tools {
+		if entry.ResolvedType() == "mcp" {
+			env.MCPServers = append(env.MCPServers, entry.Name)
+		}
 	}
 	// Derive token usage, turn count, truncation, skills from events
 	for _, ev := range evalReport.SessionEvents {
@@ -858,30 +861,38 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		StarterFiles: evalReport.StarterFiles,
 	}
 	// Record configured MCP servers with details.
-	for name, srv := range task.Config.Generator.MCPServers {
-		details := srv.Command
-		if len(srv.Args) > 0 {
-			details += " " + strings.Join(srv.Args, " ")
+	for _, entry := range task.Config.Generator.Tools {
+		if entry.ResolvedType() != "mcp" {
+			continue
+		}
+		details := entry.Command
+		if len(entry.Args) > 0 {
+			details += " " + strings.Join(entry.Args, " ")
 		}
 		setup.MCPServers = append(setup.MCPServers, report.ToolLoadResult{
-			Name:    name,
+			Name:    entry.Name,
 			Status:  "configured",
 			Details: details,
 		})
 	}
 	// Record configured skills with details.
-	for _, s := range task.Config.Generator.Skills {
-		name := s.Name
-		if name == "" {
-			name = s.Path
+	for _, entry := range task.Config.Generator.Tools {
+		if entry.ResolvedType() != "skill" {
+			continue
 		}
+		name := entry.Name
 		if name == "" {
-			name = s.Repo
+			if entry.Path != "" {
+				name = entry.Path
+			} else {
+				name = entry.Repo
+			}
 		}
+		details := entry.SkillSource()
 		setup.Skills = append(setup.Skills, report.ToolLoadResult{
 			Name:    name,
 			Status:  "configured",
-			Details: s.Type,
+			Details: details,
 		})
 	}
 	// Determine system prompt status.
@@ -1017,22 +1028,22 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 							rr.PromptDetails = &report.PromptGraderDetail{
 								Model: r.PromptDetails.Model, Rubric: r.PromptDetails.Rubric,
 								Reasoning: r.PromptDetails.Reasoning,
-								RawScore: r.PromptDetails.RawScore, MaxScore: r.PromptDetails.MaxScore,
+								RawScore:  r.PromptDetails.RawScore, MaxScore: r.PromptDetails.MaxScore,
 							}
 						}
 						if r.BehaviorDetails != nil {
 							rr.BehaviorDetails = &report.BehaviorGraderDetail{
 								ToolsUsed: r.BehaviorDetails.ToolsUsed, MissingTools: r.BehaviorDetails.MissingTools,
 								ForbiddenUsed: r.BehaviorDetails.ForbiddenUsed,
-								TurnCount: r.BehaviorDetails.TurnCount, MaxTurns: r.BehaviorDetails.MaxTurns,
+								TurnCount:     r.BehaviorDetails.TurnCount, MaxTurns: r.BehaviorDetails.MaxTurns,
 								ActualTurns: r.BehaviorDetails.ActualTurns, TotalActions: r.BehaviorDetails.TotalActions,
 								TurnLimitHit: r.BehaviorDetails.TurnLimitHit, Violations: r.BehaviorDetails.Violations,
-								SequenceMatch: r.BehaviorDetails.SequenceMatch,
+								SequenceMatch:    r.BehaviorDetails.SequenceMatch,
 								ExpectedSequence: r.BehaviorDetails.ExpectedSequence,
-								ActualSequence: r.BehaviorDetails.ActualSequence,
-								MatchedActions: r.BehaviorDetails.MatchedActions,
-								ConstraintsMet: r.BehaviorDetails.ConstraintsMet,
-								ToolCounts: r.BehaviorDetails.ToolCounts,
+								ActualSequence:   r.BehaviorDetails.ActualSequence,
+								MatchedActions:   r.BehaviorDetails.MatchedActions,
+								ConstraintsMet:   r.BehaviorDetails.ConstraintsMet,
+								ToolCounts:       r.BehaviorDetails.ToolCounts,
 							}
 						}
 						reportResults[i] = rr

--- a/hyoka/internal/pairwise/pairwise.go
+++ b/hyoka/internal/pairwise/pairwise.go
@@ -16,8 +16,7 @@ import (
 //   - Variant 1..N: each disables one togglable tool, named "{base}/without-{tool}"
 //
 // Tools with AlwaysOn: true in Generator.Tools are never toggled.
-// Both Generator.Tools ([]ToolEntry) and Generator.AvailableTools ([]string)
-// are considered; duplicates across the two lists are unified.
+// Only ToolEntry values with type "tool" are considered.
 func ExpandPairwise(base config.ToolConfig) []config.ToolConfig {
 	togglable := collectTogglable(base)
 
@@ -40,7 +39,6 @@ func ExpandPairwise(base config.ToolConfig) []config.ToolConfig {
 }
 
 // collectTogglable returns deduplicated tool names eligible for toggling.
-// Order: ToolEntry names first (preserving order), then AvailableTools.
 func collectTogglable(cfg config.ToolConfig) []string {
 	if cfg.Generator == nil {
 		return nil
@@ -50,26 +48,17 @@ func collectTogglable(cfg config.ToolConfig) []string {
 	var tools []string
 
 	for _, te := range cfg.Generator.Tools {
-		if te.AlwaysOn || seen[te.Name] {
+		if te.ResolvedType() != "tool" || te.AlwaysOn || seen[te.Name] {
 			continue
 		}
 		seen[te.Name] = true
 		tools = append(tools, te.Name)
 	}
 
-	for _, name := range cfg.Generator.AvailableTools {
-		if seen[name] {
-			continue
-		}
-		seen[name] = true
-		tools = append(tools, name)
-	}
-
 	return tools
 }
 
-// removeTool removes a named tool from both Generator.Tools and
-// Generator.AvailableTools in the given config.
+// removeTool removes a named tool from Generator.Tools in the given config.
 func removeTool(cfg *config.ToolConfig, name string) {
 	if cfg.Generator == nil {
 		return
@@ -77,19 +66,11 @@ func removeTool(cfg *config.ToolConfig, name string) {
 
 	var tools []config.ToolEntry
 	for _, te := range cfg.Generator.Tools {
-		if te.Name != name {
+		if te.ResolvedType() != "tool" || te.Name != name {
 			tools = append(tools, te)
 		}
 	}
 	cfg.Generator.Tools = tools
-
-	var avail []string
-	for _, t := range cfg.Generator.AvailableTools {
-		if t != name {
-			avail = append(avail, t)
-		}
-	}
-	cfg.Generator.AvailableTools = avail
 }
 
 // cloneToolConfig returns a deep copy of a ToolConfig so mutations to the
@@ -99,11 +80,6 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 
 	if src.Generator != nil {
 		gen := *src.Generator
-
-		if len(src.Generator.Skills) > 0 {
-			gen.Skills = make([]config.Skill, len(src.Generator.Skills))
-			copy(gen.Skills, src.Generator.Skills)
-		}
 
 		if len(src.Generator.Tools) > 0 {
 			gen.Tools = make([]config.ToolEntry, len(src.Generator.Tools))
@@ -116,12 +92,17 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 					}
 					gen.Tools[i].When = m
 				}
+				if te.Args != nil {
+					args := make([]string, len(te.Args))
+					copy(args, te.Args)
+					gen.Tools[i].Args = args
+				}
+				if te.MCPTools != nil {
+					tools := make([]string, len(te.MCPTools))
+					copy(tools, te.MCPTools)
+					gen.Tools[i].MCPTools = tools
+				}
 			}
-		}
-
-		if len(src.Generator.AvailableTools) > 0 {
-			gen.AvailableTools = make([]string, len(src.Generator.AvailableTools))
-			copy(gen.AvailableTools, src.Generator.AvailableTools)
 		}
 
 		if len(src.Generator.ExcludedTools) > 0 {
@@ -129,30 +110,33 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 			copy(gen.ExcludedTools, src.Generator.ExcludedTools)
 		}
 
-		if len(src.Generator.MCPServers) > 0 {
-			gen.MCPServers = make(map[string]*config.MCPServer, len(src.Generator.MCPServers))
-			for k, v := range src.Generator.MCPServers {
-				srv := *v
-				if len(v.Args) > 0 {
-					srv.Args = make([]string, len(v.Args))
-					copy(srv.Args, v.Args)
-				}
-				if len(v.Tools) > 0 {
-					srv.Tools = make([]string, len(v.Tools))
-					copy(srv.Tools, v.Tools)
-				}
-				gen.MCPServers[k] = &srv
-			}
-		}
-
 		dst.Generator = &gen
 	}
 
 	if src.Reviewer != nil {
 		rev := *src.Reviewer
-		if len(src.Reviewer.Skills) > 0 {
-			rev.Skills = make([]config.Skill, len(src.Reviewer.Skills))
-			copy(rev.Skills, src.Reviewer.Skills)
+		if len(src.Reviewer.Tools) > 0 {
+			rev.Tools = make([]config.ToolEntry, len(src.Reviewer.Tools))
+			copy(rev.Tools, src.Reviewer.Tools)
+			for i, te := range rev.Tools {
+				if te.When != nil {
+					m := make(map[string]string, len(te.When))
+					for k, v := range te.When {
+						m[k] = v
+					}
+					rev.Tools[i].When = m
+				}
+				if te.Args != nil {
+					args := make([]string, len(te.Args))
+					copy(args, te.Args)
+					rev.Tools[i].Args = args
+				}
+				if te.MCPTools != nil {
+					tools := make([]string, len(te.MCPTools))
+					copy(tools, te.MCPTools)
+					rev.Tools[i].MCPTools = tools
+				}
+			}
 		}
 		if len(src.Reviewer.Models) > 0 {
 			rev.Models = make([]string, len(src.Reviewer.Models))
@@ -171,135 +155,135 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 
 // VariantResult holds the evaluation outcome for a single pairwise variant.
 type VariantResult struct {
-ConfigName  string `json:"config_name"`
-RemovedTool string `json:"removed_tool,omitempty"`
-Score       int    `json:"score"`
-MaxScore    int    `json:"max_score"`
-Success     bool   `json:"success"`
+	ConfigName  string `json:"config_name"`
+	RemovedTool string `json:"removed_tool,omitempty"`
+	Score       int    `json:"score"`
+	MaxScore    int    `json:"max_score"`
+	Success     bool   `json:"success"`
 }
 
 // ToolImpact holds the computed impact of a single tool.
 type ToolImpact struct {
-ToolName      string  `json:"tool_name"`
-Impact        float64 `json:"impact"`
-BaselineScore float64 `json:"baseline_score"`
-WithoutScore  float64 `json:"without_score"`
-BaselinePass  bool    `json:"baseline_pass"`
-WithoutPass   bool    `json:"without_pass"`
+	ToolName      string  `json:"tool_name"`
+	Impact        float64 `json:"impact"`
+	BaselineScore float64 `json:"baseline_score"`
+	WithoutScore  float64 `json:"without_score"`
+	BaselinePass  bool    `json:"baseline_pass"`
+	WithoutPass   bool    `json:"without_pass"`
 }
 
 // PairwiseReport holds the complete pairwise comparison results for a prompt.
 type PairwiseReport struct {
-PromptID string          `json:"prompt_id"`
-Baseline VariantResult   `json:"baseline"`
-Variants []VariantResult `json:"variants"`
-Impacts  []ToolImpact    `json:"impacts"`
+	PromptID string          `json:"prompt_id"`
+	Baseline VariantResult   `json:"baseline"`
+	Variants []VariantResult `json:"variants"`
+	Impacts  []ToolImpact    `json:"impacts"`
 }
 
 // normalizeScore converts a raw score/maxScore pair to a 0-100 scale.
 func normalizeScore(score, maxScore int) float64 {
-if maxScore <= 0 {
-return 0
-}
-return math.Round(float64(score)/float64(maxScore)*1000) / 10
+	if maxScore <= 0 {
+		return 0
+	}
+	return math.Round(float64(score)/float64(maxScore)*1000) / 10
 }
 
 // ComputeImpacts calculates per-tool impact from a baseline and a set of variants.
 func ComputeImpacts(promptID string, results []VariantResult) (*PairwiseReport, error) {
-var baseline *VariantResult
-var variants []VariantResult
+	var baseline *VariantResult
+	var variants []VariantResult
 
-for i := range results {
-if results[i].RemovedTool == "" {
-baseline = &results[i]
-} else {
-variants = append(variants, results[i])
-}
-}
+	for i := range results {
+		if results[i].RemovedTool == "" {
+			baseline = &results[i]
+		} else {
+			variants = append(variants, results[i])
+		}
+	}
 
-if baseline == nil {
-return nil, fmt.Errorf("pairwise: no baseline found for prompt %s", promptID)
-}
+	if baseline == nil {
+		return nil, fmt.Errorf("pairwise: no baseline found for prompt %s", promptID)
+	}
 
-baselineNorm := normalizeScore(baseline.Score, baseline.MaxScore)
+	baselineNorm := normalizeScore(baseline.Score, baseline.MaxScore)
 
-impacts := make([]ToolImpact, 0, len(variants))
-for _, v := range variants {
-withoutNorm := normalizeScore(v.Score, v.MaxScore)
-impacts = append(impacts, ToolImpact{
-ToolName:      v.RemovedTool,
-Impact:        math.Round((baselineNorm-withoutNorm)*10) / 10,
-BaselineScore: baselineNorm,
-WithoutScore:  withoutNorm,
-BaselinePass:  baseline.Success,
-WithoutPass:   v.Success,
-})
-}
+	impacts := make([]ToolImpact, 0, len(variants))
+	for _, v := range variants {
+		withoutNorm := normalizeScore(v.Score, v.MaxScore)
+		impacts = append(impacts, ToolImpact{
+			ToolName:      v.RemovedTool,
+			Impact:        math.Round((baselineNorm-withoutNorm)*10) / 10,
+			BaselineScore: baselineNorm,
+			WithoutScore:  withoutNorm,
+			BaselinePass:  baseline.Success,
+			WithoutPass:   v.Success,
+		})
+	}
 
-SortByImpact(impacts)
+	SortByImpact(impacts)
 
-return &PairwiseReport{
-PromptID: promptID,
-Baseline: *baseline,
-Variants: variants,
-Impacts:  impacts,
-}, nil
+	return &PairwiseReport{
+		PromptID: promptID,
+		Baseline: *baseline,
+		Variants: variants,
+		Impacts:  impacts,
+	}, nil
 }
 
 // SortByImpact sorts impacts by impact score descending.
 func SortByImpact(impacts []ToolImpact) {
-sort.Slice(impacts, func(i, j int) bool {
-if impacts[i].Impact != impacts[j].Impact {
-return impacts[i].Impact > impacts[j].Impact
-}
-return impacts[i].ToolName < impacts[j].ToolName
-})
+	sort.Slice(impacts, func(i, j int) bool {
+		if impacts[i].Impact != impacts[j].Impact {
+			return impacts[i].Impact > impacts[j].Impact
+		}
+		return impacts[i].ToolName < impacts[j].ToolName
+	})
 }
 
 // AggregateImpacts merges impacts from multiple prompts into a single per-tool summary.
 func AggregateImpacts(reports []*PairwiseReport) []ToolImpact {
-type accum struct {
-totalImpact   float64
-totalBaseline float64
-totalWithout  float64
-count         int
-baselinePass  int
-withoutPass   int
-}
+	type accum struct {
+		totalImpact   float64
+		totalBaseline float64
+		totalWithout  float64
+		count         int
+		baselinePass  int
+		withoutPass   int
+	}
 
-byTool := make(map[string]*accum)
-for _, r := range reports {
-for _, imp := range r.Impacts {
-a, ok := byTool[imp.ToolName]
-if !ok {
-a = &accum{}
-byTool[imp.ToolName] = a
-}
-a.totalImpact += imp.Impact
-a.totalBaseline += imp.BaselineScore
-a.totalWithout += imp.WithoutScore
-a.count++
-if imp.BaselinePass {
-a.baselinePass++
-}
-if imp.WithoutPass {
-a.withoutPass++
-}
-}
-}
+	byTool := make(map[string]*accum)
+	for _, r := range reports {
+		for _, imp := range r.Impacts {
+			a, ok := byTool[imp.ToolName]
+			if !ok {
+				a = &accum{}
+				byTool[imp.ToolName] = a
+			}
+			a.totalImpact += imp.Impact
+			a.totalBaseline += imp.BaselineScore
+			a.totalWithout += imp.WithoutScore
+			a.count++
+			if imp.BaselinePass {
+				a.baselinePass++
+			}
+			if imp.WithoutPass {
+				a.withoutPass++
+			}
+		}
+	}
 
-result := make([]ToolImpact, 0, len(byTool))
-for tool, a := range byTool {
-result = append(result, ToolImpact{
-ToolName:      tool,
-Impact:        math.Round(a.totalImpact/float64(a.count)*10) / 10,
-BaselineScore: math.Round(a.totalBaseline/float64(a.count)*10) / 10,
-WithoutScore:  math.Round(a.totalWithout/float64(a.count)*10) / 10,
-BaselinePass:  a.baselinePass == a.count,
-WithoutPass:   a.withoutPass == a.count,
-})
-}
+	result := make([]ToolImpact, 0, len(byTool))
+	for tool, a := range byTool {
+		result = append(result, ToolImpact{
+			ToolName:      tool,
+			Impact:        math.Round(a.totalImpact/float64(a.count)*10) / 10,
+			BaselineScore: math.Round(a.totalBaseline/float64(a.count)*10) / 10,
+			WithoutScore:  math.Round(a.totalWithout/float64(a.count)*10) / 10,
+			BaselinePass:  a.baselinePass == a.count,
+			WithoutPass:   a.withoutPass == a.count,
+		})
+	}
 
-SortByImpact(result)
-return result
+	SortByImpact(result)
+	return result
 }

--- a/hyoka/internal/plugin/plugin.go
+++ b/hyoka/internal/plugin/plugin.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ronniegeraghty/hyoka/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,7 +26,7 @@ type Plugin struct {
 	Source      string                `yaml:"-" json:"source,omitempty"` // file path
 }
 
-// PluginSkill is the same as config.Skill but defined here to avoid import cycles.
+// PluginSkill mirrors the skill fields supported in plugin definitions.
 type PluginSkill struct {
 	Type string `yaml:"type" json:"type"`
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
@@ -143,37 +144,57 @@ func (r *Registry) Count() int {
 }
 
 // ApplyToGenerator resolves plugin names and merges their skills and MCP
-// servers into the generator's existing configuration. Duplicate skills and
-// MCP servers are skipped.
-func (r *Registry) ApplyToGenerator(pluginNames []string, skills *[]PluginSkill, mcpServers *map[string]*MCPServer) error {
+// servers into the generator's existing configuration. Duplicate entries
+// are skipped.
+func (r *Registry) ApplyToGenerator(pluginNames []string, tools *[]config.ToolEntry) error {
 	for _, name := range pluginNames {
 		p, err := r.Get(name)
 		if err != nil {
 			return err
 		}
 		for _, s := range p.Skills {
-			if !containsSkill(*skills, s) {
-				*skills = append(*skills, s)
+			entry := toolEntryFromPluginSkill(s)
+			if !containsToolEntry(*tools, entry) {
+				*tools = append(*tools, entry)
 			}
 		}
-		if len(p.MCPServers) > 0 {
-			if *mcpServers == nil {
-				*mcpServers = make(map[string]*MCPServer)
+		for k, v := range p.MCPServers {
+			entry := config.ToolEntry{
+				Name:     k,
+				Type:     "mcp",
+				Command:  v.Command,
+				Args:     v.Args,
+				MCPTools: v.Tools,
 			}
-			for k, v := range p.MCPServers {
-				if _, exists := (*mcpServers)[k]; !exists {
-					(*mcpServers)[k] = v
-				}
+			if !containsToolEntry(*tools, entry) {
+				*tools = append(*tools, entry)
 			}
 		}
 	}
 	return nil
 }
 
-func containsSkill(skills []PluginSkill, s PluginSkill) bool {
-	for _, existing := range skills {
-		if existing.Type == s.Type && existing.Name == s.Name &&
-			existing.Repo == s.Repo && existing.Path == s.Path {
+func toolEntryFromPluginSkill(s PluginSkill) config.ToolEntry {
+	name := s.Name
+	if name == "" {
+		if s.Path != "" {
+			name = s.Path
+		} else {
+			name = s.Repo
+		}
+	}
+	return config.ToolEntry{
+		Name:   name,
+		Type:   "skill",
+		Source: s.Type,
+		Path:   s.Path,
+		Repo:   s.Repo,
+	}
+}
+
+func containsToolEntry(tools []config.ToolEntry, entry config.ToolEntry) bool {
+	for _, existing := range tools {
+		if existing.ResolvedType() == entry.ResolvedType() && existing.Name == entry.Name {
 			return true
 		}
 	}

--- a/hyoka/internal/plugin/plugin_test.go
+++ b/hyoka/internal/plugin/plugin_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
 )
 
 func TestMain(m *testing.M) {
@@ -196,20 +198,23 @@ func TestApplyToGenerator(t *testing.T) {
 		},
 	}
 
-	var skills []PluginSkill
-	mcpServers := map[string]*MCPServer{}
+	var tools []config.ToolEntry
 
-	err := reg.ApplyToGenerator([]string{"sdk-tools", "review-helpers"}, &skills, &mcpServers)
+	err := reg.ApplyToGenerator([]string{"sdk-tools", "review-helpers"}, &tools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(skills) != 3 {
-		t.Errorf("expected 3 skills, got %d", len(skills))
+	if len(tools) != 4 {
+		t.Errorf("expected 4 tools, got %d", len(tools))
 	}
-	if len(mcpServers) != 1 {
-		t.Errorf("expected 1 MCP server, got %d", len(mcpServers))
+	foundMCP := false
+	for _, entry := range tools {
+		if entry.ResolvedType() == "mcp" && entry.Name == "azure-cli" {
+			foundMCP = true
+			break
+		}
 	}
-	if _, ok := mcpServers["azure-cli"]; !ok {
+	if !foundMCP {
 		t.Error("expected azure-cli MCP server")
 	}
 }
@@ -231,27 +236,22 @@ func TestApplyToGeneratorDedup(t *testing.T) {
 		},
 	}
 
-	var skills []PluginSkill
-	mcpServers := map[string]*MCPServer{}
+	var tools []config.ToolEntry
 
-	err := reg.ApplyToGenerator([]string{"a", "b"}, &skills, &mcpServers)
+	err := reg.ApplyToGenerator([]string{"a", "b"}, &tools)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(skills) != 1 {
-		t.Errorf("expected 1 deduplicated skill, got %d", len(skills))
-	}
-	if len(mcpServers) != 1 {
-		t.Errorf("expected 1 deduplicated MCP server, got %d", len(mcpServers))
+	if len(tools) != 2 {
+		t.Errorf("expected 2 deduplicated tools, got %d", len(tools))
 	}
 }
 
 func TestApplyToGeneratorNotFound(t *testing.T) {
 	reg := NewRegistry()
-	var skills []PluginSkill
-	mcpServers := map[string]*MCPServer{}
+	var tools []config.ToolEntry
 
-	err := reg.ApplyToGenerator([]string{"nonexistent"}, &skills, &mcpServers)
+	err := reg.ApplyToGenerator([]string{"nonexistent"}, &tools)
 	if err == nil {
 		t.Fatal("expected error for missing plugin")
 	}

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -13,31 +13,34 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/config"
 )
 
-// ResolveSkillDirs takes a list of Skill entries and resolves them to
+// ResolveSkillDirs takes a list of tool entries and resolves the skill entries to
 // absolute directory paths. The baseDir is used as the root for resolving
 // relative local paths.
 //
-//   - type: local  → resolves path (supports glob patterns like "./skills/generator/*")
-//   - type: remote → fetches from GitHub repo via "npx skills add", returns the install dir
-func ResolveSkillDirs(skills []config.Skill, baseDir string) ([]string, error) {
+//   - source: local  → resolves path (supports glob patterns like "./skills/generator/*")
+//   - source: remote → fetches from GitHub repo via "npx skills add", returns the install dir
+func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, error) {
 	var dirs []string
-	for _, s := range skills {
-		switch s.Type {
+	for _, entry := range entries {
+		if entry.ResolvedType() != "skill" {
+			continue
+		}
+		switch entry.SkillSource() {
 		case "local":
-			resolved, err := resolveLocal(s.Path, baseDir)
+			resolved, err := resolveLocal(entry.Path, baseDir)
 			if err != nil {
-				return nil, fmt.Errorf("resolving local skill %q: %w", s.Path, err)
+				return nil, fmt.Errorf("resolving local skill %q: %w", entry.Path, err)
 			}
-			slog.Debug("Resolved local skill", "path", s.Path, "resolved_count", len(resolved))
+			slog.Debug("Resolved local skill", "path", entry.Path, "resolved_count", len(resolved))
 			dirs = append(dirs, resolved...)
 		case "remote":
-			dir, err := fetchRemote(s, baseDir)
+			dir, err := fetchRemote(entry, baseDir)
 			if err != nil {
-				return nil, fmt.Errorf("fetching remote skill %s/%s: %w", s.Repo, s.Name, err)
+				return nil, fmt.Errorf("fetching remote skill %s/%s: %w", entry.Repo, entry.Name, err)
 			}
 			dirs = append(dirs, dir)
 		default:
-			return nil, fmt.Errorf("unknown skill type %q", s.Type)
+			return nil, fmt.Errorf("unknown skill source %q", entry.Source)
 		}
 	}
 	return dirs, nil
@@ -100,11 +103,11 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 
 // fetchRemote fetches a remote skill from a GitHub repo using npx skills add.
 // Returns the directory where the skill was installed.
-func fetchRemote(s config.Skill, baseDir string) (string, error) {
+func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 	// Determine install directory: use a skills cache dir under baseDir
-	installDir := filepath.Join(baseDir, ".skills-cache", s.Repo)
-	if s.Name != "" {
-		installDir = filepath.Join(installDir, s.Name)
+	installDir := filepath.Join(baseDir, ".skills-cache", entry.Repo)
+	if entry.Name != "" {
+		installDir = filepath.Join(installDir, entry.Name)
 	}
 
 	if err := os.MkdirAll(installDir, 0755); err != nil {
@@ -112,13 +115,13 @@ func fetchRemote(s config.Skill, baseDir string) (string, error) {
 	}
 
 	// Use npx skills add to fetch the skill
-	args := []string{"skills", "add", s.Repo, "--directory", installDir}
-	if s.Name != "" {
-		args = append(args, "--name", s.Name)
+	args := []string{"skills", "add", entry.Repo, "--directory", installDir}
+	if entry.Name != "" {
+		args = append(args, "--name", entry.Name)
 	}
 
-	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", s.Name, s.Repo)
-	slog.Info("Fetching remote skill", "skill", s.Name, "repo", s.Repo)
+	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", entry.Name, entry.Repo)
+	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo)
 	cmd := exec.Command("npx", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/hyoka/internal/skills/fetcher_test.go
+++ b/hyoka/internal/skills/fetcher_test.go
@@ -15,8 +15,8 @@ func TestResolveLocal_DirectPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirs, err := ResolveSkillDirs([]config.Skill{
-		{Type: "local", Path: skillDir},
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: skillDir, Name: "local-skill"},
 	}, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -36,8 +36,8 @@ func TestResolveLocal_RelativePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirs, err := ResolveSkillDirs([]config.Skill{
-		{Type: "local", Path: "skills/generator"},
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: "skills/generator", Name: "local-skill"},
 	}, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -61,8 +61,8 @@ func TestResolveLocal_GlobPattern(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "skills", "readme.txt"), []byte("hi"), 0644)
 	_ = f
 
-	dirs, err := ResolveSkillDirs([]config.Skill{
-		{Type: "local", Path: filepath.Join(dir, "skills", "*")},
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: filepath.Join(dir, "skills", "*"), Name: "local-skill"},
 	}, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -84,8 +84,8 @@ func TestResolveLocal_EmptySkills(t *testing.T) {
 }
 
 func TestResolveLocal_InvalidType(t *testing.T) {
-	_, err := ResolveSkillDirs([]config.Skill{
-		{Type: "unknown", Path: "/some/path"},
+	_, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "unknown", Path: "/some/path", Name: "bad-skill"},
 	}, ".")
 	if err == nil {
 		t.Fatal("expected error for unknown type")


### PR DESCRIPTION
## Summary
- unify generator/reviewer tools into typed ToolEntry entries (tool/mcp/skill)
- update consumers, validation, and skill/MCP handling
- migrate configs and docs; update tests

## Testing
- go build ./hyoka/...
- go vet ./hyoka/...
- go test ./hyoka/... -count=1