### PR TITLE
fix(site): defensive null/NaN checks and inline error messages (#265, #270)

### DIFF
--- a/site/src/__tests__/runs-page.test.tsx
+++ b/site/src/__tests__/runs-page.test.tsx
@@ -77,4 +77,61 @@ describe("RunsPage", () => {
       expect(screen.getByText(/Network failure/)).toBeInTheDocument();
     });
   });
+
+  it("renders N/A for missing or invalid timestamp", async () => {
+    const runsWithBadDate = [
+      {
+        run_id: "run-baddate",
+        timestamp: "not-a-date",
+        total_evaluations: 3,
+        passed: 1,
+        failed: 2,
+        errors: 0,
+        duration_seconds: 30,
+        results: [],
+      },
+    ];
+    vi.mocked(fetchRuns).mockResolvedValue(runsWithBadDate as any);
+
+    render(
+      <MemoryRouter>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/run-baddate/)).toBeInTheDocument();
+    });
+    // Invalid timestamp renders "N/A" instead of "Invalid Date"
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("handles missing duration and pass counts gracefully", async () => {
+    const runsWithMissing = [
+      {
+        run_id: "run-missing",
+        timestamp: "",
+        total_evaluations: 0,
+        errors: 0,
+        duration_seconds: undefined,
+        results: [],
+      },
+    ];
+    vi.mocked(fetchRuns).mockResolvedValue(runsWithMissing as any);
+
+    render(
+      <MemoryRouter>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/run-missing/)).toBeInTheDocument();
+    });
+    // Missing duration and timestamp both render "N/A"
+    const naElements = screen.getAllByText("N/A");
+    expect(naElements.length).toBeGreaterThanOrEqual(2);
+    // Pass rate should show 0.0% (not NaN%)
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
+  });
 });

--- a/site/src/app/components/run-detail-page.tsx
+++ b/site/src/app/components/run-detail-page.tsx
@@ -12,7 +12,8 @@ function ScoreBadge({ score, max = 100 }: { score: number; max?: number }) {
   return <span className={color} style={{ ...mono, fontSize: 13 }}>{score}/{max}</span>;
 }
 
