### PR TITLE
fix: CLI polish — replace os.Exit, add serve message, fix session estimate, add dry-run banner

### DIFF
--- a/hyoka/cmd/serve.go
+++ b/hyoka/cmd/serve.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ronniegeraghty/hyoka/internal/config"
 	"github.com/ronniegeraghty/hyoka/internal/serve"
 	"github.com/spf13/cobra"
@@ -29,6 +31,7 @@ func serveCmd() *cobra.Command {
 			promptsDir = resolvePathFlag(cmd, "prompts",
 				config.ResolveCandidates(proj, "prompts", "./prompts", "../prompts"))
 
+			fmt.Printf("Listening on http://localhost:%d\n", port)
 			return serve.Start(serve.Options{
 				ReportsDir: reportsDir,
 				SiteDir:    siteDir,

--- a/hyoka/cmd/validate.go
+++ b/hyoka/cmd/validate.go
@@ -11,6 +11,18 @@ import (
 "github.com/spf13/cobra"
 )
 
+func noPromptsFoundError(promptsDir string) error {
+	nearMisses := prompt.ScanNearMisses(promptsDir)
+	fmt.Printf("\u2717 No prompts found in %s\n", promptsDir)
+	if len(nearMisses) > 0 {
+		fmt.Println("\nDid you mean one of these?")
+		for _, nm := range nearMisses {
+			fmt.Printf("  %s\n", nm)
+		}
+	}
+	return fmt.Errorf("no prompts found in %s", promptsDir)
+}
+
 func validateCmd() *cobra.Command {
 var promptsDir string
 
@@ -24,26 +36,10 @@ allOK := true
 
 result, err := validate.Validate(promptsDir)
 if err != nil {
-nearMisses := prompt.ScanNearMisses(promptsDir)
-fmt.Printf("\u2717 No prompts found in %s\n", promptsDir)
-if len(nearMisses) > 0 {
-fmt.Println("\nDid you mean one of these?")
-for _, nm := range nearMisses {
-fmt.Printf("  %s\n", nm)
-}
-}
-os.Exit(1)
+return noPromptsFoundError(promptsDir)
 }
 if result.TotalFiles == 0 {
-nearMisses := prompt.ScanNearMisses(promptsDir)
-fmt.Printf("\u2717 No prompts found in %s\n", promptsDir)
-if len(nearMisses) > 0 {
-fmt.Println("\nDid you mean one of these?")
-for _, nm := range nearMisses {
-fmt.Printf("  %s\n", nm)
-}
-}
-os.Exit(1)
+return noPromptsFoundError(promptsDir)
 }
 fmt.Println(validate.FormatResult(result))
 if !result.OK() {
@@ -77,7 +73,7 @@ fmt.Printf("\u2717 %d of %d config(s) have errors\n", configErrors, configCount)
 }
 
 if !allOK {
-os.Exit(1)
+return fmt.Errorf("validation failed: one or more prompts or configs have errors")
 }
 return nil
 },

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -53,7 +53,9 @@ type StubEvaluator struct{}
 func (s *StubEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cfg *config.ToolConfig, workDir string) (*EvalResult, error) {
 	// Write a stub file so file graders can find it on disk.
 	if workDir != "" {
-		_ = os.WriteFile(filepath.Join(workDir, "stub_output.txt"), []byte("stub"), 0644)
+		if err := os.WriteFile(filepath.Join(workDir, "stub_output.txt"), []byte("stub"), 0644); err != nil {
+			slog.Warn("stub file write failed", "error", err)
+		}
 	}
 	return &EvalResult{
 		GeneratedFiles: []string{"stub_output.txt"},
@@ -291,7 +293,13 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 
 	// Pre-run summary (#34: fan-out visibility)
 	evalCount := len(tasks)
-	estimatedSessions := evalCount * 2 // generate + review per eval
+	sessionsPerEval := 2 // generate + review
+	sessionLabel := fmt.Sprintf("%d × 2 for generate/review", evalCount)
+	if e.opts.SkipReview {
+		sessionsPerEval = 1
+		sessionLabel = fmt.Sprintf("%d × 1 for generate only", evalCount)
+	}
+	estimatedSessions := evalCount * sessionsPerEval
 	maxSessions := e.opts.Workers * 3
 	slog.Info("Evaluation plan",
 		"evaluations", evalCount,
@@ -300,15 +308,23 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 		"estimated_sessions", estimatedSessions,
 		"workers", e.opts.Workers,
 		"max_sessions", maxSessions)
+
+	if e.opts.DryRun {
+		e.printf("\n🔍 DRY RUN MODE — No evaluations will be executed\n")
+	}
 	e.printf("\n📊 Evaluation plan: %d evaluations (%d prompts × %d configs)\n", evalCount, len(prompts), len(configs))
-	e.printf("   Estimated Copilot sessions: %d (%d × 2 for generate/review)\n", estimatedSessions, evalCount)
+	e.printf("   Estimated Copilot sessions: %d (%s)\n", estimatedSessions, sessionLabel)
 	e.printf("   Workers: %d | Max sessions: %d\n\n", e.opts.Workers, maxSessions)
 
 	// Confirmation prompt for large runs (#34)
 	if evalCount > 10 && e.opts.ConfirmLargeRuns && !e.opts.AutoConfirm {
 		e.printf("⚠️  Large run detected (%d evaluations). Continue? [y/N] ", evalCount)
 		var answer string
-		_, _ = fmt.Scanln(&answer)
+		if _, err := fmt.Scanln(&answer); err != nil {
+			// On piped input or EOF, default to "no" for safety.
+			slog.Info("No TTY input detected, defaulting to abort")
+			return nil, fmt.Errorf("no interactive input available for confirmation")
+		}
 		answer = strings.TrimSpace(strings.ToLower(answer))
 		if answer != "y" && answer != "yes" {
 			return nil, fmt.Errorf("run aborted by user (use -y to skip confirmation)")

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -779,6 +779,63 @@ func TestLargeRunConfirmAbort(t *testing.T) {
 	}
 }
 
+func TestStubEvaluatorWriteErrorLogsWarning(t *testing.T) {
+	// When workDir is an invalid path, the stub evaluator should still
+	// succeed (logging a warning) rather than returning an error.
+	stub := &StubEvaluator{}
+	p := &prompt.Prompt{ID: "test-prompt", Properties: map[string]string{"language": "go"}}
+	cfg := &config.ToolConfig{Name: "test-config", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+
+	result, err := stub.Evaluate(context.Background(), p, cfg, filepath.Join(t.TempDir(), "nonexistent", "subdir"))
+	if err != nil {
+		t.Fatalf("stub evaluator should not return an error even when write fails: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected stub to report success even when file write fails")
+	}
+	if !result.IsStub {
+		t.Error("expected IsStub to be true")
+	}
+}
+
+func TestLargeRunConfirmNoTTY(t *testing.T) {
+	// With ConfirmLargeRuns=true and stdin closed (simulating piped/no-TTY input),
+	// the run should abort with an "no interactive input" error.
+	outputDir := t.TempDir()
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{
+		Workers:          1,
+		OutputDir:        outputDir,
+		SkipReview:       true,
+		ConfirmLargeRuns: true,
+		AutoConfirm:      false,
+	}))
+
+	var prompts []*prompt.Prompt
+	for i := 0; i < 12; i++ {
+		prompts = append(prompts, &prompt.Prompt{
+			ID:         fmt.Sprintf("no-tty-%d", i),
+			Properties: map[string]string{"service": "storage", "plane": "data-plane", "language": "go", "category": "crud"},
+		})
+	}
+
+	// Redirect stdin to a closed pipe (EOF immediately).
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	_, err := engine.Run(context.Background(), prompts, []config.ToolConfig{
+		{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when stdin is closed (no TTY)")
+	}
+	if !strings.Contains(err.Error(), "no interactive input available") {
+		t.Errorf("expected 'no interactive input available' error, got: %v", err)
+	}
+}
+
 // capturingReviewer records the evaluation criteria passed to Review.
 type capturingReviewer struct {
 	capturedCriteria string


### PR DESCRIPTION
## Summary

Four CLI polish fixes in one branch:

### #263 (P0): Replace os.Exit() in cmd/validate.go
- Replaced all 3 `os.Exit(1)` calls with `return fmt.Errorf()` so defers execute properly
- Extracted `noPromptsFoundError()` helper to deduplicate the near-miss printing logic

### #267 (P2): Add serve startup message
- Added `Listening on http://localhost:{port}` output before `serve.Start()`

### #268 (P2): Fix --skip-review session estimate
- When `--skip-review` is set, session estimate now correctly shows `N × 1 for generate only` instead of always showing `N × 2 for generate/review`

### #269 (P2): Add dry-run banner
- Added `🔍 DRY RUN MODE — No evaluations will be executed` banner before the plan output when `--dry-run` is active

## Testing
- `go build ./hyoka/...` ✅
- `go test ./hyoka/... -count=1` ✅ (all 27 packages pass)

Closes #263, Closes #267, Closes #268, Closes #269