### PR TITLE
Add example config using remote skill from microsoft/skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ site/dist/
 
 # Playwright MCP snapshots
 .playwright-mcp/
+
+# Remote skill cache (populated on first run / dry-run by internal/skills/fetcher.go)
+.skills-cache/

--- a/examples/configs/example-remote-skill.yaml
+++ b/examples/configs/example-remote-skill.yaml
@@ -1,29 +1,30 @@
-# Example: generator config that pulls a skill from a remote GitHub repo.
+# Example: generator config that pulls skills from a remote GitHub repo.
 #
-# This config demonstrates hyoka's two remote-skill fetch paths:
+# This config demonstrates hyoka's two remote-skill fetch paths in ONE
+# generator — the repo's published skill AND a skill from a subpath:
 #
-# 1. Whole-repo fetch (default — this file).
+# 1. Whole-repo fetch via `npx skills add` (the `copilot-sdk` entry below).
 #    `repo: owner/name` → hyoka shells out to
 #    `npx skills add <repo> --skill <name> --agent claude-code --copy --yes`
 #    Cache: .skills-cache/<repo>/.claude/skills/<name>/
 #    Requires Node.js / `npx` on PATH.
+#    Use this for skills the repo publishes through the skills CLI.
 #
-# 2. Subpath fetch via git sparse-checkout (see the commented config below).
+# 2. Subpath fetch via `git sparse-checkout` (the `azure-identity-rust` entry).
 #    `repo: owner/name/path/under/repo` → hyoka clones the repo with
 #    `git clone --filter=blob:none --no-checkout --depth=1` and pulls only
-#    the named subpath via `git sparse-checkout`. Use this for skills that
-#    live inside a monorepo's plugins/ tree (e.g. microsoft/skills ships
-#    Rust skills under .github/plugins/azure-sdk-rust/skills/).
+#    the named subpath via `git sparse-checkout`.
 #    Cache: .skills-cache/<repo>/<subpath>/<name>/
 #    Requires `git` on PATH.
+#    Use this for skills that live inside a monorepo's plugins/ tree —
+#    e.g. microsoft/skills ships Rust-specific Azure SDK skills under
+#    .github/plugins/azure-sdk-rust/skills/ that aren't surfaced by
+#    `npx skills list`.
 #
 # The remote-skill pattern is the fields under tools:
 #   source: remote
-#   repo:   microsoft/skills     # 2 segments → npx flow
-#   repo:   microsoft/skills/.github/plugins/azure-sdk-rust/skills
-#                                # 3+ segments → sparse-checkout flow
-#   name:   copilot-sdk          # specific skill within that repo (required;
-#                                # selects which subdir to install/check out)
+#   repo:   <owner>/<name>[/<sub>/<path>]   # segment count selects fetch path
+#   name:   <skill-name>                    # required; selects which subdir
 #
 # Because this config lives under examples/configs/ (not the default
 # configs/ discovery path), invoke it with --config-file, e.g.:
@@ -34,35 +35,24 @@
 #     --language python --dry-run
 #
 # The copilot-sdk skill was chosen because hyoka itself is built on the
-# Copilot SDK and evaluates Copilot-generated code — a natural domain fit
-# for demonstrating a remote skill.
+# Copilot SDK and evaluates Copilot-generated code — a natural domain fit.
+# The azure-identity-rust skill demonstrates pulling a single skill from a
+# plugin directory that the skills CLI doesn't surface directly.
 configs:
   - name: example-remote-skill/claude-sonnet-4.5
-    description: "Example — remote skill fetched from microsoft/skills (npx flow)"
+    description: "Example — remote skills fetched from microsoft/skills (both fetch paths)"
 
     generator:
       model: "claude-sonnet-4.5"
       tools:
-        # Remote skill — fetched from https://github.com/microsoft/skills
-        # via `npx skills add microsoft/skills --skill copilot-sdk ...`.
+        # Published skill — fetched via `npx skills add microsoft/skills`.
         - name: copilot-sdk
           type: skill
           source: remote
           repo: microsoft/skills
 
