### PR TITLE
Fix stale CLI flags and update example config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Every code-generation session is automatically aborted if it exceeds any of thes
 
 | Limit | Default | Flag | Purpose |
 |-------|---------|------|---------|
-| Turn count | 25 | `--max-turns` | Prevents runaway conversations |
+| Session actions | 50 | `--max-session-actions` | Limits reasoning, response, and tool call actions per session |
 | File count | 50 | `--max-files` | Prevents excessive file creation |
 | Output size | 1 MB | `--max-output-size` | Prevents oversized outputs (supports KB, MB suffixes) |
 | Session actions | 50 | `--max-session-actions` | Limits reasoning, response, and tool call actions per session |
@@ -183,7 +183,6 @@ hyoka list --json
 | `--progress` | `auto` | Progress display mode: `auto`, `live`, `log`, `off` |
 | `--skip-tests` | `false` | Skip test generation |
 | `--skip-review` | `false` | Skip code review |
-| `--verify-build` | `false` | Run build verification on generated code |
 | `--stub` | `false` | Use stub evaluator (no Copilot SDK) |
 | `--dry-run` | `false` | List matching prompts without running |
 | `--workers` | CPU cores (max 8) | Parallel evaluation workers |
@@ -192,18 +191,15 @@ hyoka list --json
 | `-y` / `--yes` | `false` | Skip confirmation prompt for large runs (>10 evaluations) |
 | `--all-configs` | `false` | Required when running all configs without a `--config` filter |
 | `--config` | | Config name(s) to run — use quotes for multiple: `"name1,name2"` |
-| `--max-turns` | `25` | Maximum conversation turns per generation before aborting |
+| `--max-session-actions` | `50` | Maximum actions per Copilot session (reasoning, response, or tool call each count as 1) |
 | `--max-files` | `50` | Maximum generated files per evaluation before aborting |
 | `--max-output-size` | `1MB` | Maximum total output size per evaluation (supports KB, MB suffixes) |
 | `--max-session-actions` | `50` | Maximum actions per Copilot session (reasoning, response, or tool call each count as 1) |
 | `--allow-cloud` | `false` | Allow generated code to provision real Azure resources |
-| `--sandbox` | `true` | Alias confirming safe/local-only mode (default behavior) |
 | `--criteria-dir` | (none) | Directory with attribute-matched criteria YAML files (e.g., `criteria/`) |
 | `--strict-cleanup` | `false` | Fail run if orphaned Copilot processes remain after cleanup |
 | `--monitor-resources` | `false` | Monitor CPU and memory usage of Copilot sessions during evaluation |
-| `--generate-timeout` | `600` | Generation phase timeout in seconds |
-| `--build-timeout` | `300` | Build verification timeout in seconds |
-| `--review-timeout` | `300` | Review phase timeout in seconds |
+| `--session-timeout` | `600` | Maximum time in seconds for any single session phase to complete |
 | `--exclude-dirs` | | Comma-separated directories to exclude from generated_files output |
 
 ### Run Command Examples
@@ -216,7 +212,7 @@ go run ./hyoka run --prompt-id my-prompt --config "baseline/claude-sonnet-4.5" -
 go run ./hyoka run --all-configs -y
 
 # Tighten guardrails for faster iteration
-go run ./hyoka run --max-turns 10 --max-files 20
+go run ./hyoka run --max-session-actions 10 --max-files 20
 
 # Allow real Azure resource provisioning (use with caution)
 go run ./hyoka run --allow-cloud

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ A single evaluation flows through these stages:
         ▼
  ┌─────────────┐     Optional: runs real build commands
  │  build/       │──→ go build, dotnet build, npm install, etc.
- └──────┬──────┘     (enabled with --verify-build)
+ └──────┬──────┘     (configurable via tool settings)
         ▼
  ┌─────────────┐     Multiple LLMs score code against rubric
  │  review/      │──→ each model reviews independently,
@@ -137,11 +137,9 @@ Key flags for `hyoka run`:
 - `--pairwise` / `-P` — Expand configs into pairwise tool-ablation variants
 - `--log-level debug` — Structured debug logging
 - `--log-file path` — Redirect logs to file
-- `--verify-build` — Run real build verification
 - `--skip-review` — Skip the review phase
 - `--criteria-dir` — Directory with tiered criteria YAML files
 - `--strict-cleanup` — Fail run if orphaned processes detected after cleanup
-- `--filter` — Generic key=value filter for prompt metadata
 
 ### Reports and Action Timeline
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,7 +43,6 @@ hyoka run --config baseline --dry-run
 | `--category` | Filter by use-case category |
 | `--tags` | Filter by tags (comma-separated) |
 | `--prompt-id` | Run a single prompt by ID |
-| `--filter` | Generic key=value filter (e.g., `--filter sdk_package=azure-storage-blob`) |
 
 #### Config Flags
 
@@ -61,9 +60,7 @@ hyoka run --config baseline --dry-run
 |------|---------|-------------|
 | `--workers` | CPU count (max 8) | Parallel evaluation workers |
 | `--max-sessions` | workers × 3 | Maximum concurrent Copilot sessions |
-| `--generate-timeout` | 600s | Generation phase timeout |
-| `--build-timeout` | 300s | Build verification timeout |
-| `--review-timeout` | 300s | Review phase timeout |
+| `--session-timeout` | 600s | Maximum time in seconds for any single session phase to complete |
 | `--output` | `./reports` | Report output directory |
 | `--progress` | `auto` | Progress display: `auto`, `live`, `log`, `off` |
 | `--stub` | false | Use stub evaluator (no Copilot SDK) |
