### PR TITLE
Fix #565: Starter-aware MaxOutputSize guardrail

### DIFF
--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -803,6 +803,11 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	}
 	evalReport.StarterFiles = starterFiles
 
+	// Snapshot starter-file sizes so guardrails can charge the agent only for
+	// the bytes/files it actually contributed, not the starter project it was
+	// handed (#565).
+	starterSnapshot := snapshotStarterSizes(genDir, starterFiles)
+
 	lg.Debug("Workspace created", "workspace", ws.Dir, "gen_dir", genDir,
 		"starter_files", len(starterFiles))
 
@@ -1102,32 +1107,25 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 				"actions", actionCount, "max_session_actions", lim.maxSessionActions)
 		}
 
-		// Check file count
-		if len(generatedFiles) > lim.maxFiles {
-			reason := fmt.Sprintf("guardrail: file count %d exceeded limit of %d", len(generatedFiles), lim.maxFiles)
+		// Check file count — charge the agent only for files it created or
+		// deleted, not starter files it was handed (#565).
+		agentFileCount := computeAgentFileCount(generatedFiles, starterSnapshot)
+		if agentFileCount > lim.maxFiles {
+			reason := fmt.Sprintf("guardrail: agent file count %d exceeded limit of %d", agentFileCount, lim.maxFiles)
 			evalReport.GuardrailAbortReason = reason
 			evalReport.Error = reason
 			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "files", len(generatedFiles), "max_files", lim.maxFiles)
+			lg.Warn("Guardrail triggered", "reason", reason, "agent_files", agentFileCount, "total_files", len(generatedFiles), "max_files", lim.maxFiles)
 		}
 
-		// Check total output size
-		var totalSize int64
-		for _, f := range generatedFiles {
-			absPath := f
-			if !filepath.IsAbs(f) {
-				absPath = filepath.Join(ws.Dir, f)
-			}
-			if info, err := os.Stat(absPath); err == nil {
-				totalSize += info.Size()
-			}
-		}
+		// Check total output size — starter-aware (#565).
+		totalSize := computeAgentOutputSize(ws.Dir, generatedFiles, starterSnapshot)
 		if totalSize > lim.maxOutputSize {
-			reason := fmt.Sprintf("guardrail: total output size %d bytes exceeded limit of %d bytes", totalSize, lim.maxOutputSize)
+			reason := fmt.Sprintf("guardrail: agent output size %d bytes exceeded limit of %d bytes", totalSize, lim.maxOutputSize)
 			evalReport.GuardrailAbortReason = reason
 			evalReport.Error = reason
 			evalReport.Success = false
-			lg.Warn("Guardrail triggered", "reason", reason, "total_size", totalSize, "max_size", lim.maxOutputSize)
+			lg.Warn("Guardrail triggered", "reason", reason, "agent_output_size", totalSize, "max_size", lim.maxOutputSize)
 		}
 	}
 

--- a/hyoka/internal/eval/guardrail.go
+++ b/hyoka/internal/eval/guardrail.go
@@ -1,0 +1,78 @@
+package eval
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// snapshotStarterSizes records the on-disk size of each starter file, keyed by
+// the same workspace-relative path format that Workspace.ListFiles returns.
+// Files that cannot be stat'd are recorded with size 0 — the safe default,
+// since any later growth will be counted as agent output (worst case: no change
+// from today's behavior). baseDir is the workspace root.
+func snapshotStarterSizes(baseDir string, starterFiles []string) map[string]int64 {
+	snap := make(map[string]int64, len(starterFiles))
+	for _, rel := range starterFiles {
+		info, err := os.Stat(filepath.Join(baseDir, rel))
+		if err != nil {
+			slog.Warn("Could not stat starter file for guardrail snapshot; treating original size as 0",
+				"file", rel, "error", err)
+			snap[rel] = 0
+			continue
+		}
+		snap[rel] = info.Size()
+	}
+	return snap
+}
+
+// computeAgentOutputSize returns the bytes the agent is responsible for, given
+// the current workspace file list and a snapshot of starter-file sizes taken
+// before generation. Files present in the snapshot only count for bytes
+// *added* beyond their original size (max(0, current - original)). Files not
+// in the snapshot count their full size (agent-created). baseDir is the
+// workspace root used to resolve relative paths.
+func computeAgentOutputSize(baseDir string, files []string, snapshot map[string]int64) int64 {
+	var total int64
+	for _, f := range files {
+		absPath := f
+		if !filepath.IsAbs(f) {
+			absPath = filepath.Join(baseDir, f)
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			continue
+		}
+		cur := info.Size()
+		if orig, isStarter := snapshot[f]; isStarter {
+			delta := cur - orig
+			if delta > 0 {
+				total += delta
+			}
+			continue
+		}
+		total += cur
+	}
+	return total
+}
+
+// computeAgentFileCount returns the number of files the agent is responsible
+// for: new files (not in the snapshot) plus starter files the agent deleted
+// (present in snapshot but missing from the current list).
+func computeAgentFileCount(files []string, snapshot map[string]int64) int {
+	present := make(map[string]bool, len(files))
+	newFiles := 0
+	for _, f := range files {
+		present[f] = true
+		if _, isStarter := snapshot[f]; !isStarter {
+			newFiles++
+		}
+	}
+	deleted := 0
+	for starter := range snapshot {
+		if !present[starter] {
+			deleted++
+		}
+	}
+	return newFiles + deleted
+}