-    reviewer:
-      models:
-        - "claude-sonnet-4.5"
-
-  # Subpath variant — demonstrates git sparse-checkout for skills that live
-  # inside a monorepo subdirectory. Pulls ONLY the azure-identity-rust skill
-  # from .github/plugins/azure-sdk-rust/skills/ in microsoft/skills.
-  - name: example-remote-skill-subpath/claude-sonnet-4.5
-    description: "Example — remote skill fetched from a subpath via git sparse-checkout"
-
-    generator:
-      model: "claude-sonnet-4.5"
-      tools:
+        # Subpath skill — fetched via `git sparse-checkout` of
+        # .github/plugins/azure-sdk-rust/skills/ in the same repo.
         - name: azure-identity-rust
           type: skill
           source: remote

--- a/examples/configs/example-remote-skill.yaml
+++ b/examples/configs/example-remote-skill.yaml
@@ -1,24 +1,29 @@
 # Example: generator config that pulls a skill from a remote GitHub repo.
 #
-# This config demonstrates hyoka's remote-skill fetch path. The `copilot-sdk`
-# skill from https://github.com/microsoft/skills is downloaded on first use
-# (including `--dry-run`, which exercises skill resolution) and cached at:
+# This config demonstrates hyoka's two remote-skill fetch paths:
 #
-#   .skills-cache/<repo>/.claude/skills/<name>/
-#   e.g. .skills-cache/microsoft/skills/.claude/skills/copilot-sdk/
+# 1. Whole-repo fetch (default — this file).
+#    `repo: owner/name` → hyoka shells out to
+#    `npx skills add <repo> --skill <name> --agent claude-code --copy --yes`
+#    Cache: .skills-cache/<repo>/.claude/skills/<name>/
+#    Requires Node.js / `npx` on PATH.
 #
-# Requirements:
-#   - `npx` on PATH — hyoka shells out to
-#     `npx skills add <repo> --skill <name> --agent claude-code --copy --yes`
-#     to fetch a single skill from GitHub, so Node.js must be installed.
+# 2. Subpath fetch via git sparse-checkout (see the commented config below).
+#    `repo: owner/name/path/under/repo` → hyoka clones the repo with
+#    `git clone --filter=blob:none --no-checkout --depth=1` and pulls only
+#    the named subpath via `git sparse-checkout`. Use this for skills that
+#    live inside a monorepo's plugins/ tree (e.g. microsoft/skills ships
+#    Rust skills under .github/plugins/azure-sdk-rust/skills/).
+#    Cache: .skills-cache/<repo>/<subpath>/<name>/
+#    Requires `git` on PATH.
 #
-# The remote-skill pattern is the three fields under tools:
+# The remote-skill pattern is the fields under tools:
 #   source: remote
-#   repo:   microsoft/skills   # GitHub owner/repo
-#   name:   copilot-sdk        # specific skill within that repo (required —
-#                              # passed to `npx skills add --skill <name>`;
-#                              # without it every skill in the repo would
-#                              # install, which is almost never what you want)
+#   repo:   microsoft/skills     # 2 segments → npx flow
+#   repo:   microsoft/skills/.github/plugins/azure-sdk-rust/skills
+#                                # 3+ segments → sparse-checkout flow
+#   name:   copilot-sdk          # specific skill within that repo (required;
+#                                # selects which subdir to install/check out)
 #
 # Because this config lives under examples/configs/ (not the default
 # configs/ discovery path), invoke it with --config-file, e.g.:
@@ -33,17 +38,35 @@
 # for demonstrating a remote skill.
 configs:
   - name: example-remote-skill/claude-sonnet-4.5
-    description: "Example — remote skill fetched from microsoft/skills"
+    description: "Example — remote skill fetched from microsoft/skills (npx flow)"
 
     generator:
       model: "claude-sonnet-4.5"
       tools:
         # Remote skill — fetched from https://github.com/microsoft/skills
-        # via `npx -y skills add microsoft/skills` on first run.
+        # via `npx skills add microsoft/skills --skill copilot-sdk ...`.
         - name: copilot-sdk
           type: skill
           source: remote
           repo: microsoft/skills
+
+    reviewer:
+      models:
+        - "claude-sonnet-4.5"
+
+  # Subpath variant — demonstrates git sparse-checkout for skills that live
+  # inside a monorepo subdirectory. Pulls ONLY the azure-identity-rust skill
+  # from .github/plugins/azure-sdk-rust/skills/ in microsoft/skills.
+  - name: example-remote-skill-subpath/claude-sonnet-4.5
+    description: "Example — remote skill fetched from a subpath via git sparse-checkout"
+
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        - name: azure-identity-rust
+          type: skill
+          source: remote
+          repo: microsoft/skills/.github/plugins/azure-sdk-rust/skills
 
     reviewer:
       models:

