### PR TITLE
fix: skip empty skill directories and count actual skills

### DIFF
--- a/configs/azure-mcp-codex.yaml
+++ b/configs/azure-mcp-codex.yaml
@@ -19,4 +19,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/configs/azure-mcp-opus.yaml
+++ b/configs/azure-mcp-opus.yaml
@@ -19,6 +19,7 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"
     limits:
       max_turns: 75

--- a/configs/azure-mcp-sonnet.yaml
+++ b/configs/azure-mcp-sonnet.yaml
@@ -19,4 +19,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/configs/baseline-codex.yaml
+++ b/configs/baseline-codex.yaml
@@ -13,4 +13,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/configs/baseline-opus-skills.yaml
+++ b/configs/baseline-opus-skills.yaml
@@ -17,4 +17,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/configs/baseline-opus-skills.yaml
+++ b/configs/baseline-opus-skills.yaml
@@ -1,15 +1,13 @@
-# Baseline with Claude Opus 4.6 + generator skills — no MCP servers
-# Uses the new generator/reviewer config structure with unified skills list.
+# Baseline with Claude Opus 4.6 + reviewer skills — no MCP servers
+# Generator skills directory was removed because it contained no skills (#291).
+# To add generator skills, create SKILL.md files in subdirectories of
+# ./skills/generator/ and add a generator tools entry — see
+# examples/configs/example-generator-skills.yaml for the pattern.
 configs:
   - name: baseline-skills/claude-opus-4.6
-    description: "Baseline + Skills — Claude Opus 4.6 with generator skills"
+    description: "Baseline + Skills — Claude Opus 4.6 with reviewer skills"
     generator:
       model: "claude-opus-4.6"
-      tools:
-        - name: generator-skills
-          type: skill
-          source: local
-          path: "./skills/generator"
     reviewer:
       models:
         - "claude-opus-4.6"

--- a/configs/baseline-opus.yaml
+++ b/configs/baseline-opus.yaml
@@ -13,4 +13,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/configs/baseline-sonnet-skills.yaml
+++ b/configs/baseline-sonnet-skills.yaml
@@ -16,6 +16,7 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"
     plugins:
       - "azure-sdk-java@skills"

--- a/configs/baseline-sonnet.yaml
+++ b/configs/baseline-sonnet.yaml
@@ -13,4 +13,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/examples/configs/example-full.yaml
+++ b/examples/configs/example-full.yaml
@@ -21,11 +21,12 @@ configs:
           source: remote
           repo: microsoft/skills
 
-        # Local skill — directory path (supports glob patterns)
-        - name: generator-skills
-          type: skill
-          source: local
-          path: "./skills/generator"
+        # Local skill — directory of skills (each subdirectory should contain SKILL.md)
+        # See examples/configs/example-generator-skills.yaml for a complete example.
+        # - name: generator-skills
+        #   type: skill
+        #   source: local
+        #   path: "./skills/generator"
 
       # MCP servers attached to the generator session
       mcp_servers:

--- a/examples/configs/example-full.yaml
+++ b/examples/configs/example-full.yaml
@@ -21,11 +21,12 @@ configs:
           source: remote
           repo: microsoft/skills
 
-        # Local skill — directory of skills (each subdirectory should contain SKILL.md)
+        # Local skill — directory of skills (skill_dir: true) or single skill
         # See examples/configs/example-generator-skills.yaml for a complete example.
         # - name: generator-skills
         #   type: skill
         #   source: local
+        #   skill_dir: true
         #   path: "./skills/generator"
 
       # MCP servers attached to the generator session
@@ -52,6 +53,7 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"
 
   # Minimal config — only required fields

--- a/examples/configs/example-generator-skills.yaml
+++ b/examples/configs/example-generator-skills.yaml
@@ -1,33 +1,46 @@
 # Example: loading generator skills from a local directory.
 #
-# hyoka supports two patterns for local skills:
+# Local skills use the `skill_dir` field to explicitly declare whether a
+# path points to a single skill or a directory containing multiple skills:
 #
-#   1. Directory of skills — point to a parent directory that contains
-#      skill subdirectories, each with a SKILL.md file.
-#      Example: path: "./skills/generator"
-#        skills/generator/
-#          azure-best-practices/SKILL.md
-#          error-handling/SKILL.md
+#   skill_dir: false (default) — path points to a single skill directory
+#   that must contain a SKILL.md file directly:
+#     path: "./skills/reviewer/code-review-comments"
+#       code-review-comments/
+#         SKILL.md          ← skill is here
+#         examples.md
 #
-#   2. Glob pattern — use a wildcard to select specific skill subdirectories.
-#      Example: path: "./skills/generator/*"
-#        Expands each matching subdirectory individually.
+#   skill_dir: true — path is a parent directory whose subdirectories
+#   each contain a SKILL.md file:
+#     path: "./skills/generator"
+#       generator/
+#         azure-best-practices/
+#           SKILL.md        ← skill
+#         error-handling/
+#           SKILL.md        ← skill
 #
-# If the directory is empty or contains no SKILL.md files, hyoka will log
-# a warning and skip it — no error, no misleading skill count.
+# If a single-skill path is missing SKILL.md, or a skill_dir contains
+# no subdirectories with SKILL.md, hyoka logs a warning and skips it.
 configs:
   - name: example-generator-skills/claude-opus-4.6
     description: "Example — generator skills from a local directory"
     generator:
       model: "claude-opus-4.6"
       tools:
