### PR TITLE
feat: multi-model generator fan-out and plugin-as-tools integration (#279, #280)

### DIFF
--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -206,6 +206,7 @@ func runCmd() *cobra.Command {
 						configs[i].Generator = &config.GeneratorConfig{}
 					}
 					configs[i].Generator.Model = f.model
+					configs[i].Generator.Models = nil
 				}
 			}
 
@@ -246,8 +247,23 @@ func runCmd() *cobra.Command {
 				return fmt.Errorf("no prompts matched the given filters")
 			}
 
+			effectiveConfigs := 0
+			for _, c := range configs {
+				if c.Generator == nil {
+					continue
+				}
+				models := c.Generator.ResolveModels()
+				if len(models) == 0 {
+					continue
+				}
+				effectiveConfigs += len(models)
+			}
+			if effectiveConfigs == 0 {
+				effectiveConfigs = len(configs)
+			}
+
 			fmt.Printf("Found %d prompt(s), %d config(s) \u2192 %d evaluation(s)\n",
-				len(filtered), len(configs), len(filtered)*len(configs))
+				len(filtered), effectiveConfigs, len(filtered)*effectiveConfigs)
 
 			// Select evaluator and reviewer
 			var evaluator eval.CopilotEvaluator

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -8,16 +8,34 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/ronniegeraghty/hyoka/internal/plugin"
 	"gopkg.in/yaml.v3"
 )
 
 // GeneratorConfig holds all configuration for the code generation agent.
 type GeneratorConfig struct {
-	Model         string      `yaml:"model" json:"model"`
+	Model         string      `yaml:"model,omitempty" json:"model,omitempty"`
+	Models        []string    `yaml:"models,omitempty" json:"models,omitempty"`
 	SystemPrompt  string      `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
 	Tools         []ToolEntry `yaml:"tools,omitempty" json:"tools,omitempty"`
 	ExcludedTools []string    `yaml:"excluded_tools,omitempty" json:"excluded_tools,omitempty"`
+}
+
+// ResolveModels returns the generator models to use. Models takes precedence
+// over Model when both are set.
+func (g *GeneratorConfig) ResolveModels() []string {
+	if g == nil {
+		return nil
+	}
+	if len(g.Models) > 0 {
+		return g.Models
+	}
+	if g.Model != "" {
+		return []string{g.Model}
+	}
+	return nil
 }
 
 // ReviewerConfig holds all configuration for the review/grading plane.
@@ -58,7 +76,17 @@ func Load(path string) (*ConfigFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
-	return Parse(data)
+	cfg, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.ExpandPlugins(resolvePluginsDir()); err != nil {
+		return nil, fmt.Errorf("expanding plugins: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 // LoadDir reads all .yaml files in a directory and merges their configs.
@@ -107,7 +135,8 @@ func Parse(data []byte) (*ConfigFile, error) {
 		return nil, err
 	}
 	for _, c := range cfg.Configs {
-		slog.Info("Config loaded", "name", c.Name, "model", c.Generator.Model)
+		models := c.Generator.ResolveModels()
+		slog.Info("Config loaded", "name", c.Name, "models", strings.Join(models, ","))
 	}
 	return &cfg, nil
 }
@@ -123,8 +152,22 @@ func (cf *ConfigFile) Validate() error {
 			return fmt.Errorf("config at index %d has no name", i)
 		}
 		// Generator with a model is required for every config.
-		if c.Generator == nil || c.Generator.Model == "" {
-			return fmt.Errorf("config %q: generator.model is required", c.Name)
+		if c.Generator == nil {
+			return fmt.Errorf("config %q: generator.model or generator.models is required", c.Name)
+		}
+		models := c.Generator.ResolveModels()
+		if len(models) == 0 {
+			return fmt.Errorf("config %q: generator.model or generator.models is required", c.Name)
+		}
+		seenModels := make(map[string]bool, len(models))
+		for _, model := range models {
+			if model == "" {
+				return fmt.Errorf("config %q: generator model must not be empty", c.Name)
+			}
+			if seenModels[model] {
+				return fmt.Errorf("config %q: duplicate generator model %q", c.Name, model)
+			}
+			seenModels[model] = true
 		}
 		if prev, ok := namesSeen[c.Name]; ok {
 			return fmt.Errorf("duplicate config name %q at index %d and %d", c.Name, prev, i)
@@ -218,8 +261,17 @@ func InstallSkillsAndPlugins(configs []ToolConfig) error {
 	}
 	var entries []entry
 
+	reg := plugin.NewRegistry()
+	pluginsDir := resolvePluginsDir()
+	if err := reg.LoadDir(pluginsDir); err != nil {
+		return err
+	}
+
 	for _, c := range configs {
 		for _, p := range c.Plugins {
+			if _, err := reg.Get(p); err == nil {
+				continue
+			}
 			if !seen["plugin:"+p] {
 				seen["plugin:"+p] = true
 				entries = append(entries, entry{"plugin", p})

--- a/hyoka/internal/config/config_test.go
+++ b/hyoka/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -349,6 +350,47 @@ configs:
 	}
 }
 
+func TestExpandPluginsAppendsTools(t *testing.T) {
+	dir := t.TempDir()
+	pluginPath := filepath.Join(dir, "test-plugin.yaml")
+	pluginData := []byte(`
+name: test-plugin
+skills:
+  - type: local
+    path: ./skills/generator
+mcp_servers:
+  azure:
+    type: stdio
+    command: npx
+    args: ["-y", "@azure/mcp@latest"]
+`)
+	if err := os.WriteFile(pluginPath, pluginData, 0644); err != nil {
+		t.Fatalf("failed to write plugin: %v", err)
+	}
+
+	cf := &ConfigFile{
+		Configs: []ToolConfig{
+			{
+				Name:        "with-plugin",
+				Description: "plugin config",
+				Generator:   &GeneratorConfig{Model: "gpt-4"},
+				Reviewer:    &ReviewerConfig{Models: []string{"gpt-4"}},
+				Plugins:     []string{"test-plugin"},
+			},
+		},
+	}
+	if err := cf.ExpandPlugins(dir); err != nil {
+		t.Fatalf("expand plugins failed: %v", err)
+	}
+	c := cf.Configs[0]
+	if len(c.Generator.Tools) != 2 {
+		t.Fatalf("expected 2 generator tools, got %d", len(c.Generator.Tools))
+	}
+	if len(c.Reviewer.Tools) != 2 {
+		t.Fatalf("expected 2 reviewer tools, got %d", len(c.Reviewer.Tools))
+	}
+}
+
 func TestInstallSkillsAndPluginsEmpty(t *testing.T) {
 	configs := []ToolConfig{
 		{Name: "empty", Description: "No skills", Generator: &GeneratorConfig{Model: "gpt-4"}},
@@ -632,6 +674,42 @@ func TestGeneratorModelDirectAccess(t *testing.T) {
 	}
 }
 
+func TestResolveModelsSingle(t *testing.T) {
+	g := &GeneratorConfig{Model: "gpt-4"}
+	if got := g.ResolveModels(); !reflect.DeepEqual(got, []string{"gpt-4"}) {
+		t.Errorf("expected [gpt-4], got %v", got)
+	}
+}
+
+func TestResolveModelsMultiple(t *testing.T) {
+	g := &GeneratorConfig{Models: []string{"claude-opus-4.6", "claude-sonnet-4.5"}}
+	want := []string{"claude-opus-4.6", "claude-sonnet-4.5"}
+	if got := g.ResolveModels(); !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestResolveModelsBoth(t *testing.T) {
+	g := &GeneratorConfig{Model: "ignored", Models: []string{"m1", "m2"}}
+	want := []string{"m1", "m2"}
+	if got := g.ResolveModels(); !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestResolveModelsNone(t *testing.T) {
+	g := &GeneratorConfig{}
+	if got := g.ResolveModels(); len(got) != 0 {
+		t.Errorf("expected empty models, got %v", got)
+	}
+	cf := &ConfigFile{
+		Configs: []ToolConfig{{Name: "missing", Generator: g}},
+	}
+	if err := cf.Validate(); err == nil {
+		t.Fatal("expected error for missing generator model")
+	}
+}
+
 func TestValidateRejectsNilGenerator(t *testing.T) {
 	cf := &ConfigFile{
 		Configs: []ToolConfig{
@@ -642,7 +720,7 @@ func TestValidateRejectsNilGenerator(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil generator")
 	}
-	want := `config "no-gen": generator.model is required`
+	want := `config "no-gen": generator.model or generator.models is required`
 	if err.Error() != want {
 		t.Errorf("got %q, want %q", err.Error(), want)
 	}
@@ -708,7 +786,7 @@ func TestValidateRejectsEmptyGeneratorModel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty generator model")
 	}
-	want := `config "empty-model": generator.model is required`
+	want := `config "empty-model": generator.model or generator.models is required`
 	if err.Error() != want {
 		t.Errorf("got %q, want %q", err.Error(), want)
 	}
@@ -879,7 +957,7 @@ configs:
 	if err == nil {
 		t.Fatal("expected error for nil generator")
 	}
-	want := `config "nil-gen": generator.model is required`
+	want := `config "nil-gen": generator.model or generator.models is required`
 	if err.Error() != want {
 		t.Errorf("got %q, want %q", err.Error(), want)
 	}

--- a/hyoka/internal/config/plugins.go
+++ b/hyoka/internal/config/plugins.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"log/slog"
+
+	"github.com/ronniegeraghty/hyoka/internal/plugin"
+)
+
+// ExpandPlugins loads plugins from dir and appends their tool entries to configs.
+// Missing plugin directories are skipped silently.
+func (cf *ConfigFile) ExpandPlugins(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	reg := plugin.NewRegistry()
+	if err := reg.LoadDir(dir); err != nil {
+		return err
+	}
+	if reg.Count() == 0 {
+		return nil
+	}
+	for i := range cf.Configs {
+		if err := cf.Configs[i].ExpandPlugins(reg); err != nil {
+			return err
+		}
+	}
+	slog.Debug("Expanded plugins into tool entries", "plugins", reg.Count())
+	return nil
+}
+
+// ExpandPlugins appends plugin-derived tool entries to generator/reviewer tools.
+func (c *ToolConfig) ExpandPlugins(reg *plugin.Registry) error {
+	if reg == nil || len(c.Plugins) == 0 {
+		return nil
+	}
+	var entries []ToolEntry
+	for _, name := range c.Plugins {
+		p, err := reg.Get(name)
+		if err != nil {
+			return err
+		}
+		for _, entry := range p.ToToolEntries() {
+			entries = append(entries, convertPluginToolEntry(entry))
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if c.Generator != nil {
+		c.Generator.Tools = appendToolEntries(c.Generator.Tools, entries)
+	}
+	if c.Reviewer != nil {
+		c.Reviewer.Tools = appendToolEntries(c.Reviewer.Tools, entries)
+	}
+	return nil
+}
+
+func convertPluginToolEntry(entry plugin.ToolEntry) ToolEntry {
+	return ToolEntry{
+		Name:     entry.Name,
+		Type:     entry.Type,
+		Source:   entry.Source,
+		Path:     entry.Path,
+		Repo:     entry.Repo,
+		Command:  entry.Command,
+		Args:     cloneStringSlice(entry.Args),
+		MCPTools: cloneStringSlice(entry.MCPTools),
+	}
+}
+
+func appendToolEntries(existing []ToolEntry, extras []ToolEntry) []ToolEntry {
+	if len(extras) == 0 {
+		return existing
+	}
+	seen := make(map[string]bool, len(existing))
+	for _, entry := range existing {
+		key := entry.ResolvedType() + ":" + entry.Name
+		seen[key] = true
+	}
+	for _, entry := range extras {
+		key := entry.ResolvedType() + ":" + entry.Name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		existing = append(existing, entry)
+	}
+	return existing
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	clone := make([]string, len(values))
+	copy(clone, values)
+	return clone
+}
+
+func resolvePluginsDir() string {
+	proj := DiscoverFromCWD()
+	candidates := ResolveCandidates(proj, "plugins", "./plugins", "../plugins")
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return "./plugins"
+}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -257,6 +257,82 @@ type resolvedLimits struct {
 	maxSessionActions int
 }
 
+func expandGeneratorModels(configs []config.ToolConfig) ([]config.ToolConfig, error) {
+	var expanded []config.ToolConfig
+	for _, cfg := range configs {
+		if cfg.Generator == nil {
+			return nil, fmt.Errorf("config %q: generator.model or generator.models is required", cfg.Name)
+		}
+		models := cfg.Generator.ResolveModels()
+		if len(models) == 0 {
+			return nil, fmt.Errorf("config %q: generator.model or generator.models is required", cfg.Name)
+		}
+		for _, model := range models {
+			clone := cloneToolConfigForModel(cfg, model)
+			if len(models) > 1 {
+				clone.Name = fmt.Sprintf("%s/%s", cfg.Name, model)
+			}
+			expanded = append(expanded, clone)
+		}
+	}
+	return expanded, nil
+}
+
+func cloneToolConfigForModel(src config.ToolConfig, model string) config.ToolConfig {
+	dst := src
+	if src.Generator != nil {
+		gen := *src.Generator
+		gen.Model = model
+		gen.Models = nil
+		if len(src.Generator.Tools) > 0 {
+			gen.Tools = cloneToolEntries(src.Generator.Tools)
+		}
+		if len(src.Generator.ExcludedTools) > 0 {
+			gen.ExcludedTools = append([]string(nil), src.Generator.ExcludedTools...)
+		}
+		dst.Generator = &gen
+	}
+	if src.Reviewer != nil {
+		rev := *src.Reviewer
+		if len(src.Reviewer.Tools) > 0 {
+			rev.Tools = cloneToolEntries(src.Reviewer.Tools)
+		}
+		if len(src.Reviewer.Models) > 0 {
+			rev.Models = append([]string(nil), src.Reviewer.Models...)
+		}
+		dst.Reviewer = &rev
+	}
+	if len(src.Plugins) > 0 {
+		dst.Plugins = append([]string(nil), src.Plugins...)
+	}
+	return dst
+}
+
+func cloneToolEntries(entries []config.ToolEntry) []config.ToolEntry {
+	clone := make([]config.ToolEntry, len(entries))
+	for i, te := range entries {
+		clone[i] = te
+		if te.When != nil {
+			m := make(map[string]string, len(te.When))
+			for k, v := range te.When {
+				m[k] = v
+			}
+			clone[i].When = m
+		}
+		if te.Args != nil {
+			args := make([]string, len(te.Args))
+			copy(args, te.Args)
+			clone[i].Args = args
+		}
+		if te.MCPTools != nil {
+			tools := make([]string, len(te.MCPTools))
+			copy(tools, te.MCPTools)
+			clone[i].MCPTools = tools
+		}
+	}
+	return clone
+}
+
 // resolveLimits merges per-config session limits with engine defaults.
 // Config values > 0 take precedence; zero values fall back to engine defaults.
 func (e *Engine) resolveLimits(cfg config.ToolConfig) resolvedLimits {
@@ -291,6 +367,12 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 
 	// Load pluggable grader configs (#136) if configured.
 	e.loadGraders()
+
+	expandedConfigs, err := expandGeneratorModels(configs)
+	if err != nil {
+		return nil, err
+	}
+	configs = expandedConfigs
 
 	// Build task list (cross product: prompts × configs)
 	var tasks []EvalTask

--- a/hyoka/internal/eval/modelcheck.go
+++ b/hyoka/internal/eval/modelcheck.go
@@ -100,10 +100,12 @@ func collectRequiredModels(configs []config.ToolConfig) []string {
 	seen := make(map[string]bool)
 	var models []string
 	for _, cfg := range configs {
-		if cfg.Generator != nil && cfg.Generator.Model != "" {
-			if !seen[cfg.Generator.Model] {
-				seen[cfg.Generator.Model] = true
-				models = append(models, cfg.Generator.Model)
+		if cfg.Generator != nil {
+			for _, gm := range cfg.Generator.ResolveModels() {
+				if !seen[gm] {
+					seen[gm] = true
+					models = append(models, gm)
+				}
 			}
 		}
 		if cfg.Reviewer != nil {

--- a/hyoka/internal/pairwise/pairwise.go
+++ b/hyoka/internal/pairwise/pairwise.go
@@ -109,6 +109,10 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 			gen.ExcludedTools = make([]string, len(src.Generator.ExcludedTools))
 			copy(gen.ExcludedTools, src.Generator.ExcludedTools)
 		}
+		if len(src.Generator.Models) > 0 {
+			gen.Models = make([]string, len(src.Generator.Models))
+			copy(gen.Models, src.Generator.Models)
+		}
 
 		dst.Generator = &gen
 	}

--- a/hyoka/internal/plugin/plugin.go
+++ b/hyoka/internal/plugin/plugin.go
@@ -10,8 +10,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 
-	"github.com/ronniegeraghty/hyoka/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -46,6 +46,18 @@ type MCPServer struct {
 type HookConfig struct {
 	PreToolUse  []string `yaml:"pre_tool_use,omitempty" json:"pre_tool_use,omitempty"`
 	PostToolUse []string `yaml:"post_tool_use,omitempty" json:"post_tool_use,omitempty"`
+}
+
+// ToolEntry describes a unified tool entry produced from a plugin.
+type ToolEntry struct {
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Source   string   `json:"source,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Repo     string   `json:"repo,omitempty"`
+	Command  string   `json:"command,omitempty"`
+	Args     []string `json:"args,omitempty"`
+	MCPTools []string `json:"mcp_tools,omitempty"`
 }
 
 // Registry holds loaded plugins indexed by name.