--- a/examples/configs/example-remote-skill.yaml
+++ b/examples/configs/example-remote-skill.yaml
@@ -4,17 +4,21 @@
 # skill from https://github.com/microsoft/skills is downloaded on first use
 # (including `--dry-run`, which exercises skill resolution) and cached at:
 #
-#   .skills-cache/<repo>/<name>/
-#   e.g. .skills-cache/microsoft/skills/copilot-sdk/
+#   .skills-cache/<repo>/.claude/skills/<name>/
+#   e.g. .skills-cache/microsoft/skills/.claude/skills/copilot-sdk/
 #
 # Requirements:
-#   - `npx` on PATH — hyoka shells out to `npx -y skills add <repo>` to
-#     fetch skills from GitHub, so Node.js must be installed.
+#   - `npx` on PATH — hyoka shells out to
+#     `npx skills add <repo> --skill <name> --agent claude-code --copy --yes`
+#     to fetch a single skill from GitHub, so Node.js must be installed.
 #
 # The remote-skill pattern is the three fields under tools:
 #   source: remote
 #   repo:   microsoft/skills   # GitHub owner/repo
-#   name:   copilot-sdk        # specific skill within that repo
+#   name:   copilot-sdk        # specific skill within that repo (required —
+#                              # passed to `npx skills add --skill <name>`;
+#                              # without it every skill in the repo would
+#                              # install, which is almost never what you want)
 #
 # Because this config lives under examples/configs/ (not the default
 # configs/ discovery path), invoke it with --config-file, e.g.:

--- a/examples/configs/example-remote-skill.yaml
+++ b/examples/configs/example-remote-skill.yaml
@@ -1,0 +1,46 @@
+# Example: generator config that pulls a skill from a remote GitHub repo.
+#
+# This config demonstrates hyoka's remote-skill fetch path. The `copilot-sdk`
+# skill from https://github.com/microsoft/skills is downloaded on first use
+# (including `--dry-run`, which exercises skill resolution) and cached at:
+#
+#   .skills-cache/<repo>/<name>/
+#   e.g. .skills-cache/microsoft/skills/copilot-sdk/
+#
+# Requirements:
+#   - `npx` on PATH — hyoka shells out to `npx -y skills add <repo>` to
+#     fetch skills from GitHub, so Node.js must be installed.
+#
+# The remote-skill pattern is the three fields under tools:
+#   source: remote
+#   repo:   microsoft/skills   # GitHub owner/repo
+#   name:   copilot-sdk        # specific skill within that repo
+#
+# Because this config lives under examples/configs/ (not the default
+# configs/ discovery path), invoke it with --config-file, e.g.:
+#
+#   go run ./hyoka run \
+#     --config-file examples/configs/example-remote-skill.yaml \
+#     --config example-remote-skill/claude-sonnet-4.5 \
+#     --language python --dry-run
+#
+# The copilot-sdk skill was chosen because hyoka itself is built on the
+# Copilot SDK and evaluates Copilot-generated code — a natural domain fit
+# for demonstrating a remote skill.
+configs:
+  - name: example-remote-skill/claude-sonnet-4.5
+    description: "Example — remote skill fetched from microsoft/skills"
+
+    generator:
+      model: "claude-sonnet-4.5"
+      tools:
+        # Remote skill — fetched from https://github.com/microsoft/skills
+        # via `npx -y skills add microsoft/skills` on first run.
+        - name: copilot-sdk
+          type: skill
+          source: remote
+          repo: microsoft/skills
+
+    reviewer:
+      models:
+        - "claude-sonnet-4.5"

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -374,7 +374,7 @@ func InstallSkillsAndPlugins(configs []ToolConfig) error {
 			cmd = exec.Command("copilot", "plugin", "install", e.value)
 		} else {
 			// npm-based skill package
-			cmd = exec.Command("npx", "skills", "add", e.value)
+			cmd = exec.Command("npx", "skills", "add", e.value, "--yes")
 		}
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -177,7 +177,7 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 	}
 
 	// Use npx skills add to fetch the skill