-        # Option 1: Entire directory (all skill subdirectories are loaded)
+        # Directory of skills (skill_dir: true) — all subdirs with SKILL.md are loaded
         - name: generator-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/generator"
 
-        # Option 2: Glob pattern (selective loading)
+        # Single skill (skill_dir: false, the default) — path must contain SKILL.md
+        # - name: azure-best-practices
+        #   type: skill
+        #   source: local
+        #   path: "./skills/generator/azure-best-practices"
+
+        # Glob pattern — each matching subdirectory is treated as a single skill
         # - name: generator-skills-glob
         #   type: skill
         #   source: local
@@ -42,4 +55,5 @@ configs:
         - name: reviewer-skills
           type: skill
           source: local
+          skill_dir: true
           path: "./skills/reviewer"

--- a/examples/configs/example-generator-skills.yaml
+++ b/examples/configs/example-generator-skills.yaml
@@ -1,0 +1,45 @@
+# Example: loading generator skills from a local directory.
+#
+# hyoka supports two patterns for local skills:
+#
+#   1. Directory of skills — point to a parent directory that contains
+#      skill subdirectories, each with a SKILL.md file.
+#      Example: path: "./skills/generator"
+#        skills/generator/
+#          azure-best-practices/SKILL.md
+#          error-handling/SKILL.md
+#
+#   2. Glob pattern — use a wildcard to select specific skill subdirectories.
+#      Example: path: "./skills/generator/*"
+#        Expands each matching subdirectory individually.
+#
+# If the directory is empty or contains no SKILL.md files, hyoka will log
+# a warning and skip it — no error, no misleading skill count.
+configs:
+  - name: example-generator-skills/claude-opus-4.6
+    description: "Example — generator skills from a local directory"
+    generator:
+      model: "claude-opus-4.6"
+      tools:
+        # Option 1: Entire directory (all skill subdirectories are loaded)
+        - name: generator-skills
+          type: skill
+          source: local
+          path: "./skills/generator"
+
+        # Option 2: Glob pattern (selective loading)
+        # - name: generator-skills-glob
+        #   type: skill
+        #   source: local
+        #   path: "./skills/generator/*"
+
+    reviewer:
+      models:
+        - "claude-opus-4.6"
+        - "gemini-3-pro-preview"
+        - "gpt-4.1"
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
+          path: "./skills/reviewer"

--- a/hyoka/internal/config/tool_filter.go
+++ b/hyoka/internal/config/tool_filter.go
@@ -17,9 +17,10 @@ type ToolEntry struct {
 	Args     []string `yaml:"args,omitempty" json:"args,omitempty"`
 	MCPTools []string `yaml:"mcp_tools,omitempty" json:"mcp_tools,omitempty"`
 	// Skill-specific fields
-	Source string `yaml:"source,omitempty" json:"source,omitempty"` // "local" or "remote"
-	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
-	Repo   string `yaml:"repo,omitempty" json:"repo,omitempty"`
+	Source   string `yaml:"source,omitempty" json:"source,omitempty"` // "local" or "remote"
+	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
+	Repo     string `yaml:"repo,omitempty" json:"repo,omitempty"`
+	SkillDir bool   `yaml:"skill_dir,omitempty" json:"skill_dir,omitempty"` // true = path is a directory of skills, false = path is a single skill
 }
 
 func resolvedToolType(entry ToolEntry) string {
@@ -115,6 +116,9 @@ func validateToolEntry(entry ToolEntry, configName string, idx int) error {
 		}
 		if entry.Source != "" && entry.Source != "local" && entry.Source != "remote" {
 			return fmt.Errorf("config %q: tools[%d] skill entry has invalid source %q", configName, idx, entry.Source)
+		}
+		if entry.SkillDir && entry.Repo != "" {
+			return fmt.Errorf("config %q: tools[%d] skill_dir is only valid for local skills", configName, idx)
 		}
 	default:
 		return fmt.Errorf("config %q: tools[%d] has unknown type %q", configName, idx, entry.Type)

--- a/hyoka/internal/config/tool_filter_test.go
+++ b/hyoka/internal/config/tool_filter_test.go
@@ -296,6 +296,31 @@ func TestValidateToolEntry_SkillInvalidSource(t *testing.T) {
 	}
 }
 
