### PR TITLE
fix: resolve .gitignore gaps — site/node_modules and .agents/ contradiction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,11 @@ logs/
 *-debug.log
 
 # Agent workspace
-.agents/
 .claude/
 skills-lock.json
+
+# Node modules
+site/node_modules/
 
 # Built binary
 /hyoka/azsdk-prompt-eval
@@ -47,3 +49,6 @@ skills-lock.json
 .squad/sessions/
 # Squad: SubSquad activation file (local to this machine)
 .squad-workstream
+
+# Playwright MCP snapshots
+.playwright-mcp/


### PR DESCRIPTION
Closes #266

- Remove .agents/ from .gitignore (files are tracked and needed)
- Add site/node_modules/ to .gitignore (452MB, not needed in git)
- Confirmed *.log already covered