### PR TITLE
docs: CHANGELOG for Phase 3.5 + Wave 1

### DIFF
--- a/.squad/agents/oracle/history.md
+++ b/.squad/agents/oracle/history.md
@@ -125,3 +125,41 @@ Audited and fixed all outdated commands in README.md. Many examples failed becau
 
 **Pattern for docs audits:** Always test commands in a live environment (worktree or main checkout). Use `--dry-run` for expensive operations. Cross-reference AGENTS.md for authoritative command syntax.
 
+### Session 2026-04-17T01:15 (Phase 3.5 + Wave 1 CHANGELOG & Drift Sweep)
+
+**Status:** COMPLETE  
+**PR:** #576
+
+CHANGELOG.md created and populated with 6 merged PRs from Phase 3.5 + Wave 1:
+
+**Added entries:**
+- PR #562: Unified grading architecture (AI review is now a grader type, structured JSON responses, deterministic voting)
+- PR #567: Starter-aware MaxOutputSize guardrails (only count delta output, not starter files)
+- PR #568: Examples updated for Phase 3 unified grading
+- PR #570: Site rebranding from Azure SDK code-gen to general-purpose AI agent evaluation
+- PR #571: WorkspaceDelta feature (file-level tracking) + eval detail page rendering
+- PR #572: GraderResultRow component + eval detail redesign
+
+**Drift fixes:**
+- README.md: Rebranded intro from "Azure SDK code" to "comprehensive evaluation tool for AI agents"
+- README.md: Updated `review/` package comment from "Multi-model review panel + rubric" → "Multi-model review (PromptReviewGrader)"
+- README.md: Updated guardrails table to reflect starter-aware counting (MaxOutputSize counts deltas only)
+- AGENTS.md: Same branding refresh (removed "Azure SDK code" reference)
+- AGENTS.md: Same `review/` package comment update
+
+**Drift patterns found:**
+1. **Branding lag** — README and AGENTS still referenced "Azure SDK code generation" despite site rebrand (PR #570). Fixed by rewriting overview sections.
+2. **Architecture comment drift** — `review/` package comment mentioned "rubric" (pre-Phase-3) instead of unified grader pattern. Fixed.
+3. **Guardrails documentation lag** — guardrails table didn't mention starter-aware calculation (PR #567 hotfix). Added clarification that MaxOutputSize/MaxFiles count deltas only.
+
+**Files most out-of-sync:**
+1. README.md (line 3) — branding + line 87 guardrails table
+2. AGENTS.md (line 5, 31) — branding + architecture comment
+3. CHANGELOG.md — didn't exist yet (created from scratch)
+
+**Watch for next wave:**
+- PR bodies should guide CHANGELOG entries (most accurate)
+- Site rebrands need systematic README/AGENTS refresh
+- Architecture package comments need updates when grader types change
+- Guardrails documentation needs to stay current with limit-calculation logic changes
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-hyoka is a Go CLI tool that evaluates AI agents generating Azure SDK code. It uses GitHub Copilot sessions to generate code from prompts, then runs a multi-model review panel to score the output.
+hyoka is a Go CLI tool that evaluates AI agents generating code. It uses GitHub Copilot sessions to generate code from prompts, then runs a multi-model review panel to score the output using extensible graders.
 
 ## Repository Structure
 
@@ -28,7 +28,7 @@ hyoka/              # Go source (module: github.com/ronniegeraghty/hyoka)
     prompt/         # Prompt loading, filtering, validation
     rerender/       # Report re-rendering from JSON
     report/         # Report generation (JSON, HTML, Markdown)
-    review/         # Multi-model review panel + rubric
+    review/         # Multi-model review (PromptReviewGrader)
     serve/          # Local web server for report browsing (#20)
     skills/         # Skill fetching (local + remote)
     tools/          # Tool-related utilities and registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to hyoka are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **WorkspaceDelta field in EvalReport JSON** — captures file-level changes (created, modified, deleted) per evaluation run, enabling graders and dashboards to reason about what the agent actually changed
+- **Eval Detail page workspace delta display** — reports now render file-level changes (created/modified/deleted) when available
+- **GraderResultRow component** — new reusable TypeScript component for rendering individual grader results with pass/fail badges, scores, and expandable details; standardizes grader display across report views
+- **Starter-aware MaxOutputSize and MaxFiles guardrails** — guardrails now correctly account for workspace state, only charging the agent for delta output (new files or modifications), not starter-project files copied in before generation
+
+### Changed
+
+- **Site rebranded** — from Azure SDK code-generation evaluation to general-purpose AI agent evaluation platform
+- **Example configs migrated** — `examples/configs/example-full.yaml` now reflects Phase 3 unified grading architecture (single results list, no separate review block)
+- **Homepage, features, and documentation** — rewritten to describe general-purpose AI agent evaluation rather than Azure SDK code generation
+- **Eval detail page** — refactored to render `grader_results` table instead of legacy rubric badges; includes graceful backward compatibility notice for pre-Phase-3 reports
+- **TypeScript type alignment** — `GraderResult` types now match Go struct definitions, ensuring all grader detail types are properly represented in reports
+
+### Fixed
+
+- **False-positive MaxOutputSize failures on large starter projects** — large starter codebases no longer incorrectly trigger guardrail failures when copied into workspace before generation
+- **Silent zero-render bug from Go↔TypeScript field drift** — Phase 3 unified grading now properly serialized to reports; eval detail page gracefully handles legacy reports with missing grader_results field
+
+## [0.3.1] — Phase 3: Advanced Core & CLI Polish
+
+### Added
+
+- **Unified grading architecture** — AI review is now a standard `PromptReviewGrader` implementing the `Grader` interface; no more separate review phase
+- **Structured JSON reviewer responses** — reviewers return validated JSON with per-criterion judgments and deterministic voting (any-fail across models = criterion fails)
+- **Remote MCP server support** — `mcp_type: remote` with URL field for connecting to MCP servers over HTTP
+- **Workspace containment hardening** — expanded PreToolUse validation, bash command containment, all file tools checked
+- **Real-time guardrail enforcement** — turn/file limits enforced during session, not just post-hoc
+- **Report tool usage tracking** — reports compare available vs. used tools per evaluation
+- **Progress redesign** — section-based per-eval layout for clearer output
+- **File exclusion unification** — single configurable system across all file operations
+- **Prompt package updates** — removed flat format compatibility, added heading-aware splitter
+
+### Changed
+
+- **Results overwrite bug fixed** — all grader types contribute to single results list
+- **Help text audit** — fixed stale references, split filter/run flags for clarity
+- **Docs audit & cleanup** — updated all documentation, removed stale content
+
+### Removed
+
+- **Snapshot hack** — workspace snapshot logic cleaned up in favor of containment validation
+
+---
+
+## Legend
+
+- **Added:** new features and capabilities
+- **Changed:** changes to existing functionality
+- **Deprecated:** soon-to-be-removed functionality
+- **Removed:** removed functionality
+- **Fixed:** bug fixes
+- **Security:** security-related changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hyoka
 
-A curated library of prompts for evaluating how well AI agents generate Azure SDK code, paired with a Go evaluation tool (`hyoka`) that runs prompts through the Copilot SDK, reviews code via a multi-model panel, and produces criteria-based pass/fail reports.
+A comprehensive evaluation tool for AI agents generating code. hyoka runs prompts through the GitHub Copilot SDK, scores generated code against extensible grader criteria (builder, complexity, prompt adherence, behavior, and AI review), and produces detailed pass/fail reports with workspace delta tracking.
 
 ## Quick Start
 
@@ -83,8 +83,8 @@ Every code-generation session is automatically aborted if it exceeds any of thes
 | Limit | Default | Flag | Purpose |
 |-------|---------|------|---------|
 | Session actions | 50 | `--max-session-actions` | Limits reasoning, response, and tool call actions per session |
-| File count | 50 | `--max-files` | Prevents excessive file creation |
-| Output size | 1 MB | `--max-output-size` | Prevents oversized outputs (supports KB, MB suffixes) |
+| File count | 50 | `--max-files` | Prevents excessive file creation (counts new files + deleted starters, ignores starter files) |
+| Output size | 1 MB | `--max-output-size` | Prevents oversized outputs (counts only deltas: new files or modifications to starters; supports KB, MB suffixes) |
 
 Prompts can override these defaults via frontmatter fields (`max_session_actions`, `max_turns`). The resolution order is: prompt frontmatter > config YAML > CLI flag > engine default.
 
@@ -482,7 +482,7 @@ hyoka/
 │       ├── prompt/                    # Prompt loading, filtering, validation
 │       ├── rerender/                  # Report re-rendering from JSON
 │       ├── report/                    # Report generation (JSON, HTML, Markdown)
-│       ├── review/                    # Multi-model review panel + rubric
+│       ├── review/                    # Multi-model review (PromptReviewGrader)
 │       ├── serve/                     # Local web server for report browsing
 │       ├── skills/                    # Skill fetching (local + remote)
 │       ├── trends/                    # Cross-run trend analysis


### PR DESCRIPTION
Captures WorkspaceDelta (#571), eval detail page redesign (#572), Phase 3 examples update (#568), site branding rewrite (#570), and starter-aware MaxOutputSize guardrail hotfix (#567).

Includes README/AGENTS.md drift fixes rebranding from Azure SDK code generation to general-purpose AI agent evaluation platform.