+func TestValidateToolEntry_SkillDirOnRemote(t *testing.T) {
+	entry := ToolEntry{Name: "skill", Type: "skill", Source: "remote", Repo: "org/repo", SkillDir: true}
+	if err := validateToolEntry(entry, "test", 0); err == nil {
+		t.Fatal("expected error for skill_dir on remote skill")
+	}
+}
+
+func TestValidateToolEntry_SkillDirOnLocal(t *testing.T) {
+	entry := ToolEntry{Name: "skill", Type: "skill", Source: "local", Path: "./skills/gen", SkillDir: true}
+	if err := validateToolEntry(entry, "test", 0); err != nil {
+		t.Fatalf("unexpected error for skill_dir on local skill: %v", err)
+	}
+}
+
+func TestToolEntrySkillDirParsed(t *testing.T) {
+	entry := ToolEntry{Name: "skills", Type: "skill", Source: "local", Path: "./skills/reviewer", SkillDir: true}
+	if !entry.SkillDir {
+		t.Error("expected SkillDir to be true")
+	}
+	entry2 := ToolEntry{Name: "skill", Type: "skill", Source: "local", Path: "./skills/reviewer/code-review"}
+	if entry2.SkillDir {
+		t.Error("expected SkillDir to default to false")
+	}
+}
+
 func TestToolEntryResolvedPairwise(t *testing.T) {
 	cases := []struct {
 		entry ToolEntry

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/progress"
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
 	"github.com/ronniegeraghty/hyoka/internal/report"
+	"github.com/ronniegeraghty/hyoka/internal/skills"
 )
 
 // CopilotSDKEvaluator uses the Copilot SDK to run real evaluations.
@@ -486,7 +487,8 @@ func (e *CopilotSDKEvaluator) Evaluate(ctx context.Context, p *prompt.Prompt, cf
 
 	slog.Info("Creating Copilot session",
 		"model", cfg.Generator.Model,
-		"skills", len(sessionCfg.SkillDirectories),
+		"skill_dirs", len(sessionCfg.SkillDirectories),
+		"skills", skills.CountSkills(sessionCfg.SkillDirectories),
 		"mcp_servers", len(sessionCfg.MCPServers),
 		"work_dir", workDir,
 	)
@@ -661,13 +663,16 @@ func mergePromptProperties(p *prompt.Prompt) map[string]string {
 }
 
 func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir string, configDir string, promptProps map[string]string) *copilot.SessionConfig {
-	// Collect skill directories from Generator.Tools (includes resolved plugins)
+	// Resolve skill directories from Generator.Tools using the skills package.
+	// This handles glob patterns, validates directories exist and contain skills,
+	// and warns about empty/missing directories (#291).
 	var skillDirs []string
 	if cfg.Generator != nil {
-		for _, entry := range cfg.Generator.Tools {
-			if entry.ResolvedType() == "skill" && entry.SkillSource() == "local" && entry.Path != "" {
-				skillDirs = append(skillDirs, entry.Path)
-			}
+		resolved, err := skills.ResolveSkillDirs(cfg.Generator.Tools, configDir)
+		if err != nil {
+			slog.Warn("Failed to resolve generator skill directories", "error", err)
+		} else {
+			skillDirs = resolved
 		}
 	}
 	// Use the config-driven system prompt (#115, #116). The default is zero
@@ -680,7 +685,8 @@ func (e *CopilotSDKEvaluator) buildSessionConfig(cfg *config.ToolConfig, workDir
 	// Instruct the agent to use available skills before generating code.
 	// Without this hint, models tend to go straight to code generation
 	// and never invoke the skill tool, even when skills are loaded.
-	if len(skillDirs) > 0 {
+	// Only add if there are actual skills, not just empty directories (#291).
+	if skills.CountSkills(skillDirs) > 0 {
 		systemMsg += "\n\nSKILLS:\n" +
 			"You have Azure SDK skills available. BEFORE writing any code, invoke the relevant skill " +
 			"using the skill tool to get SDK-specific patterns, API examples, and acceptance criteria. " +

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -1408,6 +1408,34 @@ func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
 	summary.TotalPrompts = len(promptIDs)
 	summary.TotalConfigs = len(configNames)
 
+	// Validate skill directories for each unique config (#291).
+	// This surfaces warnings about empty/missing skill dirs during dry run.
+	validatedConfigs := make(map[string]bool)
+	for _, t := range tasks {
+		if validatedConfigs[t.Config.Name] {
+			continue
+		}
+		validatedConfigs[t.Config.Name] = true
+		if t.Config.Generator != nil {
+			resolved, err := skills.ResolveSkillDirs(t.Config.Generator.Tools, "")
+			if err != nil {
+				slog.Warn("Failed to resolve generator skills", "config", t.Config.Name, "error", err)
+				continue
+			}
+			count := skills.CountSkills(resolved)
+			e.printf("   Config %q: %d generator skill dir(s), %d skill(s) found\n", t.Config.Name, len(resolved), count)
+		}
+		if t.Config.Reviewer != nil {
+			resolved, err := skills.ResolveSkillDirs(t.Config.Reviewer.Tools, "")
+			if err != nil {
+				slog.Warn("Failed to resolve reviewer skills", "config", t.Config.Name, "error", err)
+				continue
+			}
+			count := skills.CountSkills(resolved)
+			e.printf("   Config %q: %d reviewer skill dir(s), %d skill(s) found\n", t.Config.Name, len(resolved), count)
+		}
+	}
+
 	return summary, nil
 }
 

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -1417,26 +1417,43 @@ func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
 		}
 		validatedConfigs[t.Config.Name] = true
 		if t.Config.Generator != nil {
+			entries := countSkillEntries(t.Config.Generator.Tools)
 			resolved, err := skills.ResolveSkillDirs(t.Config.Generator.Tools, "")
 			if err != nil {
 				slog.Warn("Failed to resolve generator skills", "config", t.Config.Name, "error", err)
 				continue
 			}
 			count := skills.CountSkills(resolved)
-			e.printf("   Config %q: %d generator skill dir(s), %d skill(s) found\n", t.Config.Name, len(resolved), count)
+			if entries > 0 {
+				e.printf("   Config %q: %d generator dir(s) searched, %d skill(s) found\n", t.Config.Name, entries, count)
+			}
 		}
 		if t.Config.Reviewer != nil {
+			entries := countSkillEntries(t.Config.Reviewer.Tools)
 			resolved, err := skills.ResolveSkillDirs(t.Config.Reviewer.Tools, "")
 			if err != nil {
 				slog.Warn("Failed to resolve reviewer skills", "config", t.Config.Name, "error", err)
 				continue
 			}
 			count := skills.CountSkills(resolved)
-			e.printf("   Config %q: %d reviewer skill dir(s), %d skill(s) found\n", t.Config.Name, len(resolved), count)
+			if entries > 0 {
+				e.printf("   Config %q: %d reviewer dir(s) searched, %d skill(s) found\n", t.Config.Name, entries, count)
+			}
 		}
 	}
 
 	return summary, nil
+}
+
+// countSkillEntries counts how many ToolEntries in the list are skills.
+func countSkillEntries(entries []config.ToolEntry) int {
+	n := 0
+	for _, e := range entries {
+		if e.ResolvedType() == "skill" {
+			n++
+		}
+	}
+	return n
 }
 
 func collectPairwiseReports(results []*report.EvalReport) ([]*pairwise.PairwiseReport, []pairwise.ToolImpact) {

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/prompt"
 	"github.com/ronniegeraghty/hyoka/internal/report"
 	"github.com/ronniegeraghty/hyoka/internal/review"
+	"github.com/ronniegeraghty/hyoka/internal/skills"
 )
 
 // EvalResult holds the raw output from a Copilot evaluation.
@@ -952,13 +953,15 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Per-phase generation duration already captured above (evalReport.GenerationDuration).
 	// Overall Duration is set at the end of the function after all phases complete.
 
-	// Populate environment info from config and captured events
+	// Populate environment info from config and captured events.
+	// Use ResolveSkillDirs for accurate directory resolution (#291).
 	var skillDirectories []string
 	if task.Config.Generator != nil {
-		for _, entry := range task.Config.Generator.Tools {
-			if entry.ResolvedType() == "skill" && entry.SkillSource() == "local" && entry.Path != "" {
-				skillDirectories = append(skillDirectories, entry.Path)
-			}
+		resolved, err := skills.ResolveSkillDirs(task.Config.Generator.Tools, "")
+		if err != nil {
+			slog.Warn("Failed to resolve skill directories for report", "error", err)
+		} else {
+			skillDirectories = resolved
 		}
 	}
 	// Resolve tools for reporting — mirrors the resolution in buildSessionConfig.

--- a/hyoka/internal/eval/engine_test.go
+++ b/hyoka/internal/eval/engine_test.go
@@ -93,6 +93,160 @@ t.Errorf("expected 2 configs, got %d", summary.TotalConfigs)
 }
 }
 
+func TestDryRunSkillDir_Populated(t *testing.T) {
+	dir := t.TempDir()
+	// Create a skill_dir with 2 skill subdirectories
+	skillsDir := filepath.Join(dir, "skills")
+	for _, name := range []string{"skill-a", "skill-b"} {
+		subDir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(subDir, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf strings.Builder
+	opts := quietOpts(EngineOptions{Workers: 1, DryRun: true})
+	opts.Stdout = &buf
+	engine := NewEngine(&StubEvaluator{}, opts)
+
+	prompts := []*prompt.Prompt{
+		{ID: "p1", Properties: map[string]string{"language": "python"}},
+	}
+	configs := []config.ToolConfig{
+		{
+			Name: "populated-skills",
+			Generator: &config.GeneratorConfig{
+				Model: "gpt-4",
+				Tools: []config.ToolEntry{
+					{Name: "gen-skills", Type: "skill", Source: "local", SkillDir: true, Path: skillsDir},
+				},
+			},
+		},
+	}
+
+	_, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "1 generator dir(s) searched, 2 skill(s) found") {
+		t.Errorf("expected '1 generator dir(s) searched, 2 skill(s) found' in output, got:\n%s", output)
+	}
+}
+
+func TestDryRunSkillDir_Empty(t *testing.T) {
+	dir := t.TempDir()
+	// Create an empty skill_dir (only .gitkeep)
+	skillsDir := filepath.Join(dir, "skills")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, ".gitkeep"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	opts := quietOpts(EngineOptions{Workers: 1, DryRun: true})
+	opts.Stdout = &buf
+	engine := NewEngine(&StubEvaluator{}, opts)
+
+	prompts := []*prompt.Prompt{
+		{ID: "p1", Properties: map[string]string{"language": "python"}},
+	}
+	configs := []config.ToolConfig{
+		{
+			Name: "empty-skills",
+			Generator: &config.GeneratorConfig{
+				Model: "gpt-4",
+				Tools: []config.ToolEntry{
+					{Name: "gen-skills", Type: "skill", Source: "local", SkillDir: true, Path: skillsDir},
+				},
+			},
+		},
+	}
+
+	_, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "1 generator dir(s) searched, 0 skill(s) found") {
+		t.Errorf("expected '1 generator dir(s) searched, 0 skill(s) found' in output, got:\n%s", output)
+	}
+}
+
+func TestDryRunSkillDir_NonExistent(t *testing.T) {
+	var buf strings.Builder
+	opts := quietOpts(EngineOptions{Workers: 1, DryRun: true})
+	opts.Stdout = &buf
+	engine := NewEngine(&StubEvaluator{}, opts)
+
+	prompts := []*prompt.Prompt{
+		{ID: "p1", Properties: map[string]string{"language": "python"}},
+	}
+	configs := []config.ToolConfig{
+		{
+			Name: "missing-dir",
+			Generator: &config.GeneratorConfig{
+				Model: "gpt-4",
+				Tools: []config.ToolEntry{
+					{Name: "gen-skills", Type: "skill", Source: "local", SkillDir: true, Path: "/does/not/exist"},
+				},
+			},
+		},
+	}
+
+	_, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "1 generator dir(s) searched, 0 skill(s) found") {
+		t.Errorf("expected '1 generator dir(s) searched, 0 skill(s) found' in output, got:\n%s", output)
+	}
+}
+
+func TestDryRunSingleSkill_MissingSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory but no SKILL.md
+	skillDir := filepath.Join(dir, "my-skill")
+	if err := os.Mkdir(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	opts := quietOpts(EngineOptions{Workers: 1, DryRun: true})
+	opts.Stdout = &buf
+	engine := NewEngine(&StubEvaluator{}, opts)
+
+	prompts := []*prompt.Prompt{
+		{ID: "p1", Properties: map[string]string{"language": "python"}},
+	}
+	configs := []config.ToolConfig{
+		{
+			Name: "bad-single-skill",
+			Generator: &config.GeneratorConfig{
+				Model: "gpt-4",
+				Tools: []config.ToolEntry{
+					{Name: "my-skill", Type: "skill", Source: "local", Path: skillDir},
+				},
+			},
+		},
+	}
+
+	_, err := engine.Run(context.Background(), prompts, configs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "1 generator dir(s) searched, 0 skill(s) found") {
+		t.Errorf("expected '1 generator dir(s) searched, 0 skill(s) found' in output, got:\n%s", output)
+	}
+}
+
 func TestEngineRun(t *testing.T) {
 outputDir := t.TempDir()
 engine := NewEngine(&StubEvaluator{}, quietOpts(EngineOptions{

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -17,8 +17,10 @@ import (
 // absolute directory paths. The baseDir is used as the root for resolving
 // relative local paths.
 //
-//   - source: local  → resolves path (supports glob patterns like "./skills/generator/*")
-//   - source: remote → fetches from GitHub repo via "npx skills add", returns the install dir
+//   - source: local, skill_dir: false → path points to a single skill (must contain SKILL.md)
+//   - source: local, skill_dir: true  → path is a directory of skills (subdirs contain SKILL.md)
+//   - source: local with glob         → each glob match is treated as a single skill directory
+//   - source: remote                  → fetches from GitHub repo via "npx skills add"
 func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, error) {
 	var dirs []string
 	for _, entry := range entries {
@@ -27,11 +29,11 @@ func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, err
 		}
 		switch entry.SkillSource() {
 		case "local":
-			resolved, err := resolveLocal(entry.Path, baseDir)
+			resolved, err := resolveLocal(entry, baseDir)
 			if err != nil {
 				return nil, fmt.Errorf("resolving local skill %q: %w", entry.Path, err)
 			}
-			slog.Debug("Resolved local skill", "path", entry.Path, "resolved_count", len(resolved))
+			slog.Debug("Resolved local skill", "path", entry.Path, "skill_dir", entry.SkillDir, "resolved_count", len(resolved))
 			dirs = append(dirs, resolved...)
 		case "remote":
 			dir, err := fetchRemote(entry, baseDir)
@@ -47,35 +49,26 @@ func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, err
 }
 
 // CountSkills counts the number of actual skill subdirectories (containing
-// SKILL.md) within the given resolved skill directories. This provides an
-// accurate count of usable skills rather than counting directory paths.
+// SKILL.md) within the given resolved skill directories. Each resolved
+// directory is expected to be a single skill (containing SKILL.md directly)
+// since skill_dir entries are expanded into individual skill dirs during
+// resolution.
 func CountSkills(dirs []string) int {
 	count := 0
 	for _, dir := range dirs {
-		// Check if the directory itself contains a SKILL.md (it IS a skill).
 		if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
 			count++
-			continue
-		}
-		// Otherwise enumerate subdirectories that contain SKILL.md.
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
-			}
-			if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil {
-				count++
-			}
 		}
 	}
 	return count
 }
 
-// resolveLocal resolves a local skill path (supports globs) to absolute paths.
-func resolveLocal(path, baseDir string) ([]string, error) {
+// resolveLocal resolves a local skill entry to absolute directory paths.
+// When entry.SkillDir is true, the path is a directory of skills — each
+// subdirectory containing SKILL.md is returned. When false (default), the
+// path points to a single skill directory. Glob patterns are also supported.
+func resolveLocal(entry config.ToolEntry, baseDir string) ([]string, error) {
+	path := entry.Path
 	// Make relative paths absolute based on baseDir
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(baseDir, path)
@@ -107,6 +100,26 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 	}
 
 	// Non-glob: try to resolve the path, checking candidate locations
+	resolved := resolvePath(path, baseDir)
+	if resolved == "" {
+		slog.Warn("Skills directory does not exist", "path", entry.Path)
+		return nil, nil
+	}
+
+	if entry.SkillDir {
+		return resolveSkillDir(resolved)
+	}
+
+	// Single skill — validate it contains SKILL.md
+	if _, err := os.Stat(filepath.Join(resolved, "SKILL.md")); err != nil {
+		slog.Warn("Skill directory missing SKILL.md", "path", resolved)
+		return nil, nil
+	}
+	return []string{resolved}, nil
+}
+
+// resolvePath finds the first existing directory matching path or baseDir+path.
+func resolvePath(path, baseDir string) string {
 	candidates := []string{
 		path,
 		filepath.Join(baseDir, path),
@@ -116,18 +129,38 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 			abs, absErr := filepath.Abs(c)
 			if absErr != nil {
 				slog.Warn("Failed to resolve absolute path", "path", c, "error", absErr)
+				return c
 			}
-			if isEmptySkillDir(abs) {
-				slog.Warn("Skills directory exists but contains no skills", "path", abs)
-				return nil, nil
-			}
-			return []string{abs}, nil
+			return abs
 		}
 	}
+	return ""
+}
 
-	// Path doesn't exist — warn and return nothing
-	slog.Warn("Skills directory does not exist", "path", path)
-	return nil, nil
+// resolveSkillDir expands a directory of skills into individual skill dirs.
+// Each subdirectory containing SKILL.md is returned. If no skills are found,
+// a warning is logged and nil is returned.
+func resolveSkillDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		slog.Warn("Failed to read skill directory", "path", dir, "error", err)
+		return nil, nil
+	}
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		subDir := filepath.Join(dir, e.Name())
+		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err == nil {
+			dirs = append(dirs, subDir)
+		}
+	}
+	if len(dirs) == 0 {
+		slog.Warn("Skills directory contains no skills (no subdirectories with SKILL.md)",
+			"path", dir)
+	}
+	return dirs, nil
 }
 
 // fetchRemote fetches a remote skill from a GitHub repo using npx skills add.