--- a/hyoka/internal/eval/guardrail_test.go
+++ b/hyoka/internal/eval/guardrail_test.go
@@ -1,0 +1,166 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file at baseDir/rel with the given contents, ensuring
+// the parent directory exists.
+func writeFile(t *testing.T, baseDir, rel string, contents []byte) {
+	t.Helper()
+	full := filepath.Join(baseDir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", full, err)
+	}
+	if err := os.WriteFile(full, contents, 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
+	}
+}
+
+func TestSnapshotStarterSizes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", []byte("package main\n"))
+	writeFile(t, dir, "pkg/lib.go", []byte("package pkg\n"))
+
+	snap := snapshotStarterSizes(dir, []string{"main.go", "pkg/lib.go", "missing.go"})
+
+	if got, want := snap["main.go"], int64(len("package main\n")); got != want {
+		t.Errorf("main.go size: got %d want %d", got, want)
+	}
+	if got, want := snap["pkg/lib.go"], int64(len("package pkg\n")); got != want {
+		t.Errorf("pkg/lib.go size: got %d want %d", got, want)
+	}
+	// Missing files are recorded with size 0 (safe default — worst case the
+	// agent's copy is fully charged).
+	if got, ok := snap["missing.go"]; !ok || got != 0 {
+		t.Errorf("missing.go: got (%d, ok=%v), want (0, ok=true)", got, ok)
+	}
+}
+
+func TestComputeAgentOutputSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		starter  map[string][]byte // starter files written before snapshot
+		after    map[string][]byte // files present at guardrail time (may overlap/differ)
+		removed  []string          // paths to remove after snapshot (simulate deletions)
+		expected int64
+	}{
+		{
+			name:     "unchanged starter produces zero agent bytes",
+			starter:  map[string][]byte{"a.go": []byte("hello"), "b.go": []byte("world!!")},
+			after:    map[string][]byte{"a.go": []byte("hello"), "b.go": []byte("world!!")},
+			expected: 0,
+		},
+		{
+			name:     "starter modified in place counts only delta",
+			starter:  map[string][]byte{"a.go": []byte("hello")},                 // 5
+			after:    map[string][]byte{"a.go": []byte("hello, extended world")}, // 21
+			expected: 21 - 5,
+		},
+		{
+			name:     "new agent file counts full size",
+			starter:  map[string][]byte{"a.go": []byte("hello")},
+			after:    map[string][]byte{"a.go": []byte("hello"), "new.go": []byte("abcdef")},
+			expected: 6,
+		},
+		{
+			name:     "starter shrunk does not count negative bytes",
+			starter:  map[string][]byte{"a.go": []byte("longer original contents")}, // 24
+			after:    map[string][]byte{"a.go": []byte("tiny")},                     // 4
+			expected: 0,
+		},
+		{
+			name:     "deleted starter contributes no bytes",
+			starter:  map[string][]byte{"a.go": []byte("hello"), "b.go": []byte("world!!")},
+			after:    map[string][]byte{"a.go": []byte("hello")},
+			removed:  []string{"b.go"},
+			expected: 0,
+		},
+		{
+			name:     "mixed: delta + new file",
+			starter:  map[string][]byte{"a.go": []byte("hi")},                                     // 2
+			after:    map[string][]byte{"a.go": []byte("hi there"), "extra.txt": []byte("xxxx")}, // 8, 4
+			expected: (8 - 2) + 4,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			var starterFiles []string
+			for name, body := range tc.starter {
+				writeFile(t, dir, name, body)
+				starterFiles = append(starterFiles, name)
+			}
+			snap := snapshotStarterSizes(dir, starterFiles)
+
+			// Rewrite workspace to match "after" state.
+			for name := range tc.starter {
+				_ = os.Remove(filepath.Join(dir, name))
+			}
+			var currentFiles []string
+			for name, body := range tc.after {
+				writeFile(t, dir, name, body)
+				currentFiles = append(currentFiles, name)
+			}
+			for _, r := range tc.removed {
+				_ = os.Remove(filepath.Join(dir, r))
+			}
+
+			got := computeAgentOutputSize(dir, currentFiles, snap)
+			if got != tc.expected {
+				t.Errorf("agent output size: got %d want %d", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestComputeAgentFileCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot map[string]int64
+		current  []string
+		want     int
+	}{
+		{
+			name:     "only starter files present — zero agent files",
+			snapshot: map[string]int64{"a.go": 10, "b.go": 20},
+			current:  []string{"a.go", "b.go"},
+			want:     0,
+		},
+		{
+			name:     "one new file",
+			snapshot: map[string]int64{"a.go": 10},
+			current:  []string{"a.go", "new.go"},
+			want:     1,
+		},
+		{
+			name:     "one deleted starter",
+			snapshot: map[string]int64{"a.go": 10, "b.go": 20},
+			current:  []string{"a.go"},
+			want:     1,
+		},
+		{
+			name:     "new + deleted",
+			snapshot: map[string]int64{"a.go": 10, "b.go": 20},
+			current:  []string{"a.go", "new.go"},
+			want:     2, // 1 new, 1 deleted
+		},
+		{
+			name:     "no starter at all — every current file counts",
+			snapshot: map[string]int64{},
+			current:  []string{"x.go", "y.go", "z.go"},
+			want:     3,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeAgentFileCount(tc.current, tc.snapshot)
+			if got != tc.want {
+				t.Errorf("agent file count: got %d want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/hyoka/internal/eval/guardrail_test.go
+++ b/hyoka/internal/eval/guardrail_test.go
@@ -84,6 +84,24 @@ func TestComputeAgentOutputSize(t *testing.T) {
 			after:    map[string][]byte{"a.go": []byte("hi there"), "extra.txt": []byte("xxxx")}, // 8, 4
 			expected: (8 - 2) + 4,
 		},
+		{
+			name:     "zero-byte starter unchanged",
+			starter:  map[string][]byte{"empty.txt": []byte("")},
+			after:    map[string][]byte{"empty.txt": []byte("")},
+			expected: 0,
+		},
+		{
+			name:     "zero-byte starter grows",
+			starter:  map[string][]byte{"empty.txt": []byte("")},
+			after:    map[string][]byte{"empty.txt": []byte("content added")},
+			expected: 13,
+		},
+		{
+			name:     "empty starter project",
+			starter:  map[string][]byte{},
+			after:    map[string][]byte{"new.go": []byte("content")},
+			expected: 7,
+		},
 	}
 
 	for _, tc := range tests {
@@ -153,6 +171,12 @@ func TestComputeAgentFileCount(t *testing.T) {
 			snapshot: map[string]int64{},
 			current:  []string{"x.go", "y.go", "z.go"},
 			want:     3,
+		},
+		{
+			name:     "zero-byte starter files still count as starter",
+			snapshot: map[string]int64{"empty.txt": 0, "README.md": 0},
+			current:  []string{"empty.txt", "README.md", "new.go"},
+			want:     1, // only new.go
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Surgical hotfix for #565. The `MaxOutputSize` and `MaxFiles` guardrails were charging the agent for the entire workspace — including starter-project files copied in before generation. On larger starter projects, this tripped the 1MB / 50-file limits before the agent produced anything, corrupting results for colleagues.

## What changed

After `CopyStarterFiles`, the engine now snapshots starter file sizes into a `map[string]int64` (same workspace-relative path format as `ws.ListFiles()`). At guardrail time:

- **MaxOutputSize**: for each current file, count `max(0, current - original)` if it's a starter file, or full size if it's new. Shrunk starters contribute zero, never negative.
- **MaxFiles**: count new agent-created files + starter files the agent deleted (`len(snapshot) - still-present`).

Hard-fail semantics are preserved. Softening to a warning and adding `WorkspaceDelta` to `GraderInput` is deferred to #566 (Phase 3.5) — see the decision doc in `.squad/decisions/inbox/morpheus-review-context-strategy.md`.

## Implementation

The three helpers — `snapshotStarterSizes`, `computeAgentOutputSize`, `computeAgentFileCount` — live in a new `hyoka/internal/eval/guardrail.go` so they're directly unit-testable.

## Tests

Added `guardrail_test.go` — table-driven coverage for:
- Unchanged starters → 0 agent bytes
- Starter modified in place → only the delta
- New agent file → full size
- Shrunk starter → no negative bytes
- Deleted starter → no bytes, counts toward agent file count
- Mixed scenarios

## Verification

```
go build ./...                                      # passes
go vet ./...                                        # clean
go test -race ./hyoka/internal/eval/... -timeout 3m # passes
```

Fixes #565

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>