### PR TITLE
feat: add Azure MCP + Skills config

### DIFF
--- a/configs/azure-mcp-sonnet-skills.yaml
+++ b/configs/azure-mcp-sonnet-skills.yaml
@@ -1,0 +1,34 @@
+# Azure MCP + SDK Skills with Claude Sonnet 4.5
+# Combines Azure MCP server tools with installed Copilot CLI plugin skills.
+# This tests whether MCP tools + SDK skills together produce better code
+# than either approach alone.
+# Install plugins: /plugin install azure-sdk-java@skills (etc.)
+# Missing plugins are skipped gracefully with a warning.
+configs:
+  - name: azure-mcp-skills/claude-sonnet-4.5
+    description: "Azure MCP + Skills — Claude Sonnet 4.5 with MCP server and SDK plugin skills"
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        - name: azure
+          type: mcp
+          command: npx
+          args: ["-y", "@azure/mcp@latest", "server", "start"]
+          mcp_tools: ["*"]
+    reviewer:
+      models:
+        - "claude-opus-4.6"
+        - "gemini-3-pro-preview"
+        - "gpt-4.1"
+      tools:
+        - name: reviewer-skills
+          type: skill
+          source: local
+          skill_dir: true
+          path: "./skills/reviewer"
+    plugins:
+      - "azure-sdk-java@skills"
+      - "azure-sdk-python@skills"
+      - "azure-sdk-dotnet@skills"
+      - "azure-sdk-typescript@skills"
+      - "azure-sdk-rust@skills"


### PR DESCRIPTION
Add a new config \azure-mcp-skills/claude-sonnet-4.5\ that combines both Azure MCP server tools and installed Copilot CLI SDK plugin skills.