-	args := []string{"skills", "add", entry.Repo, "--directory", installDir}
+	args := []string{"skills", "add", entry.Repo, "--directory", installDir, "--yes"}
 	if entry.Name != "" {
 		args = append(args, "--name", entry.Name)
 	}

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -260,7 +260,7 @@ func fetchRemoteNpx(entry config.ToolEntry, repo, baseDir string) (string, error
 // The final skill dir is <cacheDir>/<subpath>/<entry.Name>/ and must contain
 // SKILL.md. Subsequent runs reuse the existing clone and refresh via "git pull".
 func fetchRemoteSparse(entry config.ToolEntry, repo, subpath, baseDir string) (string, error) {
-	cacheDir := filepath.Join(baseDir, ".skills-cache", repo)
+	cacheDir := filepath.Join(baseDir, ".skills-cache", "sparse", repo)
 	skillDir := filepath.Join(cacheDir, subpath, entry.Name)
 	cloneURL := fmt.Sprintf("https://github.com/%s.git", repo)
 

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -163,37 +163,57 @@ func resolveSkillDir(dir string) ([]string, error) {
 	return dirs, nil
 }
 
-// fetchRemote fetches a remote skill from a GitHub repo using npx skills add.
-// Returns the directory where the skill was installed.
+// fetchRemote fetches a single skill from a GitHub repo using "npx skills add".
+//
+// The skills CLI installs into <cwd>/.claude/skills/<skill-name>/ when the
+// claude-code agent is targeted. hyoka sets cmd.Dir to a per-repo cache
+// directory so multiple configs don't clobber each other, then returns the
+// absolute path to the installed skill for the session to load.
+//
+// entry.Name is required and is passed as --skill, selecting exactly one skill
+// from the repository (repositories often publish many skills).
 func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
-	// Determine install directory: use a skills cache dir under baseDir
-	installDir := filepath.Join(baseDir, ".skills-cache", entry.Repo)
-	if entry.Name != "" {
-		installDir = filepath.Join(installDir, entry.Name)
+	if entry.Name == "" {
+		return "", fmt.Errorf("remote skill from %q requires a 'name' field (the skill to install from the repo)", entry.Repo)
 	}
 
-	if err := os.MkdirAll(installDir, 0755); err != nil {
-		return "", fmt.Errorf("creating skill install dir: %w", err)
+	// Per-repo cache dir; skills CLI will create .claude/skills/<name>/ inside it.
+	cacheDir := filepath.Join(baseDir, ".skills-cache", entry.Repo)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", fmt.Errorf("creating skill cache dir: %w", err)
 	}
 
-	// Use npx skills add to fetch the skill
-	args := []string{"skills", "add", entry.Repo, "--directory", installDir, "--yes"}
-	if entry.Name != "" {
-		args = append(args, "--name", entry.Name)
+	// Flags reference: https://www.npmjs.com/package/skills
+	//   --skill <name>       select a single skill from the repo
+	//   --agent claude-code  install layout hyoka consumes (.claude/skills/<name>/SKILL.md)
+	//   --copy               copy files instead of symlinking (portable across machines)
+	//   --yes                skip interactive confirmation prompts
+	args := []string{"skills", "add", entry.Repo,
+		"--skill", entry.Name,
+		"--agent", "claude-code",
+		"--copy",
+		"--yes",
 	}
 
 	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", entry.Name, entry.Repo)
-	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo)
+	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo, "cache_dir", cacheDir)
 	cmd := exec.Command("npx", args...)
+	cmd.Dir = cacheDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("npx skills add: %w", err)
 	}
 
-	abs, absErr := filepath.Abs(installDir)
+	installedDir := filepath.Join(cacheDir, ".claude", "skills", entry.Name)
+	if _, err := os.Stat(filepath.Join(installedDir, "SKILL.md")); err != nil {
+		return "", fmt.Errorf("skills add completed but SKILL.md not found at %s (skill %q may not exist in repo %q)", installedDir, entry.Name, entry.Repo)
+	}
+
+	abs, absErr := filepath.Abs(installedDir)
 	if absErr != nil {
-		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
+		slog.Warn("Failed to resolve absolute install path", "path", installedDir, "error", absErr)
+		return installedDir, nil
 	}
 	return abs, nil
 }