@@ -163,28 +196,4 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
 	}
 	return abs, nil
-}
-
-// isEmptySkillDir reports whether dir contains no SKILL.md files, either
-// directly or in immediate subdirectories. A directory with only .gitkeep
-// or other non-skill files is considered empty.
-func isEmptySkillDir(dir string) bool {
-	// Check if the directory itself is a skill (has SKILL.md).
-	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
-		return false
-	}
-	// Check immediate subdirectories for SKILL.md.
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil {
-			return false
-		}
-	}
-	return true
 }

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -46,6 +46,34 @@ func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, err
 	return dirs, nil
 }
 
+// CountSkills counts the number of actual skill subdirectories (containing
+// SKILL.md) within the given resolved skill directories. This provides an
+// accurate count of usable skills rather than counting directory paths.
+func CountSkills(dirs []string) int {
+	count := 0
+	for _, dir := range dirs {
+		// Check if the directory itself contains a SKILL.md (it IS a skill).
+		if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+			count++
+			continue
+		}
+		// Otherwise enumerate subdirectories that contain SKILL.md.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // resolveLocal resolves a local skill path (supports globs) to absolute paths.
 func resolveLocal(path, baseDir string) ([]string, error) {
 	// Make relative paths absolute based on baseDir
@@ -89,16 +117,17 @@ func resolveLocal(path, baseDir string) ([]string, error) {
 			if absErr != nil {
 				slog.Warn("Failed to resolve absolute path", "path", c, "error", absErr)
 			}
+			if isEmptySkillDir(abs) {
+				slog.Warn("Skills directory exists but contains no skills", "path", abs)
+				return nil, nil
+			}
 			return []string{abs}, nil
 		}
 	}
 
-	// Path doesn't exist yet — return absolute form anyway
-	abs, absErr := filepath.Abs(path)
-	if absErr != nil {
-		slog.Warn("Failed to resolve absolute path", "path", path, "error", absErr)
-	}
-	return []string{abs}, nil
+	// Path doesn't exist — warn and return nothing
+	slog.Warn("Skills directory does not exist", "path", path)
+	return nil, nil
 }
 
 // fetchRemote fetches a remote skill from a GitHub repo using npx skills add.
