### PR TITLE
fix: remove plugins field from baseline-sonnet-skills config

### DIFF
--- a/configs/baseline-sonnet-skills.yaml
+++ b/configs/baseline-sonnet-skills.yaml
@@ -1,10 +1,8 @@
-# Baseline with Claude Sonnet 4.5 + SDK skills — no MCP servers
-# Uses installed Copilot CLI plugin skills for code generation guidance.
-# Install plugins: /plugin install azure-sdk-java@skills
-# Missing plugins are skipped gracefully with a warning.
+# Baseline with Claude Sonnet 4.5 + generator skills — no MCP servers
+# Skills are loaded from ./skills/generator/ directory.
 configs:
   - name: baseline-skills/claude-sonnet-4.5
-    description: "Baseline + Skills — Claude Sonnet 4.5 with SDK plugin skills"
+    description: "Baseline + Skills — Claude Sonnet 4.5 with generator skills"
     generator:
       model: "claude-sonnet-4.5"
       tools:
@@ -24,9 +22,3 @@ configs:
           source: local
           skill_dir: true
           path: "./skills/reviewer"
-    plugins:
-      - "azure-sdk-java@skills"
-      - "azure-sdk-python@skills"
-      - "azure-sdk-dotnet@skills"
-      - "azure-sdk-typescript@skills"
-      - "azure-sdk-rust@skills"


### PR DESCRIPTION
## Problem

\aseline-sonnet-skills.yaml\ had both \generator.tools\ (pointing to \./skills/generator/\) **and** a \plugins\ field listing 5 SDK plugins. The \plugins\ field triggered \
px skills add\ attempts for every plugin not found locally, causing noisy failures:

\\\
Installing plugin: azure-sdk-python@skills
Failed to clone azure-sdk-python@skills: fatal: repository does not exist
\\\

This happened on every run, even though the skills were already available via \./skills/generator/\.

## Fix

Remove the \plugins\ field. The \generator.tools\ approach (local directory) is the team consensus:
- Skills live in \./skills/generator/\ in the repo
- Works for everyone without plugin installation
- Explicit control over generator vs reviewer skills

## What about the plugin loading code (PR #295)?

The graceful plugin loading changes in \plugins.go\ and \config.go\ are **kept** — they're defensive improvements that protect against future plugin references. If no config uses \plugins:\, that code simply doesn't run.