### PR TITLE
docs: document prompt-level session limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ go run ./hyoka run --service key-vault --language python \
 - Without `--config` or `--all-configs`, the run will fail
 - `--log-level debug` enables verbose logging; pair with `--log-file` to capture to file
 - `--max-session-actions` (default: 50) limits actions per Copilot session
+- Prompt-level overrides: Prompts can override `--max-session-actions` and `--max-turns` via frontmatter (see [configuration.md](docs/configuration.md#prompt-level-limits) for examples). Resolution order: prompt frontmatter > config YAML > CLI flag > default.
 
 ### Available Filter Flags
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Every code-generation session is automatically aborted if it exceeds any of thes
 | Session actions | 50 | `--max-session-actions` | Limits reasoning, response, and tool call actions per session |
 | File count | 50 | `--max-files` | Prevents excessive file creation |
 | Output size | 1 MB | `--max-output-size` | Prevents oversized outputs (supports KB, MB suffixes) |
-| Session actions | 50 | `--max-session-actions` | Limits reasoning, response, and tool call actions per session |
+
+Prompts can override these defaults via frontmatter fields (`max_session_actions`, `max_turns`). The resolution order is: prompt frontmatter > config YAML > CLI flag > engine default.
 
 When a guardrail trips, the evaluation is marked as failed with a clear reason (e.g., `guardrail: turn count 26 exceeded limit of 25`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,7 +226,11 @@ generator:
 
 ## Limits
 
-Guardrail limits can be set globally via CLI flags or per-config in the YAML file. CLI flags take precedence over config values.
+Guardrail limits can be set at multiple levels with the following resolution order:
+
+**prompt frontmatter > config YAML > CLI flag > engine default**
+
+This allows fine-grained control at the prompt level while maintaining sensible defaults.
 
 | Field | Type | Default | CLI Flag | Description |
 |-------|------|---------|----------|-------------|
@@ -234,6 +238,10 @@ Guardrail limits can be set globally via CLI flags or per-config in the YAML fil
 | `max_files` | int | 50 | `--max-files` | Maximum generated files per evaluation |
 | `max_output_size` | string | "1MB" | `--max-output-size` | Maximum total output size (supports KB, MB suffixes) |
 | `max_session_actions` | int | 50 | `--max-session-actions` | Maximum actions per Copilot session |
+
+### Config-Level Limits
+
+Set limits in the config YAML file (overridden by CLI flags):
 
 ```yaml
 configs:
@@ -246,6 +254,25 @@ configs:
       max_output_size: "512KB"
       max_session_actions: 25
 ```
+
+### Prompt-Level Limits
+
+Override limits for a specific prompt via frontmatter (highest priority). This is useful for complex prompts that require more actions or turns:
+
+```yaml
+---
+id: storage-dp-python-batch
+service: storage
+language: python
+plane: data-plane
+category: crud
+difficulty: advanced
+max_session_actions: 100  # This prompt needs more reasoning steps
+max_turns: 40             # Allow more back-and-forth turns
+---
+```
+
+Prompts with unset limit fields fall through to config > CLI > default, ensuring backward compatibility.
 
 ## Multiple Config Files
 


### PR DESCRIPTION
## Overview

Updates documentation for PR #285 (feat: Move session limits to prompt frontmatter with config/CLI fallback).

## Changes

1. **README.md** — Removed duplicate 'Session actions' row in guardrails table; added note about prompt-level overrides via frontmatter

2. **docs/configuration.md** — Expanded limits section with:
   - Full resolution order: prompt frontmatter > config YAML > CLI flag > engine default
   - Separate subsections for config-level and prompt-level limits
   - Example showing prompt frontmatter with `max_session_actions` and `max_turns`

3. **AGENTS.md** — Added note in 'Important Flag Rules' about prompt-level overrides

## Resolution Order

The new layered resolution for limits is:
1. **Prompt frontmatter** (highest priority) — `max_session_actions`, `max_turns`
2. **Config YAML** — limits section
3. **CLI flags** — `--max-session-actions`, `--max-turns`
4. **Engine defaults** (lowest priority) — 50 actions, 25 turns

This allows prompt authors to declare the resource budget their prompts need, while maintaining backward compatibility.

## Related to
Closes #284 (supports PR #285)