--- a/hyoka/internal/skills/fetcher.go
+++ b/hyoka/internal/skills/fetcher.go
@@ -20,7 +20,8 @@ import (
 //   - source: local, skill_dir: false → path points to a single skill (must contain SKILL.md)
 //   - source: local, skill_dir: true  → path is a directory of skills (subdirs contain SKILL.md)
 //   - source: local with glob         → each glob match is treated as a single skill directory
-//   - source: remote                  → fetches from GitHub repo via "npx skills add"
+//   - source: remote, repo "owner/name"         → fetches via "npx skills add"
+//   - source: remote, repo "owner/name/subpath" → git sparse-checkout of that subpath
 func ResolveSkillDirs(entries []config.ToolEntry, baseDir string) ([]string, error) {
 	var dirs []string
 	for _, entry := range entries {
@@ -163,22 +164,56 @@ func resolveSkillDir(dir string) ([]string, error) {
 	return dirs, nil
 }
 
-// fetchRemote fetches a single skill from a GitHub repo using "npx skills add".
+// parseRepoSpec splits a repo spec of the form "owner/name" or
+// "owner/name/sub/path" into the repo slug (first two segments) and an
+// optional subpath (remaining segments, joined with "/"). An empty subpath
+// means "whole repo" — the caller should use the npx fetch path. A non-empty
+// subpath means "fetch just this directory" — the caller should use the
+// git sparse-checkout fetch path.
+func parseRepoSpec(spec string) (repo, subpath string) {
+	parts := strings.Split(strings.Trim(spec, "/"), "/")
+	if len(parts) < 2 {
+		return spec, ""
+	}
+	repo = parts[0] + "/" + parts[1]
+	if len(parts) > 2 {
+		subpath = strings.Join(parts[2:], "/")
+	}
+	return repo, subpath
+}
+
+// fetchRemote fetches a single skill from a GitHub repo.
 //
-// The skills CLI installs into <cwd>/.claude/skills/<skill-name>/ when the
-// claude-code agent is targeted. hyoka sets cmd.Dir to a per-repo cache
-// directory so multiple configs don't clobber each other, then returns the
-// absolute path to the installed skill for the session to load.
+// When entry.Repo is just "owner/name", hyoka shells out to
+// "npx skills add <repo> --skill <name> ..." and consumes the resulting
+// .claude/skills/<name>/ layout.
 //
-// entry.Name is required and is passed as --skill, selecting exactly one skill
-// from the repository (repositories often publish many skills).
+// When entry.Repo includes a subpath ("owner/name/sub/dir"), hyoka uses
+// "git sparse-checkout" to fetch just that directory from the repo. The
+// skill is expected at <subpath>/<name>/SKILL.md. This is the escape hatch
+// for repos that don't publish through the skills CLI (e.g. skills living
+// inside a monorepo's plugins/ tree).
+//
+// entry.Name is required in both cases and selects a single skill.
 func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 	if entry.Name == "" {
 		return "", fmt.Errorf("remote skill from %q requires a 'name' field (the skill to install from the repo)", entry.Repo)
 	}
 
+	repo, subpath := parseRepoSpec(entry.Repo)
+	if subpath != "" {
+		return fetchRemoteSparse(entry, repo, subpath, baseDir)
+	}
+	return fetchRemoteNpx(entry, repo, baseDir)
+}
+
+// fetchRemoteNpx runs "npx skills add" to install a single skill from a
+// GitHub repo. The skills CLI installs into <cwd>/.claude/skills/<skill-name>/.
+// hyoka sets cmd.Dir to a per-repo cache directory so multiple configs don't
+// clobber each other, then returns the absolute path to the installed skill.
+func fetchRemoteNpx(entry config.ToolEntry, repo, baseDir string) (string, error) {
 	// Per-repo cache dir; skills CLI will create .claude/skills/<name>/ inside it.
-	cacheDir := filepath.Join(baseDir, ".skills-cache", entry.Repo)
+	cacheDir := filepath.Join(baseDir, ".skills-cache", repo)
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return "", fmt.Errorf("creating skill cache dir: %w", err)
 	}
@@ -188,15 +223,15 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 	//   --agent claude-code  install layout hyoka consumes (.claude/skills/<name>/SKILL.md)
 	//   --copy               copy files instead of symlinking (portable across machines)
 	//   --yes                skip interactive confirmation prompts
-	args := []string{"skills", "add", entry.Repo,
+	args := []string{"skills", "add", repo,
 		"--skill", entry.Name,
 		"--agent", "claude-code",
 		"--copy",
 		"--yes",
 	}
 
-	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", entry.Name, entry.Repo)
-	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo, "cache_dir", cacheDir)
+	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", entry.Name, repo)
+	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", repo, "cache_dir", cacheDir)
 	cmd := exec.Command("npx", args...)
 	cmd.Dir = cacheDir
 	cmd.Stdout = os.Stdout
@@ -207,7 +242,7 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 
 	installedDir := filepath.Join(cacheDir, ".claude", "skills", entry.Name)
 	if _, err := os.Stat(filepath.Join(installedDir, "SKILL.md")); err != nil {
-		return "", fmt.Errorf("skills add completed but SKILL.md not found at %s (skill %q may not exist in repo %q)", installedDir, entry.Name, entry.Repo)
+		return "", fmt.Errorf("skills add completed but SKILL.md not found at %s (skill %q may not exist in repo %q)", installedDir, entry.Name, repo)
 	}
 
 	abs, absErr := filepath.Abs(installedDir)
@@ -216,4 +251,69 @@ func fetchRemote(entry config.ToolEntry, baseDir string) (string, error) {
 		return installedDir, nil
 	}
 	return abs, nil
+}
+
+// fetchRemoteSparse clones a GitHub repo with git sparse-checkout and returns
+// the path to a specific skill inside a subpath. Used when entry.Repo includes
+// a subpath (e.g. "microsoft/skills/.github/plugins/azure-sdk-rust/skills").
+//
+// The final skill dir is <cacheDir>/<subpath>/<entry.Name>/ and must contain
+// SKILL.md. Subsequent runs reuse the existing clone and refresh via "git pull".
+func fetchRemoteSparse(entry config.ToolEntry, repo, subpath, baseDir string) (string, error) {
+	cacheDir := filepath.Join(baseDir, ".skills-cache", repo)
+	skillDir := filepath.Join(cacheDir, subpath, entry.Name)
+	cloneURL := fmt.Sprintf("https://github.com/%s.git", repo)
+
+	fmt.Printf("Fetching remote skill: %s (repo: %s, subpath: %s)\n", entry.Name, repo, subpath)
+	slog.Info("Fetching remote skill (sparse)", "skill", entry.Name, "repo", repo, "subpath", subpath, "cache_dir", cacheDir)
+
+	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
+		// First-time clone: blobless, no checkout, then configure sparse-checkout.
+		if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
+			return "", fmt.Errorf("creating skill cache dir: %w", err)
+		}
+		if err := runGit("", "clone", "--filter=blob:none", "--no-checkout", "--depth=1", cloneURL, cacheDir); err != nil {
+			return "", fmt.Errorf("git clone %s: %w", repo, err)
+		}
+		// Non-cone mode: the subpath may start with "." (e.g. ".github/...").
+		if err := runGit(cacheDir, "sparse-checkout", "init", "--no-cone"); err != nil {
+			return "", fmt.Errorf("git sparse-checkout init: %w", err)
+		}
+	}
+
+	// Always (re)apply the sparse pattern — cheap and lets multiple configs
+	// layer different subpaths into the same clone without stomping each other.
+	sparsePattern := "/" + subpath + "/"
+	if err := runGit(cacheDir, "sparse-checkout", "add", sparsePattern); err != nil {
+		// Fall back to `set` if `add` is unavailable (older git).
+		if err := runGit(cacheDir, "sparse-checkout", "set", "--no-cone", sparsePattern); err != nil {
+			return "", fmt.Errorf("git sparse-checkout add %s: %w", sparsePattern, err)
+		}
+	}
+	if err := runGit(cacheDir, "checkout"); err != nil {
+		return "", fmt.Errorf("git checkout: %w", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		return "", fmt.Errorf("sparse-checkout completed but SKILL.md not found at %s (skill %q may not exist under %q in repo %q)", skillDir, entry.Name, subpath, repo)
+	}
+
+	abs, absErr := filepath.Abs(skillDir)
+	if absErr != nil {
+		slog.Warn("Failed to resolve absolute skill path", "path", skillDir, "error", absErr)
+		return skillDir, nil
+	}
+	return abs, nil
+}
+
+// runGit runs `git <args>` with the given working directory (empty = inherit).
+// stdout/stderr are streamed so clone progress and errors are visible.
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/hyoka/internal/skills/fetcher_test.go
+++ b/hyoka/internal/skills/fetcher_test.go
@@ -195,3 +195,24 @@ func TestResolveLocal_InvalidType(t *testing.T) {
 		t.Fatal("expected error for unknown type")
 	}
 }