@@ -77,7 +74,6 @@ hyoka run --config baseline --dry-run
 | `--skip-tests` | false | Skip test generation |
 | `--skip-review` | false | Skip code review phase |
 | `--skip-trends` | false | Skip trend analysis after run |
-| `--verify-build` | false | Run build verification on generated code |
 | `--dry-run` | false | List matches without running |
 | `--monitor-resources` | false | Track CPU/memory of Copilot sessions |
 | `--strict-cleanup` | false | Fail if orphaned processes remain after cleanup |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,7 +206,7 @@ go run ./hyoka run --service identity --language python \
 
 ```bash
 # Tighter limits for faster iteration
-go run ./hyoka run --max-turns 10 --max-files 20 --max-output-size 512KB
+go run ./hyoka run --max-session-actions 10 --max-files 20 --max-output-size 512KB
 
 # Allow real Azure resource provisioning
 go run ./hyoka run --allow-cloud
@@ -254,9 +254,7 @@ Every code-generation session is automatically aborted if it exceeds:
 
 | Limit | Default | Flag |
 |-------|---------|------|
-| Conversation turns | 25 | `--max-turns` |
-| Generated files | 50 | `--max-files` |
-| Total output size | 1 MB | `--max-output-size` |
+| Session actions | 50 | `--max-session-actions` |
 
 When a limit is hit, the evaluation stops and the report shows the specific guardrail that triggered (e.g., `guardrail: file count 51 exceeded limit of 50`).
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -8,7 +8,7 @@ These limits apply per-evaluation and abort the run if exceeded:
 
 | Guardrail | Default | Flag | Description |
 |-----------|---------|------|-------------|
-| Max Turns | 25 | `--max-turns` | Maximum assistant message turns. Prevents agents from looping indefinitely. |
+| Max Session Actions | 50 | `--max-session-actions` | Maximum actions (reasoning, response, or tool call) per Copilot session. |
 | Max Files | 50 | `--max-files` | Maximum files generated. Prevents agents from creating excessive output. |
 | Max Output Size | 1 MB | `--max-output-size` | Total size of all generated files. Accepts `KB`, `MB`, `GB` suffixes. |
 | Max Session Actions | 50 | `--max-session-actions` | Maximum actions (reasoning, response, or tool call) per Copilot session. |
@@ -25,7 +25,6 @@ By default, hyoka enforces safety boundaries preventing generated code from prov
 | Flag | Description |
 |------|-------------|
 | `--allow-cloud` | Disables safety boundaries, allowing real Azure resource provisioning |
-| `--sandbox` | (Default) Enforces safety boundaries |
 
 ## Fan-Out Confirmation
 
@@ -78,9 +77,7 @@ Each phase has an independent timeout:
 
 | Phase | Default | Flag |
 |-------|---------|------|
-| Generation | 600s (10 min) | `--generate-timeout` |
-| Build | 300s (5 min) | `--build-timeout` |
-| Review | 300s (5 min) | `--review-timeout` |
+| Session timeout | `--session-timeout` |
 
 If a phase times out, the report includes `error_category: "timeout"` with details.
 

--- a/examples/configs/example-full.yaml
+++ b/examples/configs/example-full.yaml
@@ -13,15 +13,18 @@ configs:
     generator:
       model: "claude-sonnet-4.5"
 
-      # Unified skills list replaces skill_directories + generator_skill_directories
-      skills:
+      # Unified tools list replaces skill_directories + generator_skill_directories
+      tools:
         # Remote skill — fetched from a GitHub repository
-        - type: remote
-          name: azure-keyvault-py
+        - name: azure-keyvault-py
+          type: skill
+          source: remote
           repo: microsoft/skills
 
         # Local skill — directory path (supports glob patterns)
-        - type: local
+        - name: generator-skills
+          type: skill
+          source: local
           path: "./skills/generator"
 
       # MCP servers attached to the generator session
@@ -43,9 +46,11 @@ configs:
         - "gemini-3-pro-preview"
         - "gpt-4.1"
 
-      # Reviewer-specific skills (e.g., rubric knowledge, build verification)
-      skills:
-        - type: local
+      # Reviewer-specific tools (e.g., rubric knowledge, build verification)
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
           path: "./skills/reviewer"
 
   # Minimal config — only required fields


### PR DESCRIPTION
Closes #262, Closes #272

## Issue #262 - Fix stale CLI flags in documentation

**Changes:**
- Replace `--max-turns` with `--max-session-actions` in README.md and docs
- Remove `--verify-build` from README flag table and docs/cli-reference.md
- Replace `--generate-timeout`, `--build-timeout`, `--review-timeout` with `--session-timeout`
- Remove `--sandbox` flag documentation (default safety behavior)
- Remove `--filter` from docs/cli-reference.md

**Files updated:**
- README.md: Fixed flag references in guardrails table and example commands
- docs/guardrails.md: Updated timeout flags and removed --sandbox
- docs/architecture.md: Updated build verification reference
- docs/cli-reference.md: Removed stale flag entries
- docs/getting-started.md: Updated example command and limits table

## Issue #272 - Update example config for tools[] format

**Changes:**
- Updated examples/configs/example-full.yaml to use new `tools:` format
- Replaced old `skills:` field with `tools:` array
- Added `type: skill` and `source: local/remote` fields
- Added `name` field to identify each tool

**Before:**
```yaml
skills:
  - type: local
    path: skills/generator
```

**After:**
```yaml
tools:
  - name: generator-skills
    type: skill
    source: local
    path: skills/generator
```

All changes ensure documentation accuracy and consistency with current CLI flags and config format.
