### PR TITLE
feat: Move session limits to prompt frontmatter with config/CLI fallback

### DIFF
--- a/examples/prompts/prompt-template.prompt.md
+++ b/examples/prompts/prompt-template.prompt.md
@@ -12,6 +12,8 @@ doc_url: # Library reference docs (e.g., learn.microsoft.com API overview, pkg.g
 tags: []
 created: # YYYY-MM-DD
 author: # GitHub username
+# max_session_actions: # Optional: override session action limit for this prompt (e.g., 100 for complex prompts)
+# max_turns:           # Optional: override max conversation turns for this prompt (e.g., 40 for complex prompts)
 # expected_tools: []  # Optional: tool names the generation session should use (e.g., create_file, run_terminal_command, azure_mcp)
 # starter_project: "" # Optional: path to starter project directory (relative to prompt file). Used with project_context: existing.
 # project_context:    # Optional: "blank" (default) starts from empty workspace; "existing" copies starter_project first.

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -336,29 +336,38 @@ func cloneToolEntries(entries []config.ToolEntry) []config.ToolEntry {
 	return clone
 }
 
-// resolveLimits merges per-config session limits with engine defaults.
-// Config values > 0 take precedence; zero values fall back to engine defaults.
-func (e *Engine) resolveLimits(cfg config.ToolConfig) resolvedLimits {
+// resolveLimits merges per-prompt and per-config session limits with engine defaults.
+// Resolution order: prompt frontmatter > config YAML > CLI flag/engine default.
+// Values > 0 take precedence; zero values fall back to the next layer.
+func (e *Engine) resolveLimits(cfg config.ToolConfig, p *prompt.Prompt) resolvedLimits {
 	rl := resolvedLimits{
 		maxTurns:          e.opts.MaxTurns,
 		maxFiles:          e.opts.MaxFiles,
 		maxOutputSize:     e.opts.MaxOutputSize,
 		maxSessionActions: e.opts.MaxSessionActions,
 	}
-	if cfg.Limits == nil {
-		return rl
+	if cfg.Limits != nil {
+		if cfg.Limits.MaxTurns > 0 {
+			rl.maxTurns = cfg.Limits.MaxTurns
+		}
+		if cfg.Limits.MaxFiles > 0 {
+			rl.maxFiles = cfg.Limits.MaxFiles
+		}
+		if cfg.Limits.MaxOutputSize > 0 {
+			rl.maxOutputSize = cfg.Limits.MaxOutputSize
+		}
+		if cfg.Limits.MaxSessionActions > 0 {
+			rl.maxSessionActions = cfg.Limits.MaxSessionActions
+		}
 	}
-	if cfg.Limits.MaxTurns > 0 {
-		rl.maxTurns = cfg.Limits.MaxTurns
-	}
-	if cfg.Limits.MaxFiles > 0 {
-		rl.maxFiles = cfg.Limits.MaxFiles
-	}
-	if cfg.Limits.MaxOutputSize > 0 {
-		rl.maxOutputSize = cfg.Limits.MaxOutputSize
-	}
-	if cfg.Limits.MaxSessionActions > 0 {
-		rl.maxSessionActions = cfg.Limits.MaxSessionActions
+	// Prompt-level overrides take highest priority (#284)
+	if p != nil {
+		if p.MaxTurns > 0 {
+			rl.maxTurns = p.MaxTurns
+		}
+		if p.MaxSessionActions > 0 {
+			rl.maxSessionActions = p.MaxSessionActions
+		}
 	}
 	return rl
 }
@@ -737,8 +746,8 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 		},
 	}
 
-	// Resolve effective limits: per-config overrides → engine defaults (#125)
-	lim := e.resolveLimits(task.Config)
+	// Resolve effective limits: prompt > per-config > engine defaults (#125, #284)
+	lim := e.resolveLimits(task.Config, task.Prompt)
 	evalReport.GuardrailMaxTurns = lim.maxTurns
 	evalReport.GuardrailMaxFiles = lim.maxFiles
 	evalReport.GuardrailMaxOutputSize = lim.maxOutputSize

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -464,7 +464,7 @@ func TestGuardrailDefaultValues(t *testing.T) {
 func TestResolveLimitsNilFallsBackToDefaults(t *testing.T) {
 	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
 	cfg := config.ToolConfig{Name: "no-limits", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-	lim := engine.resolveLimits(cfg)
+	lim := engine.resolveLimits(cfg, nil)
 	if lim.maxTurns != 25 { t.Errorf("expected maxTurns 25, got %d", lim.maxTurns) }
 	if lim.maxSessionActions != 50 { t.Errorf("expected maxSessionActions 50, got %d", lim.maxSessionActions) }
 	if lim.maxFiles != 50 { t.Errorf("expected maxFiles 50, got %d", lim.maxFiles) }
@@ -474,7 +474,7 @@ func TestResolveLimitsNilFallsBackToDefaults(t *testing.T) {
 func TestResolveLimitsZeroFieldsFallBackToDefaults(t *testing.T) {
 	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
 	cfg := config.ToolConfig{Name: "zero", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{}}
-	lim := engine.resolveLimits(cfg)
+	lim := engine.resolveLimits(cfg, nil)
 	if lim.maxTurns != 25 { t.Errorf("expected 25, got %d", lim.maxTurns) }
 	if lim.maxSessionActions != 50 { t.Errorf("expected 50, got %d", lim.maxSessionActions) }
 	if lim.maxFiles != 50 { t.Errorf("expected 50, got %d", lim.maxFiles) }
@@ -484,7 +484,7 @@ func TestResolveLimitsZeroFieldsFallBackToDefaults(t *testing.T) {
 func TestResolveLimitsConfigOverridesDefaults(t *testing.T) {
 	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
 	cfg := config.ToolConfig{Name: "custom", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10, MaxFiles: 20, MaxOutputSize: 524288, MaxSessionActions: 30}}
-	lim := engine.resolveLimits(cfg)
+	lim := engine.resolveLimits(cfg, nil)
 	if lim.maxTurns != 10 { t.Errorf("expected 10, got %d", lim.maxTurns) }
 	if lim.maxSessionActions != 30 { t.Errorf("expected 30, got %d", lim.maxSessionActions) }
 	if lim.maxFiles != 20 { t.Errorf("expected 20, got %d", lim.maxFiles) }
@@ -494,11 +494,48 @@ func TestResolveLimitsConfigOverridesDefaults(t *testing.T) {
 func TestResolveLimitsPartialOverride(t *testing.T) {
 	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
 	cfg := config.ToolConfig{Name: "partial", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10}}
-	lim := engine.resolveLimits(cfg)
+	lim := engine.resolveLimits(cfg, nil)
 	if lim.maxTurns != 10 { t.Errorf("expected 10, got %d", lim.maxTurns) }
 	if lim.maxSessionActions != 50 { t.Errorf("expected 50, got %d", lim.maxSessionActions) }
 	if lim.maxFiles != 50 { t.Errorf("expected 50, got %d", lim.maxFiles) }
 	if lim.maxOutputSize != 1048576 { t.Errorf("expected 1048576, got %d", lim.maxOutputSize) }
+}
+
+func TestResolveLimitsPromptOverridesConfig(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "cfg", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10, MaxSessionActions: 30}}
+	p := &prompt.Prompt{ID: "test", MaxSessionActions: 100, MaxTurns: 40}
+	lim := engine.resolveLimits(cfg, p)
+	if lim.maxTurns != 40 { t.Errorf("expected prompt maxTurns 40, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 100 { t.Errorf("expected prompt maxSessionActions 100, got %d", lim.maxSessionActions) }
+	if lim.maxFiles != 50 { t.Errorf("expected default maxFiles 50, got %d", lim.maxFiles) }
+}
+
+func TestResolveLimitsPromptOverridesDefaults(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "no-limits", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
+	p := &prompt.Prompt{ID: "test", MaxSessionActions: 75}
+	lim := engine.resolveLimits(cfg, p)
+	if lim.maxSessionActions != 75 { t.Errorf("expected prompt maxSessionActions 75, got %d", lim.maxSessionActions) }
+	if lim.maxTurns != 25 { t.Errorf("expected default maxTurns 25, got %d", lim.maxTurns) }
+}
+
+func TestResolveLimitsPromptPartialOverride(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "cfg", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxTurns: 10, MaxSessionActions: 30}}
+	p := &prompt.Prompt{ID: "test", MaxSessionActions: 100}
+	lim := engine.resolveLimits(cfg, p)
+	if lim.maxTurns != 10 { t.Errorf("expected config maxTurns 10, got %d", lim.maxTurns) }
+	if lim.maxSessionActions != 100 { t.Errorf("expected prompt maxSessionActions 100, got %d", lim.maxSessionActions) }
+}
+
+func TestResolveLimitsPromptZeroDoesNotOverride(t *testing.T) {
+	engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{}))
+	cfg := config.ToolConfig{Name: "cfg", Generator: &config.GeneratorConfig{Model: "gpt-4"}, Limits: &config.SessionLimits{MaxSessionActions: 30}}
+	p := &prompt.Prompt{ID: "test", MaxSessionActions: 0, MaxTurns: 0}
+	lim := engine.resolveLimits(cfg, p)
+	if lim.maxSessionActions != 30 { t.Errorf("expected config maxSessionActions 30, got %d", lim.maxSessionActions) }
+	if lim.maxTurns != 25 { t.Errorf("expected default maxTurns 25, got %d", lim.maxTurns) }
 }
 
 func TestConfigLimitsRespectedByGuardrail(t *testing.T) {

--- a/hyoka/internal/prompt/loader_test.go
+++ b/hyoka/internal/prompt/loader_test.go
@@ -558,3 +558,78 @@ t.Errorf("expected 0 near misses for .prompt.yaml file, got %d", len(misses))
 }
 }
 
+func TestParsePromptWithSessionLimits(t *testing.T) {
+content := []byte(`---
+id: test-limits
+max_session_actions: 100
+max_turns: 40
+properties:
+  service: storage
+  language: python
+---
+
+# Test Limits
+
+## Prompt
+
+Test prompt with session limits.
+`)
+p, err := ParsePromptFile(content, "test-limits.prompt.md")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if p.MaxSessionActions != 100 {
+t.Errorf("expected MaxSessionActions 100, got %d", p.MaxSessionActions)
+}
+if p.MaxTurns != 40 {
+t.Errorf("expected MaxTurns 40, got %d", p.MaxTurns)
+}
+}
+
+func TestParsePromptWithoutSessionLimitsDefaultsToZero(t *testing.T) {
+content := []byte(`---
+id: test-no-limits
+properties:
+  service: storage
+  language: python
+---
+
+# No Limits
+
+## Prompt
+
+Test prompt without session limits.
+`)
+p, err := ParsePromptFile(content, "test-no-limits.prompt.md")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if p.MaxSessionActions != 0 {
+t.Errorf("expected MaxSessionActions 0 (unset), got %d", p.MaxSessionActions)
+}
+if p.MaxTurns != 0 {
+t.Errorf("expected MaxTurns 0 (unset), got %d", p.MaxTurns)
+}
+}
+
+func TestParseYAMLPromptWithSessionLimits(t *testing.T) {
+content := []byte(`id: yaml-limits
+max_session_actions: 75
+max_turns: 30
+properties:
+  service: identity
+  language: dotnet
+prompt_text: "Test YAML prompt with limits."
+`)
+p, err := ParsePromptYAML(content, "yaml-limits.prompt.yaml")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if p.MaxSessionActions != 75 {
+t.Errorf("expected MaxSessionActions 75, got %d", p.MaxSessionActions)
+}
+if p.MaxTurns != 30 {
+t.Errorf("expected MaxTurns 30, got %d", p.MaxTurns)
+}
+}
+

--- a/hyoka/internal/prompt/parser.go
+++ b/hyoka/internal/prompt/parser.go
@@ -20,9 +20,11 @@ Tags            []string          `yaml:"tags"`
 ProjectContext  map[string]string `yaml:"project_context"`
 StarterProject  string            `yaml:"starter_project"`
 ReferenceAnswer string            `yaml:"reference_answer"`
-Timeout         int               `yaml:"timeout"`
-ExpectedPkgs    []string          `yaml:"expected_packages"`
-ExpectedTools   []string          `yaml:"expected_tools"`
+Timeout           int               `yaml:"timeout"`
+MaxSessionActions int               `yaml:"max_session_actions"`
+MaxTurns          int               `yaml:"max_turns"`
+ExpectedPkgs      []string          `yaml:"expected_packages"`
+ExpectedTools     []string          `yaml:"expected_tools"`
 
 // New nested format
 Properties map[string]string `yaml:"properties"`
@@ -48,14 +50,16 @@ EvaluationCriteriaField string `yaml:"evaluation_criteria"`
 // populating Properties from flat fields when the nested format is absent.
 func rawToPrompt(raw *rawFrontmatter) *Prompt {
 p := &Prompt{
-ID:              raw.ID,
-Tags:            raw.Tags,
-ProjectContext:  raw.ProjectContext,
-StarterProject:  raw.StarterProject,
-ReferenceAnswer: raw.ReferenceAnswer,
-Timeout:         raw.Timeout,
-ExpectedPkgs:    raw.ExpectedPkgs,
-ExpectedTools:   raw.ExpectedTools,
+ID:                raw.ID,
+Tags:              raw.Tags,
+ProjectContext:    raw.ProjectContext,
+StarterProject:    raw.StarterProject,
+ReferenceAnswer:   raw.ReferenceAnswer,
+Timeout:           raw.Timeout,
+MaxSessionActions: raw.MaxSessionActions,
+MaxTurns:          raw.MaxTurns,
+ExpectedPkgs:      raw.ExpectedPkgs,
+ExpectedTools:     raw.ExpectedTools,
 }
 
 if raw.Properties != nil {

--- a/hyoka/internal/prompt/types.go
+++ b/hyoka/internal/prompt/types.go
@@ -13,9 +13,11 @@ Tags            []string          `yaml:"tags" json:"tags"`
 ProjectContext  map[string]string `yaml:"project_context" json:"project_context,omitempty"`
 StarterProject  string            `yaml:"starter_project" json:"starter_project,omitempty"`
 ReferenceAnswer string            `yaml:"reference_answer" json:"reference_answer,omitempty"`
-Timeout         int               `yaml:"timeout" json:"timeout,omitempty"`
-ExpectedPkgs    []string          `yaml:"expected_packages" json:"expected_packages,omitempty"`
-ExpectedTools   []string          `yaml:"expected_tools" json:"expected_tools,omitempty"`
+Timeout           int               `yaml:"timeout" json:"timeout,omitempty"`
+MaxSessionActions int               `yaml:"max_session_actions" json:"max_session_actions,omitempty"`
+MaxTurns          int               `yaml:"max_turns" json:"max_turns,omitempty"`
+ExpectedPkgs      []string          `yaml:"expected_packages" json:"expected_packages,omitempty"`
+ExpectedTools     []string          `yaml:"expected_tools" json:"expected_tools,omitempty"`
 
 // Properties holds all metadata string fields (service, language, plane, etc.).
 // Keys must be snake_case.


### PR DESCRIPTION
## Summary

Adds per-prompt session limit overrides (`max_session_actions` and `max_turns`) to prompt frontmatter with a layered resolution order:

```
prompt frontmatter > config YAML > CLI flag > engine default
```

## Changes

- **`hyoka/internal/prompt/types.go`** — Added `MaxSessionActions` and `MaxTurns` fields to `Prompt` struct
- **`hyoka/internal/prompt/parser.go`** — Added fields to `rawFrontmatter` and propagated through `rawToPrompt()`
- **`hyoka/internal/eval/engine.go`** — Updated `resolveLimits()` to accept `*prompt.Prompt` and apply prompt-level overrides (highest priority)
- **`hyoka/internal/eval/engine_test.go`** — 4 new tests for prompt-level resolution + updated existing tests for new signature
- **`hyoka/internal/prompt/loader_test.go`** — 3 new tests for frontmatter parsing (markdown + YAML, with and without limits)
- **`examples/prompts/prompt-template.prompt.md`** — Added optional `max_session_actions` and `max_turns` fields

## Backward Compatibility

Zero values (unset) fall through to config/default — fully backward compatible. No existing prompts require changes. This is opt-in: prompt authors can declare the action budget a prompt needs.

## Usage

```yaml
---
id: storage-dp-python-batch
max_session_actions: 100
max_turns: 40
properties:
  difficulty: advanced
---
```

Closes #284