+
+func TestParseRepoSpec(t *testing.T) {
+	cases := []struct {
+		in          string
+		wantRepo    string
+		wantSubpath string
+	}{
+		{"microsoft/skills", "microsoft/skills", ""},
+		{"microsoft/skills/.github/plugins/azure-sdk-rust/skills", "microsoft/skills", ".github/plugins/azure-sdk-rust/skills"},
+		{"owner/repo/sub", "owner/repo", "sub"},
+		{"/microsoft/skills/", "microsoft/skills", ""},
+		{"solo", "solo", ""},
+	}
+	for _, tc := range cases {
+		repo, subpath := parseRepoSpec(tc.in)
+		if repo != tc.wantRepo || subpath != tc.wantSubpath {
+			t.Errorf("parseRepoSpec(%q) = (%q, %q), want (%q, %q)",
+				tc.in, repo, subpath, tc.wantRepo, tc.wantSubpath)
+		}
+	}
+}


### PR DESCRIPTION
## What this demonstrates

Adds `examples/configs/example-remote-skill.yaml` — a minimal, runnable config that pulls a skill from a remote GitHub repo instead of a local directory.

The remote-skill pattern lives in the generator's `tools:` block:

```yaml
- name: copilot-sdk
  type: skill
  source: remote
  repo: microsoft/skills
```

