### PR TITLE
Redesign pairwise tool ablation

### DIFF
--- a/docs/tool-filter-schema.md
+++ b/docs/tool-filter-schema.md
@@ -35,7 +35,8 @@ generator:
 ```
 
 Only entries with `type: tool` (or empty type) participate in tool filtering. `type: mcp`
-entries configure MCP servers, and `type: skill` entries configure skills.
+entries configure MCP servers, and `type: skill` entries configure skills. Pairwise
+ablation can be configured for any entry type via the `pairwise` field.
 
 ### `ToolEntry` (tool filtering fields)
 
@@ -45,6 +46,7 @@ entries configure MCP servers, and `type: skill` entries configure skills.
 | `type`    | `string`            | no       | Defaults to `tool`; only `tool` entries are filtered |
 | `when`    | `map[string]string` | no       | Include this tool only when **all** key-value pairs match |
 | `always_on` | `bool`            | no       | Never toggled during pairwise tool ablation |
+| `pairwise`  | `string`          | no       | Pairwise toggle mode: `off`, `shallow` (default), `deep` |
 
 A `ToolEntry` with no `when` clause is unconditional (always included).
 

--- a/hyoka/cmd/cmd_test.go
+++ b/hyoka/cmd/cmd_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+"bytes"
 "io"
+"os"
+"path/filepath"
+"strings"
 "testing"
 )
 
@@ -301,6 +305,60 @@ t.Fatalf("getting -P value: %v", err)
 }
 if !val2 {
 t.Error("-P shorthand should set --pairwise to true")
+}
+}
+
+func TestRunCmdPairwiseDryRunWithMCPConfig(t *testing.T) {
+cmd := runCmd()
+cmd.SilenceErrors = true
+cmd.SilenceUsage = true
+
+repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+if err != nil {
+t.Fatalf("resolving repo root: %v", err)
+}
+
+args := []string{
+"--dry-run",
+"--pairwise",
+"--prompt-id", "key-vault-dp-python-crud",
+"--config", "azure-mcp/claude-opus-4.6",
+"--prompts", filepath.Join(repoRoot, "prompts"),
+"--config-dir", filepath.Join(repoRoot, "configs"),
+"--progress", "off",
+"--output", filepath.Join(repoRoot, "reports"),
+}
+cmd.SetArgs(args)
+
+oldStdout := os.Stdout
+reader, writer, err := os.Pipe()
+if err != nil {
+t.Fatalf("creating stdout pipe: %v", err)
+}
+os.Stdout = writer
+t.Cleanup(func() {
+os.Stdout = oldStdout
+})
+
+outputCh := make(chan string, 1)
+go func() {
+var buf bytes.Buffer
+_, _ = io.Copy(&buf, reader)
+_ = reader.Close()
+outputCh <- buf.String()
+}()
+
+execErr := cmd.Execute()
+_ = writer.Close()
+os.Stdout = oldStdout
+output := <-outputCh
+
+if execErr != nil {
+t.Fatalf("run command failed: %v", execErr)
+}
+
+if !strings.Contains(output, "Expanded config \"azure-mcp/claude-opus-4.6\" into 2 pairwise variants") {
+t.Errorf("expected pairwise expansion output, got: %s", output)
 }
 }
 

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -11,6 +11,7 @@ type ToolEntry struct {
 	Type     string            `yaml:"type,omitempty" json:"type,omitempty"` // "tool" (default), "mcp", "skill"
 	When     map[string]string `yaml:"when,omitempty" json:"when,omitempty"`
 	AlwaysOn bool              `yaml:"always_on,omitempty" json:"always_on,omitempty"`
+	Pairwise string            `yaml:"pairwise,omitempty" json:"pairwise,omitempty"` // "off", "shallow" (default), "deep"
 	// MCP-specific fields
 	Command  string   `yaml:"command,omitempty" json:"command,omitempty"`
 	Args     []string `yaml:"args,omitempty" json:"args,omitempty"`
@@ -31,6 +32,18 @@ func resolvedToolType(entry ToolEntry) string {
 // ResolvedType returns the normalized entry type ("tool" by default).
 func (e ToolEntry) ResolvedType() string {
 	return resolvedToolType(e)
+}
+
+// ResolvedPairwise returns the effective pairwise setting ("shallow" default).
+// AlwaysOn overrides any explicit setting to "off".
+func (e ToolEntry) ResolvedPairwise() string {
+	if e.AlwaysOn {
+		return "off"
+	}
+	if e.Pairwise == "" {
+		return "shallow"
+	}
+	return e.Pairwise
 }
 
 // SkillSource returns the normalized skill source ("local" or "remote").
@@ -85,6 +98,9 @@ func matchesWhen(when map[string]string, props map[string]string) bool {
 func validateToolEntry(entry ToolEntry, configName string, idx int) error {
 	if entry.Name == "" {
 		return fmt.Errorf("config %q: tools[%d] missing name", configName, idx)
+	}
+	if entry.Pairwise != "" && entry.Pairwise != "off" && entry.Pairwise != "shallow" && entry.Pairwise != "deep" {
+		return fmt.Errorf("config %q: tools[%d] has invalid pairwise %q", configName, idx, entry.Pairwise)
 	}
 	switch resolvedToolType(entry) {
 	case "tool":

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -131,7 +131,8 @@ func TestMatchesWhen_MissingProperty(t *testing.T) {
 func TestValidateToolEntry_Valid(t *testing.T) {
 	cases := []ToolEntry{
 		{Name: "bash"},
-		{Name: "azure", Type: "mcp", Command: "npx"},
+		{Name: "create", Pairwise: "off"},
+		{Name: "azure", Type: "mcp", Command: "npx", Pairwise: "deep", MCPTools: []string{"storage"}},
 		{Name: "gen-skill", Type: "skill", Source: "local", Path: "./skills/generator"},
 	}
 	for i, tc := range cases {
@@ -267,6 +268,13 @@ func TestValidateToolEntry_InvalidType(t *testing.T) {
 	}
 }
 
+func TestValidateToolEntry_InvalidPairwise(t *testing.T) {
+	entry := ToolEntry{Name: "bad", Pairwise: "loud"}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for invalid pairwise value")
+	}
+}
+
 func TestValidateToolEntry_MCPMissingCommand(t *testing.T) {
 	entry := ToolEntry{Name: "azure", Type: "mcp"}
 	if err := validateToolEntry(entry, "test", 0); err == nil {
@@ -285,5 +293,22 @@ func TestValidateToolEntry_SkillInvalidSource(t *testing.T) {
 	entry := ToolEntry{Name: "skill", Type: "skill", Source: "bad", Path: "./skills"}
 	if err := validateToolEntry(entry, "test", 0); err == nil {
 		t.Fatal("expected error for invalid skill source")
+	}
+}
+
+func TestToolEntryResolvedPairwise(t *testing.T) {
+	cases := []struct {
+		entry ToolEntry
+		want  string
+	}{
+		{entry: ToolEntry{Name: "bash"}, want: "shallow"},
+		{entry: ToolEntry{Name: "bash", Pairwise: "deep"}, want: "deep"},
+		{entry: ToolEntry{Name: "bash", Pairwise: "off"}, want: "off"},
+		{entry: ToolEntry{Name: "bash", Pairwise: "deep", AlwaysOn: true}, want: "off"},
+	}
+	for _, tc := range cases {
+		if got := tc.entry.ResolvedPairwise(); got != tc.want {
+			t.Errorf("ResolvedPairwise(%+v) = %q, want %q", tc.entry, got, tc.want)
+		}
 	}
 }

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/criteria"
 	"github.com/ronniegeraghty/hyoka/internal/graders"
 	"github.com/ronniegeraghty/hyoka/internal/logging"
+	"github.com/ronniegeraghty/hyoka/internal/pairwise"
 	"github.com/ronniegeraghty/hyoka/internal/progress"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
 	"github.com/ronniegeraghty/hyoka/internal/report"
@@ -675,6 +678,14 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 			SessionCount:   rs.SessionCount,
 		}
 		e.printf("\n🔍 Resource usage: %s\n", resMonitor.SummaryLine())
+	}
+
+	pairwiseReports, pairwiseImpacts := collectPairwiseReports(summary.Results)
+	if len(pairwiseReports) > 0 {
+		summary.PairwiseResults = pairwiseReports
+		if _, err := report.WritePairwiseReport(runID, pairwiseReports, pairwiseImpacts, e.opts.OutputDir); err != nil {
+			slog.Warn("Failed to write pairwise report", "error", err)
+		}
 	}
 
 	// Write JSON summary
@@ -1385,6 +1396,97 @@ func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
 	summary.TotalConfigs = len(configNames)
 
 	return summary, nil
+}
+
+func collectPairwiseReports(results []*report.EvalReport) ([]*pairwise.PairwiseReport, []pairwise.ToolImpact) {
+	type key struct {
+		promptID string
+		baseName string
+	}
+
+	byKey := make(map[key][]pairwise.VariantResult)
+
+	for _, r := range results {
+		model := ""
+		if r.ConfigUsed != nil {
+			if m, ok := r.ConfigUsed["model"].(string); ok {
+				model = m
+			}
+		}
+		baseName, removedTool, ok := parsePairwiseConfigName(r.ConfigName, model)
+		if !ok {
+			continue
+		}
+		score, maxScore := pairwiseScore(r)
+		k := key{promptID: r.PromptID, baseName: baseName}
+		byKey[k] = append(byKey[k], pairwise.VariantResult{
+			ConfigName:  r.ConfigName,
+			RemovedTool: removedTool,
+			Score:       score,
+			MaxScore:    maxScore,
+			Success:     r.Success,
+		})
+	}
+
+	if len(byKey) == 0 {
+		return nil, nil
+	}
+
+	var reports []*pairwise.PairwiseReport
+	for k, variants := range byKey {
+		report, err := pairwise.ComputeImpacts(k.promptID, variants)
+		if err != nil {
+			slog.Warn("Pairwise impact computation failed", "prompt", k.promptID, "config", k.baseName, "error", err)
+			continue
+		}
+		reports = append(reports, report)
+	}
+
+	if len(reports) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].PromptID != reports[j].PromptID {
+			return reports[i].PromptID < reports[j].PromptID
+		}
+		return reports[i].Baseline.ConfigName < reports[j].Baseline.ConfigName
+	})
+
+	impacts := pairwise.AggregateImpacts(reports)
+	return reports, impacts
+}
+
+func parsePairwiseConfigName(configName, model string) (string, string, bool) {
+	suffix := ""
+	if model != "" && strings.HasSuffix(configName, "/"+model) {
+		suffix = "/" + model
+		configName = strings.TrimSuffix(configName, suffix)
+	}
+
+	if strings.HasSuffix(configName, "/baseline") {
+		base := strings.TrimSuffix(configName, "/baseline")
+		return base + suffix, "", true
+	}
+
+	if idx := strings.LastIndex(configName, "/without-"); idx != -1 {
+		base := configName[:idx]
+		removed := configName[idx+len("/without-"):]
+		return base + suffix, removed, true
+	}
+
+	return "", "", false
+}
+
+func pairwiseScore(r *report.EvalReport) (int, int) {
+	if r.Review != nil {
+		return r.Review.OverallScore, r.Review.MaxScore
+	}
+	if r.ScoreBreakdown != nil {
+		score := int(math.Round(r.ScoreBreakdown.FinalScorePct))
+		return score, 100
+	}
+	return 0, 0
 }
 
 // evaluateToolUsage compares expected tools from prompt frontmatter with actual tool calls.

--- a/hyoka/internal/pairwise/pairwise.go
+++ b/hyoka/internal/pairwise/pairwise.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/ronniegeraghty/hyoka/internal/config"
 )
@@ -16,7 +17,8 @@ import (
 //   - Variant 1..N: each disables one togglable tool, named "{base}/without-{tool}"
 //
 // Tools with AlwaysOn: true in Generator.Tools are never toggled.
-// Only ToolEntry values with type "tool" are considered.
+// Entries marked pairwise: off are excluded. MCP entries can opt into deep
+// toggling, which expands their mcp_tools list into individual variants.
 func ExpandPairwise(base config.ToolConfig) []config.ToolConfig {
 	togglable := collectTogglable(base)
 
@@ -48,11 +50,31 @@ func collectTogglable(cfg config.ToolConfig) []string {
 	var tools []string
 
 	for _, te := range cfg.Generator.Tools {
-		if te.ResolvedType() != "tool" || te.AlwaysOn || seen[te.Name] {
+		if te.ResolvedPairwise() == "off" {
 			continue
 		}
-		seen[te.Name] = true
-		tools = append(tools, te.Name)
+		if te.ResolvedPairwise() == "deep" && te.ResolvedType() == "mcp" {
+			if len(te.MCPTools) == 0 || containsWildcard(te.MCPTools) {
+				if !seen[te.Name] {
+					seen[te.Name] = true
+					tools = append(tools, te.Name)
+				}
+				continue
+			}
+			for _, tool := range te.MCPTools {
+				name := fmt.Sprintf("%s/%s", te.Name, tool)
+				if seen[name] {
+					continue
+				}
+				seen[name] = true
+				tools = append(tools, name)
+			}
+			continue
+		}
+		if !seen[te.Name] {
+			seen[te.Name] = true
+			tools = append(tools, te.Name)
+		}
 	}
 
 	return tools
@@ -64,9 +86,23 @@ func removeTool(cfg *config.ToolConfig, name string) {
 		return
 	}
 
+	if strings.Contains(name, "/") {
+		mcpName, toolName, ok := strings.Cut(name, "/")
+		if ok {
+			for i, te := range cfg.Generator.Tools {
+				if te.ResolvedType() != "mcp" || te.Name != mcpName {
+					continue
+				}
+				te.MCPTools = removeMCPTool(te.MCPTools, toolName)
+				cfg.Generator.Tools[i] = te
+				return
+			}
+		}
+	}
+
 	var tools []config.ToolEntry
 	for _, te := range cfg.Generator.Tools {
-		if te.ResolvedType() != "tool" || te.Name != name {
+		if te.Name != name {
 			tools = append(tools, te)
 		}
 	}
@@ -155,6 +191,36 @@ func cloneToolConfig(src config.ToolConfig) config.ToolConfig {
 	}
 
 	return dst
+}
+
+func containsWildcard(values []string) bool {
+	for _, v := range values {
+		if v == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func removeMCPTool(tools []string, remove string) []string {
+	if len(tools) == 0 {
+		return tools
+	}
+	if containsWildcard(tools) {
+		// Wildcard lists require enumerating all tools to remove one entry.
+		// Until the SDK exposes tool discovery, leave the wildcard in place.
+		return tools
+	}
+	kept := tools[:0]
+	for _, tool := range tools {
+		if tool != remove {
+			kept = append(kept, tool)
+		}
+	}
+	if len(kept) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), kept...)
 }
 
 // VariantResult holds the evaluation outcome for a single pairwise variant.

--- a/hyoka/internal/pairwise/pairwise_test.go
+++ b/hyoka/internal/pairwise/pairwise_test.go
@@ -3,6 +3,8 @@ package pairwise
 import (
 	"math"
 	"testing"
+
+	"github.com/ronniegeraghty/hyoka/internal/config"
 )
 
 func TestComputeImpacts(t *testing.T) {
@@ -53,6 +55,80 @@ func TestComputeImpacts(t *testing.T) {
 	if report.Impacts[2].Impact != -10.0 {
 		t.Errorf("expected impact -10.0, got %.1f", report.Impacts[2].Impact)
 	}
+}
+
+func TestExpandPairwise_ShallowMCP(t *testing.T) {
+	cfg := config.ToolConfig{
+		Name: "baseline",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{Name: "azure", Type: "mcp", Command: "npx"},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(cfg)
+	if len(variants) != 2 {
+		t.Fatalf("expected 2 variants, got %d", len(variants))
+	}
+	if variants[0].Name != "baseline/baseline" {
+		t.Errorf("expected baseline variant name, got %q", variants[0].Name)
+	}
+	if variants[1].Name != "baseline/without-azure" {
+		t.Errorf("expected without-azure variant, got %q", variants[1].Name)
+	}
+	if len(variants[1].Generator.Tools) != 0 {
+		t.Errorf("expected MCP entry removed, got %d tools", len(variants[1].Generator.Tools))
+	}
+}
+
+func TestExpandPairwise_DeepMCPTools(t *testing.T) {
+	cfg := config.ToolConfig{
+		Name: "baseline",
+		Generator: &config.GeneratorConfig{
+			Model: "gpt-4",
+			Tools: []config.ToolEntry{
+				{
+					Name:     "azure",
+					Type:     "mcp",
+					Command:  "npx",
+					Pairwise: "deep",
+					MCPTools: []string{"storage", "key-vault"},
+				},
+			},
+		},
+	}
+
+	variants := ExpandPairwise(cfg)
+	if len(variants) != 3 {
+		t.Fatalf("expected 3 variants, got %d", len(variants))
+	}
+
+	checkVariant := func(name string, expected []string) {
+		t.Helper()
+		for _, v := range variants {
+			if v.Name == name {
+				if len(v.Generator.Tools) != 1 {
+					t.Fatalf("expected 1 tool entry for %s, got %d", name, len(v.Generator.Tools))
+				}
+				got := v.Generator.Tools[0].MCPTools
+				if len(got) != len(expected) {
+					t.Fatalf("expected %d mcp tools for %s, got %d", len(expected), name, len(got))
+				}
+				for i, tool := range expected {
+					if got[i] != tool {
+						t.Fatalf("expected tool %q at %d for %s, got %q", tool, i, name, got[i])
+					}
+				}
+				return
+			}
+		}
+		t.Fatalf("variant %q not found", name)
+	}
+
+	checkVariant("baseline/without-azure/storage", []string{"key-vault"})
+	checkVariant("baseline/without-azure/key-vault", []string{"storage"})
 }
 
 func TestComputeImpactsNoBaseline(t *testing.T) {

--- a/hyoka/internal/report/pairwise.go
+++ b/hyoka/internal/report/pairwise.go
@@ -1,0 +1,53 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ronniegeraghty/hyoka/internal/pairwise"
+)
+
+// PairwiseRunReport captures per-prompt and aggregate pairwise results for a run.
+type PairwiseRunReport struct {
+	RunID     string                     `json:"run_id"`
+	Timestamp string                     `json:"timestamp"`
+	Reports   []*pairwise.PairwiseReport `json:"reports"`
+	Impacts   []pairwise.ToolImpact      `json:"aggregate_impacts,omitempty"`
+}
+
+// WritePairwiseReport writes pairwise results to the run output directory.
+func WritePairwiseReport(runID string, reports []*pairwise.PairwiseReport, impacts []pairwise.ToolImpact, outputDir string) (string, error) {
+	if len(reports) == 0 {
+		return "", nil
+	}
+
+	reportDir := filepath.Join(outputDir, runID)
+	if err := os.MkdirAll(reportDir, 0755); err != nil {
+		return "", fmt.Errorf("creating pairwise report directory: %w", err)
+	}
+
+	path := filepath.Join(reportDir, "pairwise.json")
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("creating pairwise report file: %w", err)
+	}
+	defer f.Close()
+
+	payload := PairwiseRunReport{
+		RunID:     runID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Reports:   reports,
+		Impacts:   impacts,
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		return "", fmt.Errorf("encoding pairwise report: %w", err)
+	}
+
+	return path, nil
+}


### PR DESCRIPTION
## Summary
- add pairwise mode to ToolEntry with validation defaults
- expand pairwise variants for MCP/skills with deep MCP tool ablation
- compute and write pairwise reports plus coverage tests

## Testing
- go build ./hyoka/...
- go test ./hyoka/... -count=1 -timeout 3m
- go run ./hyoka run --pairwise --dry-run --prompt-id key-vault-dp-python-crud --config "azure-mcp/claude-opus-4.6" --progress off