-function formatDuration(s: number): string {
+function formatDuration(s: number | undefined | null): string {
+  if (s == null || isNaN(s)) return "N/A";
   if (s < 60) return `${s.toFixed(1)}s`;
   const m = Math.floor(s / 60);
   const sec = (s % 60).toFixed(0);
@@ -55,7 +56,9 @@ export function RunDetailPage() {
     );
   }
 
-  const rate = run.total_evaluations > 0 ? ((run.passed / run.total_evaluations) * 100).toFixed(1) : "0.0";
+  const passed = run.passed ?? 0;
+  const total = run.total_evaluations ?? 0;
+  const rate = total > 0 ? ((passed / total) * 100).toFixed(1) : "0.0";
   const results = run.results || [];
 
   const services = [...new Set(results.map(r => r.prompt_metadata?.service).filter(Boolean))];
@@ -83,7 +86,7 @@ export function RunDetailPage() {
               Run {run.run_id}
             </h1>
             <p className="text-white/40" style={{ fontSize: 13 }}>
-              {new Date(run.timestamp).toLocaleString()} · {run.total_evaluations} evaluations · {formatDuration(run.duration_seconds)}
+              {run.timestamp && !isNaN(new Date(run.timestamp).getTime()) ? new Date(run.timestamp).toLocaleString() : "N/A"} · {run.total_evaluations ?? 0} evaluations · {formatDuration(run.duration_seconds)}
             </p>
           </div>
           <div className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-4 py-2">
@@ -148,7 +151,7 @@ export function RunDetailPage() {
           <table className="w-full" style={{ fontSize: 13 }}>
             <thead>
               <tr className="border-b border-white/8">
-                {["Status", "Prompt", "Config", "Service", "Lang", "Difficulty", "Score", "Duration", ""].map(h => (
+                {["Status", "Prompt", "Config", "Service", "Lang", "Difficulty", "Score", "Duration", "Error", ""].map(h => (
                   <th key={h} className="px-4 py-3 text-left text-white/30" style={{ fontWeight: 500, fontSize: 11 }}>{h}</th>
                 ))}
               </tr>
@@ -181,7 +184,16 @@ export function RunDetailPage() {
                   <td className="px-4 py-3">
                     <ScoreBadge score={r.review?.overall_score ?? 0} max={r.review?.max_score ?? 100} />
                   </td>
-                  <td className="px-4 py-3 text-white/40" style={{ ...mono, fontSize: 12 }}>{r.duration_seconds.toFixed(1)}s</td>
+                  <td className="px-4 py-3 text-white/40" style={{ ...mono, fontSize: 12 }}>
+                    {r.duration_seconds != null && !isNaN(r.duration_seconds) ? `${r.duration_seconds.toFixed(1)}s` : "N/A"}
+                  </td>
+                  <td className="max-w-[200px] px-4 py-3">
+                    {!r.success && r.error ? (
+                      <span className="text-red-400/80" style={{ fontSize: 11 }} title={r.error}>
+                        {r.error.length > 100 ? r.error.slice(0, 100) + "…" : r.error}
+                      </span>
+                    ) : null}
+                  </td>
                   <td className="px-4 py-3">
                     <Link
                       to={`/runs/${run.run_id}/eval/${encodeURIComponent(r.prompt_id)}/${encodeURIComponent(r.config_name)}`}

--- a/site/src/app/components/runs-page.tsx
+++ b/site/src/app/components/runs-page.tsx
@@ -5,15 +5,18 @@ import type { RunSummary } from "../data/types";
 import { CheckCircle2, XCircle, AlertTriangle, Clock, ChevronRight, Loader2 } from "lucide-react";
 import { motion } from "motion/react";
 
-function formatDuration(s: number): string {
+function formatDuration(s: number | undefined | null): string {
+  if (s == null || isNaN(s)) return "N/A";
   if (s < 60) return `${s.toFixed(1)}s`;
   const m = Math.floor(s / 60);
   const sec = (s % 60).toFixed(0);
   return `${m}m ${sec}s`;
 }
 
-function formatDate(ts: string): string {
+function formatDate(ts: string | undefined | null): string {
+  if (!ts) return "N/A";
   const d = new Date(ts);
+  if (isNaN(d.getTime())) return "N/A";
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", hour: "2-digit", minute: "2-digit" });
 }
 
@@ -67,7 +70,9 @@ export function RunsPage() {
         ) : (
           <div className="space-y-4">
             {runs.map((run, i) => {
-              const rate = run.total_evaluations > 0 ? ((run.passed / run.total_evaluations) * 100).toFixed(1) : "0.0";
+              const passed = run.passed ?? 0;
+              const total = run.total_evaluations ?? 0;
+              const rate = total > 0 ? ((passed / total) * 100).toFixed(1) : "0.0";
               return (
                 <motion.div
                   key={run.run_id}


### PR DESCRIPTION
## Summary

Fixes two site issues:

### Issue #265 — Invalid Date / NaN rendering
- `formatDate` now returns "N/A" for missing/empty/malformed timestamps instead of showing "Invalid Date"
- `formatDuration` returns "N/A" when duration is `undefined`/`null`/`NaN` instead of rendering "NaNm NaNs"
- Pass rate calculations use `?? 0` fallbacks so missing `passed`/`total_evaluations` show "0.0%" instead of "NaN%"

### Issue #270 — Surface error messages in run table
- Added "Error" column to the run-detail results table
- When `success === false && error` exists, shows first 100 characters inline with full error in title tooltip
- Enables quick triage without clicking through to eval detail

### Testing
- 2 new tests covering invalid timestamp and missing duration/pass count scenarios
- All 43 tests pass

Closes #265, Closes #270