On first use (including `--dry-run`), hyoka calls `npx -y skills add microsoft/skills` via `internal/skills/fetcher.go::fetchRemote` and caches the skill under `.skills-cache/microsoft/skills/copilot-sdk/`.

The `copilot-sdk` skill was picked because hyoka is itself built on the Copilot SDK — a natural domain fit.

## Proof it works — dry-run

```bash
go run ./hyoka run \
  --config-file examples/configs/example-remote-skill.yaml \
  --config example-remote-skill/claude-sonnet-4.5 \
  --prompt-id identity-dp-python-default-credential \
  --dry-run --log-level debug
```

Output excerpt (the remote fetch path is exercised):

```
🔍 DRY RUN MODE — No evaluations will be executed

📊 Evaluation plan: 1 evaluations (1 prompts × 1 configs)

Fetching remote skill: copilot-sdk (repo: microsoft/skills)
level=INFO msg="Fetching remote skill" skill=copilot-sdk repo=microsoft/skills

┌ skills
◇ Source: https://github.com/microsoft/skills.git
◇ Repository cloned
◇ Found 11 skills
   Config "example-remote-skill/claude-sonnet-4.5": 1 generator dir(s) searched, 0 skill(s) found

Run Summary:
  Run ID:      dry-run
  Evaluations: 1
```

Exit code: 0.

## Caveats

1. **Dry-run validates skill resolution (including the remote fetch path) but does NOT verify the Copilot session actually loads or activates the skill.** That requires a real eval run against the Copilot SDK.

2. **Interactive `skills add` prompt.** `npx skills add <repo> --name <name>` still shows an interactive "Select skills to install" prompt when run non-TTY, so the 0-skills-resolved line above is expected in the current fetcher. The repo is cloned and the fetch path exercised — the skill directory itself is empty because no selection was made. Fixing this (passing `--yes` / a non-interactive install) is out of scope for this PR; tracking separately if needed.

3. **Config lives under `examples/configs/`**, so it's not picked up by the default `configs/` loader. Invoke it with `--config-file examples/configs/example-remote-skill.yaml` — the config header documents this.

## Requirements

- `npx` on PATH (Node.js). The `skills` CLI is fetched via `npx -y`.

## Files

- `examples/configs/example-remote-skill.yaml` — new
- `.gitignore` — adds `.skills-cache/` (cache populated by remote fetcher)
