### PR TITLE
fix: workspace lifecycle bug and pre-flight model check (#261, #264)

### DIFF
--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -61,6 +61,8 @@ type runFlags struct {
 	sessionTimeout string
 	// Pairwise tool-ablation (#121)
 	pairwiseMode bool
+	// Pre-flight model check (#264)
+	checkModels bool
 }
 
 func addFilterFlags(cmd *cobra.Command, f *runFlags) {
@@ -107,6 +109,8 @@ func addFilterFlags(cmd *cobra.Command, f *runFlags) {
 	cmd.Flags().StringVar(&f.sessionTimeout, "session-timeout", "10m", "Maximum duration for a single generation or review session (e.g., 10m, 30m, 1h)")
 	// Pairwise tool-ablation (#121)
 	cmd.Flags().BoolVarP(&f.pairwiseMode, "pairwise", "P", false, "Expand each config into N+1 pairwise tool-ablation variants")
+
+	cmd.Flags().BoolVar(&f.checkModels, "check-models", false, "Pre-flight check that all configured models (generator + reviewer) are available before starting evaluations")
 }
 
 func buildFilter(f *runFlags) prompt.Filter {
@@ -384,6 +388,7 @@ func runCmd() *cobra.Command {
 				CriteriaDir:       f.criteriaDir,
 				ExcludeDirs:       excludeDirs,
 				SessionTimeout:    sessionTimeout,
+				CheckModels:       f.checkModels,
 			})
 
 			summary, err := engine.Run(context.Background(), filtered, configs)

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -108,29 +108,43 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 
 	// Track session ID for cleanup — set after CreateSession.
 	var sessionID string
-	// Defer client cleanup (#62). Delete session state first (requires
-	// connected client), then stop the client. DeleteSession sends
-	// session.delete RPC which removes session-state dir AND the SQLite
-	// session-store.db entry — unlike os.RemoveAll which misses the DB.
-	defer func() {
-		if sessionID != "" {
-			deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer deleteCancel()
-			if err := client.DeleteSession(deleteCtx, sessionID); err != nil {
-				slog.Debug("session delete failed, session-state may remain",
-					"sessionID", sessionID, "error", err)
+
+	// buildCleanupFn returns a function that deletes session state and stops
+	// the client. It is stored in EvalResult.CleanupFn so the engine can call
+	// it AFTER copying generated files out of the workspace (#261). Previously,
+	// DeleteSession was deferred here, which removed workspace artifacts before
+	// the engine could copy them — causing baseline configs (which lack MCP
+	// server processes that keep files alive) to report zero generated files.
+	buildCleanupFn := func() func() {
+		return func() {
+			if sessionID != "" {
+				deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer deleteCancel()
+				if err := client.DeleteSession(deleteCtx, sessionID); err != nil {
+					slog.Debug("session delete failed, session-state may remain",
+						"sessionID", sessionID, "error", err)
+				}
+			}
+			done := make(chan struct{})
+			go func() { client.Stop(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				client.ForceStop()
+			}
+			// Remove PID files for processes we tracked.
+			for _, cpid := range trackedPIDs {
+				pidfile.Remove(cpid)
 			}
 		}
-		done := make(chan struct{})
-		go func() { client.Stop(); close(done) }()
-		select {
-		case <-done:
-		case <-time.After(10 * time.Second):
-			client.ForceStop()
-		}
-		// Remove PID files for processes we tracked.
-		for _, cpid := range trackedPIDs {
-			pidfile.Remove(cpid)
+	}
+
+	// Safety net: if we return early (error paths that don't attach CleanupFn
+	// to a result), ensure the client is stopped and PIDs cleaned up.
+	var cleanupCalled bool
+	defer func() {
+		if !cleanupCalled {
+			buildCleanupFn()()
 		}
 	}()
 
@@ -529,6 +543,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 			}
 			lg.Warn("Returning partial results after action-limit cancellation",
 				"actions", actionCounter, "files", len(generatedFiles))
+			cleanupCalled = true
 			return &EvalResult{
 				GeneratedFiles: generatedFiles,
 				EventCount:     len(captured),
@@ -536,6 +551,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 				SessionEvents:  captured,
 				ActionTimeline: BuildActionTimeline(captured),
 				Success:        true, // Let engine.go guardrail set the proper failure
+				CleanupFn:      buildCleanupFn(),
 			}, nil
 		}
 
@@ -546,6 +562,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 			ToolCalls:      extractToolCalls(capturedEvts),
 			Error:          fmt.Sprintf("prompt send failed: %v", err),
 			ErrorDetails:   err.Error(),
+			CleanupFn:      buildCleanupFn(),
 		}, fmt.Errorf("sending prompt: %w", err)
 	}
 
@@ -569,6 +586,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		"tool_calls", len(toolCalls),
 		"files", len(generatedFiles))
 
+	cleanupCalled = true
 	return &EvalResult{
 		GeneratedFiles: generatedFiles,
 		EventCount:     len(capturedEvents),
@@ -577,6 +595,7 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 		ActionTimeline: BuildActionTimeline(capturedRecords),
 		Success:        !hasError,
 		Error:          "",
+		CleanupFn:      buildCleanupFn(),
 	}, nil
 }
 

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -35,6 +35,10 @@ type EvalResult struct {
 	ErrorDetails   string
 	IsStub         bool
 	StarterFiles   []string
+	// CleanupFn deletes session state after the caller has consumed the
+	// workspace files. Must be called after copying generated files out
+	// of the workspace directory (#261). Nil for stub evaluators.
+	CleanupFn func()
 }
 
 // CopilotEvaluator defines the interface for running evaluations.
@@ -98,6 +102,11 @@ type EngineOptions struct {
 	GradersDir string // Directory containing grader config YAML files.
 	// Directory exclusion (#63)
 	ExcludeDirs []string // Directories to exclude from generated_files output.
+	// Pre-flight model availability check (#264).
+	// When true, the engine queries the Copilot backend for available models
+	// before starting evaluations and fails fast if any configured model
+	// (generator or reviewer) is unavailable.
+	CheckModels bool
 	// Output writer for user-facing messages (defaults to os.Stdout).
 	Stdout io.Writer
 	// Tracker overrides the default process tracker (used in tests to avoid
@@ -303,6 +312,20 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 	e.printf("\n📊 Evaluation plan: %d evaluations (%d prompts × %d configs)\n", evalCount, len(prompts), len(configs))
 	e.printf("   Estimated Copilot sessions: %d (%d × 2 for generate/review)\n", estimatedSessions, evalCount)
 	e.printf("   Workers: %d | Max sessions: %d\n\n", e.opts.Workers, maxSessions)
+
+	// Pre-flight model availability check (#264). Query the backend for
+	// available models and fail fast if any configured model is unavailable.
+	// This prevents mid-eval failures from unavailable reviewer models
+	// (e.g. gemini-3-pro-preview).
+	if e.opts.CheckModels {
+		if checker, ok := e.evaluator.(*CopilotSDKEvaluator); ok {
+			e.printf("🔍 Checking model availability...\n")
+			if err := checker.ValidateModelAvailability(ctx, configs); err != nil {
+				return nil, fmt.Errorf("pre-flight check failed: %w", err)
+			}
+			e.printf("✅ All models available\n\n")
+		}
+	}
 
 	// Confirmation prompt for large runs (#34)
 	if evalCount > 10 && e.opts.ConfirmLargeRuns && !e.opts.AutoConfirm {
@@ -747,6 +770,15 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Copy generated files from isolated workspace to persistent report directory (#26)
 	if err := copyDir(genDir, ws.Dir); err != nil {
 		lg.Warn("Failed to copy generated files to report dir", "error", err)
+	}
+
+	// Release session state AFTER workspace files are safely copied (#261).
+	// Previously, Evaluate's defer called DeleteSession before returning,
+	// which removed workspace artifacts before copyDir could read them.
+	// Baseline configs (no MCP) were affected because there were no MCP
+	// server processes keeping files alive during cleanup.
+	if result != nil && result.CleanupFn != nil {
+		result.CleanupFn()
 	}
 
 	generatedFiles, listErr := ws.ListFiles()

--- a/hyoka/internal/eval/modelcheck.go
+++ b/hyoka/internal/eval/modelcheck.go
@@ -1,0 +1,135 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
+)
+
+// ModelCheckResult holds the outcome of a pre-flight model availability check.
+type ModelCheckResult struct {
+	// Available lists the model IDs that were found in the backend.
+	Available []string
+	// Unavailable lists the model IDs that were NOT found.
+	Unavailable []string
+	// AllModels is the complete set of models returned by the backend.
+	AllModels []string
+}
+
+// OK returns true if all requested models are available.
+func (r *ModelCheckResult) OK() bool {
+	return len(r.Unavailable) == 0
+}
+
+// Error returns a human-readable summary of unavailable models.
+func (r *ModelCheckResult) Error() string {
+	if r.OK() {
+		return ""
+	}
+	return fmt.Sprintf("unavailable model(s): %s", strings.Join(r.Unavailable, ", "))
+}
+
+// CheckModelAvailability queries the Copilot backend for available models and
+// checks that every model referenced by the given configs (generator +
+// reviewer) is present. This pre-flight check prevents mid-eval failures
+// when a model like "gemini-3-pro-preview" is configured but not available
+// in the backend (#264).
+func (e *CopilotSDKEvaluator) CheckModelAvailability(ctx context.Context, configs []config.ToolConfig) (*ModelCheckResult, error) {
+	// Create a temporary workspace for the client — the ListModels RPC
+	// doesn't access the filesystem, but the SDK requires a valid CWD.
+	tmpDir, err := os.MkdirTemp("", "hyoka-modelcheck-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir for model check: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	client, err := e.Client(checkCtx, tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("starting client for model check: %w", err)
+	}
+	defer func() {
+		done := make(chan struct{})
+		go func() { client.Stop(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			client.ForceStop()
+		}
+	}()
+
+	models, err := client.ListModels(checkCtx)
+	if err != nil {
+		return nil, fmt.Errorf("listing models: %w", err)
+	}
+
+	// Build a set of available model IDs.
+	availableSet := make(map[string]bool, len(models))
+	allModelIDs := make([]string, 0, len(models))
+	for _, m := range models {
+		availableSet[m.ID] = true
+		allModelIDs = append(allModelIDs, m.ID)
+	}
+
+	// Collect all unique model IDs referenced by configs.
+	requiredModels := collectRequiredModels(configs)
+
+	result := &ModelCheckResult{AllModels: allModelIDs}
+	for _, model := range requiredModels {
+		if availableSet[model] {
+			result.Available = append(result.Available, model)
+		} else {
+			result.Unavailable = append(result.Unavailable, model)
+			slog.Warn("Model not available", "model", model)
+		}
+	}
+
+	return result, nil
+}
+
+// collectRequiredModels extracts all unique model IDs from a set of configs,
+// including both generator and reviewer models.
+func collectRequiredModels(configs []config.ToolConfig) []string {
+	seen := make(map[string]bool)
+	var models []string
+	for _, cfg := range configs {
+		if cfg.Generator != nil && cfg.Generator.Model != "" {
+			if !seen[cfg.Generator.Model] {
+				seen[cfg.Generator.Model] = true
+				models = append(models, cfg.Generator.Model)
+			}
+		}
+		if cfg.Reviewer != nil {
+			for _, m := range cfg.Reviewer.Models {
+				if !seen[m] {
+					seen[m] = true
+					models = append(models, m)
+				}
+			}
+		}
+	}
+	return models
+}
+
+// ValidateModelAvailability is a convenience wrapper that runs
+// CheckModelAvailability and returns an error if any models are unavailable.
+// Intended for use at run start to fail fast (#264).
+func (e *CopilotSDKEvaluator) ValidateModelAvailability(ctx context.Context, configs []config.ToolConfig) error {
+	result, err := e.CheckModelAvailability(ctx, configs)
+	if err != nil {
+		return fmt.Errorf("model availability check failed: %w", err)
+	}
+	if !result.OK() {
+		return fmt.Errorf("pre-flight model check: %s — available models: %s",
+			result.Error(), strings.Join(result.AllModels, ", "))
+	}
+	slog.Info("Pre-flight model check passed", "models_checked", len(result.Available))
+	return nil
+}

--- a/hyoka/internal/eval/modelcheck_test.go
+++ b/hyoka/internal/eval/modelcheck_test.go
@@ -1,0 +1,121 @@
+package eval
+
+import (
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
+)
+
+func TestCollectRequiredModels_Basic(t *testing.T) {
+	configs := []config.ToolConfig{
+		{
+			Generator: &config.GeneratorConfig{Model: "claude-opus-4.6"},
+			Reviewer:  &config.ReviewerConfig{Models: []string{"claude-opus-4.6", "gpt-4.1"}},
+		},
+	}
+	models := collectRequiredModels(configs)
+	if len(models) != 2 {
+		t.Errorf("expected 2 unique models, got %d: %v", len(models), models)
+	}
+	// claude-opus-4.6 appears in both generator and reviewer but should only appear once
+	found := map[string]bool{}
+	for _, m := range models {
+		found[m] = true
+	}
+	if !found["claude-opus-4.6"] || !found["gpt-4.1"] {
+		t.Errorf("missing models: %v", models)
+	}
+}
+
+func TestCollectRequiredModels_MultipleConfigs(t *testing.T) {
+	configs := []config.ToolConfig{
+		{
+			Name:      "baseline",
+			Generator: &config.GeneratorConfig{Model: "claude-sonnet-4.5"},
+			Reviewer:  &config.ReviewerConfig{Models: []string{"claude-opus-4.6", "gemini-3-pro-preview", "gpt-4.1"}},
+		},
+		{
+			Name:      "azure-mcp",
+			Generator: &config.GeneratorConfig{Model: "claude-opus-4.6"},
+			Reviewer:  &config.ReviewerConfig{Models: []string{"claude-opus-4.6", "gemini-3-pro-preview", "gpt-4.1"}},
+		},
+	}
+	models := collectRequiredModels(configs)
+	// Unique models: claude-sonnet-4.5, claude-opus-4.6, gemini-3-pro-preview, gpt-4.1
+	if len(models) != 4 {
+		t.Errorf("expected 4 unique models, got %d: %v", len(models), models)
+	}
+}
+
+func TestCollectRequiredModels_EmptyConfig(t *testing.T) {
+	configs := []config.ToolConfig{{Name: "empty"}}
+	models := collectRequiredModels(configs)
+	if len(models) != 0 {
+		t.Errorf("expected 0 models for empty config, got %d", len(models))
+	}
+}
+
+func TestCollectRequiredModels_NilGenerator(t *testing.T) {
+	configs := []config.ToolConfig{
+		{
+			Reviewer: &config.ReviewerConfig{Models: []string{"gpt-4.1"}},
+		},
+	}
+	models := collectRequiredModels(configs)
+	if len(models) != 1 || models[0] != "gpt-4.1" {
+		t.Errorf("expected [gpt-4.1], got %v", models)
+	}
+}
+
+func TestModelCheckResult_OK(t *testing.T) {
+	r := &ModelCheckResult{
+		Available: []string{"claude-opus-4.6", "gpt-4.1"},
+	}
+	if !r.OK() {
+		t.Error("expected OK with no unavailable models")
+	}
+	if r.Error() != "" {
+		t.Errorf("expected empty error, got %q", r.Error())
+	}
+}
+
+func TestModelCheckResult_NotOK(t *testing.T) {
+	r := &ModelCheckResult{
+		Available:   []string{"claude-opus-4.6"},
+		Unavailable: []string{"gemini-3-pro-preview"},
+	}
+	if r.OK() {
+		t.Error("expected NOT OK with unavailable models")
+	}
+	errMsg := r.Error()
+	if errMsg == "" {
+		t.Error("expected non-empty error message")
+	}
+	if !stringContains(errMsg, "gemini-3-pro-preview") {
+		t.Errorf("error should mention unavailable model: %q", errMsg)
+	}
+}
+
+func TestModelCheckResult_MultipleUnavailable(t *testing.T) {
+	r := &ModelCheckResult{
+		Available:   []string{"claude-opus-4.6"},
+		Unavailable: []string{"gemini-3-pro-preview", "nonexistent-model"},
+	}
+	errMsg := r.Error()
+	if !stringContains(errMsg, "gemini-3-pro-preview") || !stringContains(errMsg, "nonexistent-model") {
+		t.Errorf("error should mention all unavailable models: %q", errMsg)
+	}
+}
+
+func stringContains(s, substr string) bool {
+	return len(s) >= len(substr) && stringContainsHelper(s, substr)
+}
+
+func stringContainsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/hyoka/internal/eval/workspace_test.go
+++ b/hyoka/internal/eval/workspace_test.go
@@ -8,6 +8,7 @@ import (
 "strings"
 "testing"
 
+"github.com/ronniegeraghty/hyoka/internal/config"
 "github.com/ronniegeraghty/hyoka/internal/prompt"
 )
 
@@ -376,5 +377,145 @@ func TestEvalWorkspace_IsIsolated(t *testing.T) {
 	}
 	if len(wsFiles) != 0 {
 		t.Errorf("workspace should be empty (isolated from CWD), got %d entries", len(wsFiles))
+	}
+}
+
+// --- Workspace lifecycle tests (#261) ---
+
+// TestWorkspaceLifecycle_FilesAvailableBeforeCleanup verifies that workspace
+// files persist through the evaluation lifecycle and can be copied to the
+// report directory before session cleanup runs.
+func TestWorkspaceLifecycle_FilesAvailableBeforeCleanup(t *testing.T) {
+	genWs, err := NewWorkspace("test-prompt", "test-config")
+	if err != nil {
+		t.Fatalf("NewWorkspace() error: %v", err)
+	}
+	defer genWs.Cleanup()
+
+	// Simulate the Copilot agent writing files to the workspace
+	os.WriteFile(filepath.Join(genWs.Dir, "main.py"), []byte("print('hello')"), 0644)
+	os.MkdirAll(filepath.Join(genWs.Dir, "pkg"), 0755)
+	os.WriteFile(filepath.Join(genWs.Dir, "pkg", "utils.py"), []byte("# utils"), 0644)
+
+	// Create persistent report directory (mirrors engine.go ws setup)
+	reportDir := filepath.Join(t.TempDir(), "generated-code")
+	ws, err := NewWorkspaceAt(reportDir)
+	if err != nil {
+		t.Fatalf("NewWorkspaceAt() error: %v", err)
+	}
+
+	// Copy files BEFORE cleanup — this is the critical ordering (#261)
+	if err := copyDir(genWs.Dir, ws.Dir); err != nil {
+		t.Fatalf("copyDir() error: %v", err)
+	}
+
+	// Verify files are in the report directory
+	files, err := ws.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files in report dir, got %d: %v", len(files), files)
+	}
+
+	// Now simulate cleanup (as if CleanupFn ran)
+	genWs.Cleanup()
+
+	// Report dir files should survive cleanup of the temp workspace
+	files, err = ws.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() after cleanup error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("report dir should retain files after cleanup, got %d", len(files))
+	}
+
+	// Verify file contents are correct
+	data, err := os.ReadFile(filepath.Join(ws.Dir, "main.py"))
+	if err != nil {
+		t.Fatalf("reading main.py: %v", err)
+	}
+	if string(data) != "print('hello')" {
+		t.Errorf("unexpected content: %q", data)
+	}
+}
+
+// TestCleanupFn_CalledAfterFileCopy verifies the CleanupFn pattern: session
+// state is only deleted after workspace files have been safely copied.
+func TestCleanupFn_CalledAfterFileCopy(t *testing.T) {
+	genDir := t.TempDir()
+	os.WriteFile(filepath.Join(genDir, "output.py"), []byte("result"), 0644)
+
+	var cleanupCalled bool
+	result := &EvalResult{
+		GeneratedFiles: []string{"output.py"},
+		Success:        true,
+		CleanupFn: func() {
+			// Simulate DeleteSession removing workspace files
+			os.RemoveAll(genDir)
+			cleanupCalled = true
+		},
+	}
+
+	// Simulate engine.go copying files before calling CleanupFn
+	reportDir := t.TempDir()
+	if err := copyDir(genDir, reportDir); err != nil {
+		t.Fatalf("copyDir() error: %v", err)
+	}
+
+	// Verify files exist in report dir BEFORE cleanup
+	data, err := os.ReadFile(filepath.Join(reportDir, "output.py"))
+	if err != nil {
+		t.Fatalf("file not copied to report dir: %v", err)
+	}
+	if string(data) != "result" {
+		t.Errorf("unexpected content: %q", data)
+	}
+
+	// Call CleanupFn — simulates session deletion
+	if result.CleanupFn != nil {
+		result.CleanupFn()
+	}
+
+	if !cleanupCalled {
+		t.Error("CleanupFn should have been called")
+	}
+
+	// genDir is now removed (simulating DeleteSession behavior)
+	if _, err := os.Stat(genDir); !os.IsNotExist(err) {
+		t.Error("genDir should be removed by CleanupFn")
+	}
+
+	// But report dir files should survive
+	data, err = os.ReadFile(filepath.Join(reportDir, "output.py"))
+	if err != nil {
+		t.Fatalf("report dir file should survive CleanupFn: %v", err)
+	}
+	if string(data) != "result" {
+		t.Errorf("unexpected content after cleanup: %q", data)
+	}
+}
+
+// TestCleanupFn_NilSafe verifies that nil CleanupFn doesn't panic.
+func TestCleanupFn_NilSafe(t *testing.T) {
+	result := &EvalResult{Success: true}
+	// Should not panic
+	if result.CleanupFn != nil {
+		result.CleanupFn()
+	}
+}
+
+// TestCleanupFn_StubEvaluatorHasNoCleanup verifies StubEvaluator returns nil CleanupFn.
+func TestCleanupFn_StubEvaluatorHasNoCleanup(t *testing.T) {
+	stub := &StubEvaluator{}
+	result, err := stub.Evaluate(context.Background(),
+		&prompt.Prompt{ID: "test"},
+		&config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "test"}},
+		t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CleanupFn != nil {
+		t.Error("StubEvaluator should have nil CleanupFn")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two issues on a single branch:

### Issue #261 (P0): Workspace lifecycle bug — baseline configs fail to generate files

**Root cause:** `CopilotSDKEvaluator.Evaluate()` deferred `client.DeleteSession()` which removed workspace artifacts (including generated files) before returning to `runSingleEval()`. The engine's `copyDir(genDir, ws.Dir)` then found an empty workspace because the CLI had already cleaned up the session's artifacts.

Azure MCP configs were unaffected because MCP server processes kept file handles open during `DeleteSession`, preventing the CLI from removing workspace files. Baseline configs (no MCP servers) had no such protection.

**Fix:** Introduced a `CleanupFn` callback on `EvalResult`. Session deletion is now deferred to the caller, who invokes it AFTER safely copying workspace files to the persistent report directory. A safety-net defer in `Evaluate()` ensures cleanup still runs on early-return error paths.

**Files changed:**
- `hyoka/internal/eval/engine.go` — Added `CleanupFn` to `EvalResult`, call it after `copyDir`
- `hyoka/internal/eval/copilot.go` — Refactored defer to use `buildCleanupFn` pattern
- `hyoka/internal/eval/workspace_test.go` — Added 4 workspace lifecycle tests

### Issue #264 (P1): Pre-flight model availability check

**Problem:** The review panel discovers unavailable models (e.g. `gemini-3-pro-preview`) mid-eval, wasting time and compute.

**Fix:** Added `--check-models` flag that queries the Copilot backend's `models.list` RPC before starting evaluations. Fails fast with a clear error listing unavailable models and available alternatives.

**Files changed:**
- `hyoka/internal/eval/modelcheck.go` — `CheckModelAvailability`/`ValidateModelAvailability` + `collectRequiredModels`
- `hyoka/internal/eval/modelcheck_test.go` — 7 tests for model collection and result handling
- `hyoka/internal/eval/engine.go` — Added `CheckModels` to `EngineOptions`, wired into `Run()`
- `hyoka/cmd/run.go` — Added `--check-models` flag

### Testing

- All 27 packages pass (`go test ./hyoka/... -count=1`)
- `go build` and `go vet` clean
- 11 new tests covering both fixes

Closes #261, Closes #264