@@ -143,38 +155,33 @@ func (r *Registry) Count() int {
 	return len(r.plugins)
 }
 
-// ApplyToGenerator resolves plugin names and merges their skills and MCP
-// servers into the generator's existing configuration. Duplicate entries
-// are skipped.
-func (r *Registry) ApplyToGenerator(pluginNames []string, tools *[]config.ToolEntry) error {
-	for _, name := range pluginNames {
-		p, err := r.Get(name)
-		if err != nil {
-			return err
+// ToToolEntries converts the plugin's skills and MCP servers into unified tool entries.
+func (p *Plugin) ToToolEntries() []ToolEntry {
+	var entries []ToolEntry
+	for _, s := range p.Skills {
+		entries = append(entries, toolEntryFromPluginSkill(s))
+	}
+	if len(p.MCPServers) > 0 {
+		names := make([]string, 0, len(p.MCPServers))
+		for name := range p.MCPServers {
+			names = append(names, name)
 		}
-		for _, s := range p.Skills {
-			entry := toolEntryFromPluginSkill(s)
-			if !containsToolEntry(*tools, entry) {
-				*tools = append(*tools, entry)
-			}
-		}
-		for k, v := range p.MCPServers {
-			entry := config.ToolEntry{
-				Name:     k,
+		sort.Strings(names)
+		for _, name := range names {
+			server := p.MCPServers[name]
+			entries = append(entries, ToolEntry{
+				Name:     name,
 				Type:     "mcp",
-				Command:  v.Command,
-				Args:     v.Args,
-				MCPTools: v.Tools,
-			}
-			if !containsToolEntry(*tools, entry) {
-				*tools = append(*tools, entry)
-			}
+				Command:  server.Command,
+				Args:     server.Args,
+				MCPTools: server.Tools,
+			})
 		}
 	}
-	return nil
+	return entries
 }
 
-func toolEntryFromPluginSkill(s PluginSkill) config.ToolEntry {
+func toolEntryFromPluginSkill(s PluginSkill) ToolEntry {
 	name := s.Name
 	if name == "" {
 		if s.Path != "" {
@@ -183,20 +190,11 @@ func toolEntryFromPluginSkill(s PluginSkill) config.ToolEntry {
 			name = s.Repo
 		}
 	}
-	return config.ToolEntry{
+	return ToolEntry{
 		Name:   name,
 		Type:   "skill",
 		Source: s.Type,
 		Path:   s.Path,
 		Repo:   s.Repo,
 	}
-}
-
-func containsToolEntry(tools []config.ToolEntry, entry config.ToolEntry) bool {
-	for _, existing := range tools {
-		if existing.ResolvedType() == entry.ResolvedType() && existing.Name == entry.Name {
-			return true
-		}
-	}
-	return false
 }

--- a/hyoka/internal/plugin/plugin_test.go
+++ b/hyoka/internal/plugin/plugin_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
-
-	"github.com/ronniegeraghty/hyoka/internal/config"
 )
 
 func TestMain(m *testing.M) {
@@ -179,80 +177,29 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func TestApplyToGenerator(t *testing.T) {
-	reg := NewRegistry()
-	reg.plugins["sdk-tools"] = &Plugin{
+func TestPluginToToolEntries(t *testing.T) {
+	p := &Plugin{
 		Name: "sdk-tools",
 		Skills: []PluginSkill{
 			{Type: "local", Path: "./skills/sdk"},
-			{Type: "remote", Repo: "github.com/example/repo"},
+			{Type: "remote", Repo: "github.com/example/repo", Name: "sdk"},
 		},
 		MCPServers: map[string]*MCPServer{
-			"azure-cli": {Type: "stdio", Command: "az", Args: []string{"mcp"}},
-		},
-	}
-	reg.plugins["review-helpers"] = &Plugin{
-		Name: "review-helpers",
-		Skills: []PluginSkill{
-			{Type: "local", Path: "./skills/review"},
+			"azure-cli": {Type: "stdio", Command: "az", Args: []string{"mcp"}, Tools: []string{"*"}},
 		},
 	}
 
-	var tools []config.ToolEntry
-
-	err := reg.ApplyToGenerator([]string{"sdk-tools", "review-helpers"}, &tools)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	entries := p.ToToolEntries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 tool entries, got %d", len(entries))
 	}
-	if len(tools) != 4 {
-		t.Errorf("expected 4 tools, got %d", len(tools))
+	if entries[0].Type != "skill" || entries[0].Name != "./skills/sdk" {
+		t.Errorf("expected first entry to use path as name, got %+v", entries[0])
 	}
-	foundMCP := false
-	for _, entry := range tools {
-		if entry.ResolvedType() == "mcp" && entry.Name == "azure-cli" {
-			foundMCP = true
-			break
-		}
+	if entries[1].Type != "skill" || entries[1].Repo != "github.com/example/repo" {
+		t.Errorf("expected second entry to be remote skill, got %+v", entries[1])
 	}
-	if !foundMCP {
-		t.Error("expected azure-cli MCP server")
-	}
-}
-
-func TestApplyToGeneratorDedup(t *testing.T) {
-	reg := NewRegistry()
-	reg.plugins["a"] = &Plugin{
-		Name:   "a",
-		Skills: []PluginSkill{{Type: "local", Path: "./same"}},
-		MCPServers: map[string]*MCPServer{
-			"srv": {Type: "stdio", Command: "cmd"},
-		},
-	}
-	reg.plugins["b"] = &Plugin{
-		Name:   "b",
-		Skills: []PluginSkill{{Type: "local", Path: "./same"}}, // duplicate
-		MCPServers: map[string]*MCPServer{
-			"srv": {Type: "stdio", Command: "other"}, // duplicate key
-		},
-	}
-
-	var tools []config.ToolEntry
-
-	err := reg.ApplyToGenerator([]string{"a", "b"}, &tools)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(tools) != 2 {
-		t.Errorf("expected 2 deduplicated tools, got %d", len(tools))
-	}
-}
-
-func TestApplyToGeneratorNotFound(t *testing.T) {
-	reg := NewRegistry()
-	var tools []config.ToolEntry
-
-	err := reg.ApplyToGenerator([]string{"nonexistent"}, &tools)
-	if err == nil {
-		t.Fatal("expected error for missing plugin")
+	if entries[2].Type != "mcp" || entries[2].Name != "azure-cli" || entries[2].Command != "az" {
+		t.Errorf("expected MCP entry for azure-cli, got %+v", entries[2])
 	}
 }

--- a/plugins/azure-python.yaml
+++ b/plugins/azure-python.yaml
@@ -1,0 +1,11 @@
+name: azure-python
+description: "Azure SDK for Python — MCP server + best practices skill"
+skills:
+  - type: local
+    name: azure-python-best-practices
+    path: ./skills/generator
+mcp_servers:
+  azure:
+    type: stdio
+    command: npx
+    args: ["-y", "@azure/mcp@latest", "server", "start"]


### PR DESCRIPTION
## Summary
- add generator models fan-out with ResolveModels and config expansion
- expand plugins into unified tool entries during config load
- include example azure-python plugin and updated tests

## Testing
- go build ./hyoka/...
- go test ./hyoka/... -count=1 -timeout 3m

Closes #279
Closes #280