@@ -134,4 +163,28 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
 	}
 	return abs, nil
+}
+
+// isEmptySkillDir reports whether dir contains no SKILL.md files, either
+// directly or in immediate subdirectories. A directory with only .gitkeep
+// or other non-skill files is considered empty.
+func isEmptySkillDir(dir string) bool {
+	// Check if the directory itself is a skill (has SKILL.md).
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+		return false
+	}
+	// Check immediate subdirectories for SKILL.md.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return true
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil {
+			return false
+		}
+	}
+	return true
 }

--- a/hyoka/internal/skills/fetcher_test.go
+++ b/hyoka/internal/skills/fetcher_test.go
@@ -14,6 +14,10 @@ func TestResolveLocal_DirectPath(t *testing.T) {
 	if err := os.Mkdir(skillDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	// Add SKILL.md so the directory is recognized as containing a skill
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	dirs, err := ResolveSkillDirs([]config.ToolEntry{
 		{Type: "skill", Source: "local", Path: skillDir, Name: "local-skill"},
@@ -33,6 +37,14 @@ func TestResolveLocal_RelativePath(t *testing.T) {
 	dir := t.TempDir()
 	skillDir := filepath.Join(dir, "skills", "generator")
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Add a skill subdirectory with SKILL.md
+	subSkill := filepath.Join(skillDir, "my-skill")
+	if err := os.Mkdir(subSkill, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subSkill, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -80,6 +92,89 @@ func TestResolveLocal_EmptySkills(t *testing.T) {
 	}
 	if len(dirs) != 0 {
 		t.Errorf("expected 0 dirs, got %d", len(dirs))
+	}
+}
+
+func TestResolveLocal_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	emptyDir := filepath.Join(dir, "skills", "generator")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create .gitkeep to mimic real scenario
+	if err := os.WriteFile(filepath.Join(emptyDir, ".gitkeep"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: emptyDir, Name: "empty-skills"},
+	}, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for empty skill directory, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestResolveLocal_NonExistentDir(t *testing.T) {
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: "/does/not/exist", Name: "missing"},
+	}, ".")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for non-existent path, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestCountSkills(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory with two skill subdirectories and one non-skill
+	skillsDir := filepath.Join(dir, "skills")
+	for _, name := range []string{"skill-a", "skill-b", "not-a-skill"} {
+		if err := os.MkdirAll(filepath.Join(skillsDir, name), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Add SKILL.md to two of them
+	for _, name := range []string{"skill-a", "skill-b"} {
+		if err := os.WriteFile(filepath.Join(skillsDir, name, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	count := CountSkills([]string{skillsDir})
+	if count != 2 {
+		t.Errorf("expected 2 skills, got %d", count)
+	}
+}
+
+func TestCountSkills_DirectSkill(t *testing.T) {
+	dir := t.TempDir()
+	// Directory itself is a skill
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	count := CountSkills([]string{dir})
+	if count != 1 {
+		t.Errorf("expected 1 skill, got %d", count)
+	}
+}
+
+func TestCountSkills_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	count := CountSkills([]string{dir})
+	if count != 0 {
+		t.Errorf("expected 0 skills for empty dir, got %d", count)
+	}
+}
+
+func TestCountSkills_NilDirs(t *testing.T) {
+	count := CountSkills(nil)
+	if count != 0 {
+		t.Errorf("expected 0 skills for nil input, got %d", count)
 	}
 }
 

--- a/hyoka/internal/skills/fetcher_test.go
+++ b/hyoka/internal/skills/fetcher_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/ronniegeraghty/hyoka/internal/config"
 )
 
-func TestResolveLocal_DirectPath(t *testing.T) {
+func TestResolveLocal_SingleSkill(t *testing.T) {
 	dir := t.TempDir()
 	skillDir := filepath.Join(dir, "my-skill")
 	if err := os.Mkdir(skillDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Add SKILL.md so the directory is recognized as containing a skill
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -33,29 +32,72 @@ func TestResolveLocal_DirectPath(t *testing.T) {
 	}
 }
 
-func TestResolveLocal_RelativePath(t *testing.T) {
+func TestResolveLocal_SingleSkillMissingSKILLMD(t *testing.T) {
 	dir := t.TempDir()
-	skillDir := filepath.Join(dir, "skills", "generator")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	skillDir := filepath.Join(dir, "my-skill")
+	if err := os.Mkdir(skillDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Add a skill subdirectory with SKILL.md
-	subSkill := filepath.Join(skillDir, "my-skill")
-	if err := os.Mkdir(subSkill, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(subSkill, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	// No SKILL.md — should warn and return nothing
 
 	dirs, err := ResolveSkillDirs([]config.ToolEntry{
-		{Type: "skill", Source: "local", Path: "skills/generator", Name: "local-skill"},
+		{Type: "skill", Source: "local", Path: skillDir, Name: "local-skill"},
 	}, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(dirs) != 1 {
-		t.Fatalf("expected 1 dir, got %d", len(dirs))
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for single skill missing SKILL.md, got %d", len(dirs))
+	}
+}
+
+func TestResolveLocal_SkillDir(t *testing.T) {
+	dir := t.TempDir()
+	skillsDir := filepath.Join(dir, "skills", "generator")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create two skill subdirectories and one non-skill
+	for _, name := range []string{"skill-a", "skill-b", "not-a-skill"} {
+		if err := os.Mkdir(filepath.Join(skillsDir, name), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"skill-a", "skill-b"} {
+		if err := os.WriteFile(filepath.Join(skillsDir, name, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: "skills/generator", Name: "gen-skills", SkillDir: true},
+	}, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 skill subdirs, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestResolveLocal_SkillDirEmpty(t *testing.T) {
+	dir := t.TempDir()
+	emptyDir := filepath.Join(dir, "skills", "generator")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(emptyDir, ".gitkeep"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := ResolveSkillDirs([]config.ToolEntry{
+		{Type: "skill", Source: "local", Path: emptyDir, Name: "empty-skills", SkillDir: true},
+	}, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for empty skill_dir, got %d: %v", len(dirs), dirs)
 	}
 }
 
@@ -85,35 +127,13 @@ func TestResolveLocal_GlobPattern(t *testing.T) {
 	}
 }
 
-func TestResolveLocal_EmptySkills(t *testing.T) {
+func TestResolveLocal_EmptyEntries(t *testing.T) {
 	dirs, err := ResolveSkillDirs(nil, ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(dirs) != 0 {
 		t.Errorf("expected 0 dirs, got %d", len(dirs))
-	}
-}
-
-func TestResolveLocal_EmptyDir(t *testing.T) {
-	dir := t.TempDir()
-	emptyDir := filepath.Join(dir, "skills", "generator")
-	if err := os.MkdirAll(emptyDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	// Create .gitkeep to mimic real scenario
-	if err := os.WriteFile(filepath.Join(emptyDir, ".gitkeep"), nil, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	dirs, err := ResolveSkillDirs([]config.ToolEntry{
-		{Type: "skill", Source: "local", Path: emptyDir, Name: "empty-skills"},
-	}, dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(dirs) != 0 {
-		t.Errorf("expected 0 dirs for empty skill directory, got %d: %v", len(dirs), dirs)
 	}
 }
 
@@ -131,35 +151,24 @@ func TestResolveLocal_NonExistentDir(t *testing.T) {
 
 func TestCountSkills(t *testing.T) {
 	dir := t.TempDir()
-	// Create a directory with two skill subdirectories and one non-skill
-	skillsDir := filepath.Join(dir, "skills")
-	for _, name := range []string{"skill-a", "skill-b", "not-a-skill"} {
-		if err := os.MkdirAll(filepath.Join(skillsDir, name), 0755); err != nil {
+	// After skill_dir expansion, each dir should directly contain SKILL.md
+	skillA := filepath.Join(dir, "skill-a")
+	skillB := filepath.Join(dir, "skill-b")
+	noSkill := filepath.Join(dir, "not-a-skill")
+	for _, d := range []string{skillA, skillB, noSkill} {
+		if err := os.Mkdir(d, 0755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	// Add SKILL.md to two of them
-	for _, name := range []string{"skill-a", "skill-b"} {
-		if err := os.WriteFile(filepath.Join(skillsDir, name, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
+	for _, d := range []string{skillA, skillB} {
+		if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	count := CountSkills([]string{skillsDir})
+	count := CountSkills([]string{skillA, skillB, noSkill})
 	if count != 2 {
 		t.Errorf("expected 2 skills, got %d", count)
-	}
-}
-
-func TestCountSkills_DirectSkill(t *testing.T) {
-	dir := t.TempDir()
-	// Directory itself is a skill
-	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Skill"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	count := CountSkills([]string{dir})
-	if count != 1 {
-		t.Errorf("expected 1 skill, got %d", count)
 	}
 }
 

--- a/plugins/azure-python.yaml
+++ b/plugins/azure-python.yaml
@@ -1,9 +1,7 @@
 name: azure-python
-description: "Azure SDK for Python — MCP server + best practices skill"
-skills:
-  - type: local
-    name: azure-python-best-practices
-    path: ./skills/generator
+description: "Azure SDK for Python — MCP server"
+# Generator skills removed: ./skills/generator/ contains no skills (#291).
+# Re-add when generator skill content is created.
 mcp_servers:
   azure:
     type: stdio


### PR DESCRIPTION
## Summary

Fixes #291 — the `baseline-skills/claude-opus-4.6` config pointed to `./skills/generator` which was empty (only `.gitkeep`), causing misleading `skills=1` in logs and a system prompt that told the agent to use skills that don't exist.

## Changes

### New `skill_dir` field on ToolEntry
Added an explicit `skill_dir` boolean field to `ToolEntry` so configs must declare whether a local skill path is a **single skill** or a **directory of skills**:

```yaml
# Single skill — path contains SKILL.md directly (skill_dir defaults to false)
- name: code-review
  type: skill
  source: local
  path: "./skills/reviewer/code-review-comments"

# Directory of skills — subdirectories each contain SKILL.md
- name: reviewer-skills
  type: skill
  source: local
  skill_dir: true
  path: "./skills/reviewer"
```

When `skill_dir: true`, `resolveLocal()` expands the directory into individual skill subdirectories (those containing SKILL.md). When `false` (default), the path itself must contain SKILL.md.

### Config cleanup
- **`configs/baseline-opus-skills.yaml`** — removed the `generator-skills` tool entry since `./skills/generator/` has no SKILL.md files
- **`plugins/azure-python.yaml`** — removed the empty skills reference
- **All configs** — added `skill_dir: true` to reviewer-skills entries that point to `./skills/reviewer`

### Code fixes (`hyoka/internal/skills/fetcher.go`)
- `resolveLocal()` now takes the full `ToolEntry` and uses `SkillDir` to decide behavior explicitly
- Single-skill paths (`skill_dir: false`) must contain SKILL.md or they're warned and skipped
- Skill directories (`skill_dir: true`) are expanded into individual skill subdirs; empty ones are warned and skipped
- Non-existent directories are warned and skipped (not returned as phantom paths)
- `CountSkills()` counts SKILL.md files in resolved directories for accurate logging

### Validation (`tool_filter.go`)
- `skill_dir: true` is rejected on remote skills (only valid for local)

### Eval integration (`copilot.go`, `engine.go`)
- `buildSessionConfig()` uses `skills.ResolveSkillDirs()` for consistent validation
- Log line reports both `skill_dirs` and `skills` counts
- SKILLS system prompt only injected when `CountSkills() > 0`

### Examples
- **`examples/configs/example-generator-skills.yaml`** — shows single skill, skill_dir, and glob patterns
- **`examples/configs/example-full.yaml`** — updated with `skill_dir: true`

### Tests
- `TestResolveLocal_SingleSkill` / `TestResolveLocal_SingleSkillMissingSKILLMD`
- `TestResolveLocal_SkillDir` / `TestResolveLocal_SkillDirEmpty`
- `TestValidateToolEntry_SkillDirOnRemote` / `TestValidateToolEntry_SkillDirOnLocal`
- `TestToolEntrySkillDirParsed`
- `TestCountSkills` / `TestCountSkills_EmptyDir` / `TestCountSkills_NilDirs`

All 27 packages pass (`go test ./hyoka/... -count=1`).