### PR TITLE
feat(#361): serve file cache + pairwise endpoint + security docs

### DIFF
--- a/hyoka/internal/serve/cache.go
+++ b/hyoka/internal/serve/cache.go
@@ -1,0 +1,79 @@
+package serve
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// fileCache is an in-memory cache for JSON report files keyed by absolute
+// path. Entries are invalidated when the file's on-disk modification time
+// or size changes, so writers (a new eval run landing on disk) transparently
+// bust the cache without any explicit invalidation.
+//
+// The cache is safe for concurrent use by multiple HTTP handlers.
+type fileCache struct {
+	mu    sync.RWMutex
+	items map[string]cacheEntry
+}
+
+// cacheEntry holds the cached payload plus the file stat fingerprint that
+// was valid when the entry was populated.
+type cacheEntry struct {
+	mtime time.Time
+	size  int64
+	data  []byte
+}
+
+func newFileCache() *fileCache {
+	return &fileCache{items: make(map[string]cacheEntry)}
+}
+
+// ReadFile returns the contents of path, serving from cache when the file's
+// mtime and size match the cached fingerprint. On a miss or stale entry it
+// re-reads from disk and updates the cache.
+//
+// Any I/O error is returned to the caller; the cache entry is evicted so the
+// next call will re-attempt the read rather than serve stale bytes.
+func (c *fileCache) ReadFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		c.invalidate(path)
+		return nil, err
+	}
+
+	mtime := info.ModTime()
+	size := info.Size()
+
+	c.mu.RLock()
+	entry, ok := c.items[path]
+	c.mu.RUnlock()
+	if ok && entry.mtime.Equal(mtime) && entry.size == size {
+		return entry.data, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		c.invalidate(path)
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.items[path] = cacheEntry{mtime: mtime, size: size, data: data}
+	c.mu.Unlock()
+	return data, nil
+}
+
+// invalidate removes a single entry. Safe to call for paths that aren't cached.
+func (c *fileCache) invalidate(path string) {
+	c.mu.Lock()
+	delete(c.items, path)
+	c.mu.Unlock()
+}
+
+// len returns the number of cached entries. Intended for tests.
+func (c *fileCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}

--- a/hyoka/internal/serve/cache_test.go
+++ b/hyoka/internal/serve/cache_test.go
@@ -1,0 +1,140 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFileCache_ReadThenCacheHit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := newFileCache()
+	first, err := c.ReadFile(path)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if string(first) != `{"a":1}` {
+		t.Fatalf("unexpected bytes: %s", first)
+	}
+	if c.len() != 1 {
+		t.Fatalf("expected 1 cache entry, got %d", c.len())
+	}
+
+	// Delete the underlying file — a cache hit should still succeed.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// Re-create with identical content AND restore the original mtime so the
+	// cache fingerprint still matches. If mtime differs, the cache busts — which
+	// is correct, but not what this test covers (see TestFileCache_MtimeChange).
+	c.mu.RLock()
+	entry := c.items[path]
+	c.mu.RUnlock()
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if err := os.Chtimes(path, entry.mtime, entry.mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	second, err := c.ReadFile(path)
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	if string(second) != `{"a":1}` {
+		t.Fatalf("unexpected bytes on hit: %s", second)
+	}
+}
+
+func TestFileCache_MtimeChangeBustsCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(path, []byte(`{"v":1}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := newFileCache()
+	if _, err := c.ReadFile(path); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+
+	// Rewrite with new content and forced newer mtime.
+	if err := os.WriteFile(path, []byte(`{"v":2}`), 0644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	data, err := c.ReadFile(path)
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	if string(data) != `{"v":2}` {
+		t.Fatalf("expected fresh bytes, got %s", data)
+	}
+}
+
+func TestFileCache_MissingFileEvictsEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := newFileCache()
+	if _, err := c.ReadFile(path); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if c.len() != 1 {
+		t.Fatalf("expected cache populated")
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := c.ReadFile(path); err == nil {
+		t.Fatalf("expected error after file removed")
+	}
+	if c.len() != 0 {
+		t.Fatalf("expected cache evicted on error, got %d entries", c.len())
+	}
+}
+
+func TestFileCache_ConcurrentReaders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	payload := []byte(`{"hello":"world"}`)
+	if err := os.WriteFile(path, payload, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := newFileCache()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				data, err := c.ReadFile(path)
+				if err != nil {
+					t.Errorf("read: %v", err)
+					return
+				}
+				if string(data) != string(payload) {
+					t.Errorf("unexpected bytes: %s", data)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/hyoka/internal/serve/dashboard.go
+++ b/hyoka/internal/serve/dashboard.go
@@ -19,7 +19,10 @@ import (
 )
 
 // registerDashboardRoutes adds dashboard-specific API routes to the mux.
-func registerDashboardRoutes(mux *http.ServeMux, opts Options) {
+// Comparison and trend handlers operate on aggregated data that we don't
+// currently cache — they walk entire run directories — so cache wiring is
+// limited to the per-run report loaders.
+func registerDashboardRoutes(mux *http.ServeMux, opts Options, cache *fileCache) {
 	mux.HandleFunc("/api/compare/configs", func(w http.ResponseWriter, r *http.Request) {
 		handleAPICompareConfigs(w, r, opts.ReportsDir)
 	})
@@ -32,10 +35,11 @@ func registerDashboardRoutes(mux *http.ServeMux, opts Options) {
 	mux.HandleFunc("/api/trends", func(w http.ResponseWriter, r *http.Request) {
 		handleAPITrends(w, r, opts.ReportsDir)
 	})
+	_ = cache // reserved for future per-report caching in dashboard endpoints
 }
 
-func handleAPIGraders(w http.ResponseWriter, _ *http.Request, reportsDir, runID string) {
-	evals, err := loadRunEvals(reportsDir, runID)
+func handleAPIGraders(w http.ResponseWriter, _ *http.Request, reportsDir, runID string, cache *fileCache) {
+	evals, err := loadRunEvals(reportsDir, runID, cache)
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -56,8 +60,8 @@ func handleAPIGraders(w http.ResponseWriter, _ *http.Request, reportsDir, runID 
 	writeJSON(w, result)
 }
 
-func handleAPITimeline(w http.ResponseWriter, _ *http.Request, reportsDir, runID string) {
-	evals, err := loadRunEvals(reportsDir, runID)
+func handleAPITimeline(w http.ResponseWriter, _ *http.Request, reportsDir, runID string, cache *fileCache) {
+	evals, err := loadRunEvals(reportsDir, runID, cache)
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -82,8 +86,8 @@ func handleAPITimeline(w http.ResponseWriter, _ *http.Request, reportsDir, runID
 	writeJSON(w, result)
 }
 
-func handleAPIScoreBreakdown(w http.ResponseWriter, _ *http.Request, reportsDir, runID string) {
-	evals, err := loadRunEvals(reportsDir, runID)
+func handleAPIScoreBreakdown(w http.ResponseWriter, _ *http.Request, reportsDir, runID string, cache *fileCache) {
+	evals, err := loadRunEvals(reportsDir, runID, cache)
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -282,7 +286,11 @@ func handleAPIPromptHistory(w http.ResponseWriter, r *http.Request, reportsDir s
 	writeJSON(w, tr)
 }
 
-func loadRunEvals(reportsDir, runID string) ([]*report.EvalReport, error) {
+// loadRunEvals walks a run directory and returns parsed EvalReport values for
+// every report.json it finds. Report bytes are served through the cache so
+// repeated requests for the same run (graders, timeline, score-breakdown all
+// call this) are a memory hit after the first read.
+func loadRunEvals(reportsDir, runID string, cache *fileCache) ([]*report.EvalReport, error) {
 	runDir := filepath.Join(reportsDir, runID)
 	if _, err := os.Stat(runDir); err != nil {
 		return nil, err
@@ -295,7 +303,7 @@ func loadRunEvals(reportsDir, runID string) ([]*report.EvalReport, error) {
 		if info.IsDir() || info.Name() != "report.json" {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
+		data, readErr := cache.ReadFile(path)
 		if readErr != nil {
 			return nil
 		}

--- a/hyoka/internal/serve/dashboard_test.go
+++ b/hyoka/internal/serve/dashboard_test.go
@@ -448,3 +448,64 @@ if rec.Code != http.StatusNotFound {
 t.Errorf("expected 404, got %d", rec.Code)
 }
 }
+
+func TestAPIPairwise(t *testing.T) {
+dir := setupTestReportsWithEvals(t)
+runID := "20260327-113302"
+
+// Seed pairwise.json so the endpoint has something to serve.
+pairwisePayload := map[string]any{
+"run_id":    runID,
+"timestamp": "2026-03-27T18:33:02Z",
+"reports": []map[string]any{
+{
+"prompt_id": "test-prompt-one",
+"baseline": map[string]any{
+"config_name": "baseline/claude-opus-4.6",
+"score":       0.85,
+"max_score":   1.0,
+"success":     true,
+},
+"variants": []any{},
+"impacts":  []any{},
+},
+},
+"aggregate_impacts": []any{},
+}
+data, _ := json.Marshal(pairwisePayload)
+if err := os.WriteFile(filepath.Join(dir, runID, "pairwise.json"), data, 0644); err != nil {
+t.Fatalf("seed pairwise.json: %v", err)
+}
+
+mux := buildMux(Options{ReportsDir: dir})
+req := httptest.NewRequest("GET", "/api/runs/"+runID+"/pairwise", nil)
+rec := httptest.NewRecorder()
+mux.ServeHTTP(rec, req)
+
+if rec.Code != http.StatusOK {
+t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+}
+if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+t.Errorf("expected JSON content type, got %q", ct)
+}
+var got map[string]any
+if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+t.Fatalf("decode: %v", err)
+}
+if got["run_id"] != runID {
+t.Errorf("expected run_id=%s, got %v", runID, got["run_id"])
+}
+}
+
+func TestAPIPairwiseMissing(t *testing.T) {
+dir := setupTestReportsWithEvals(t)
+mux := buildMux(Options{ReportsDir: dir})
+
+// No pairwise.json in this run → 404.
+req := httptest.NewRequest("GET", "/api/runs/20260327-113302/pairwise", nil)
+rec := httptest.NewRecorder()
+mux.ServeHTTP(rec, req)
+if rec.Code != http.StatusNotFound {
+t.Errorf("expected 404 for run without pairwise.json, got %d", rec.Code)
+}
+}

--- a/hyoka/internal/serve/serve.go
+++ b/hyoka/internal/serve/serve.go
@@ -1,4 +1,33 @@
 // Package serve provides a local web server for browsing evaluation reports.
+//
+// # Security
+//
+// The serve command is designed for local, single-user inspection of
+// evaluation reports. It has no authentication, no authorization, and no
+// rate limiting. The default listener binds to all interfaces on the chosen
+// port (e.g. 0.0.0.0:8080), which means anyone who can reach the host on
+// that port can:
+//
+//   - Read every evaluation report, prompt, and doc the server is configured
+//     to expose, including prompt text, generated source, and model output.
+//   - Enumerate run IDs and download raw JSON via /api/runs and /reports/.
+//   - Access the embedded SPA without any credential.
+//
+// CORS is intentionally permissive (Access-Control-Allow-Origin: *) so the
+// dev-mode Vite server can hit the API; this is safe for localhost use but
+// should NOT be exposed on a shared network.
+//
+// Operator guidance for shared machines:
+//
+//   - Prefer binding to 127.0.0.1 via a reverse proxy or SSH tunnel rather
+//     than exposing the port directly.
+//   - Treat the reports directory as sensitive: it may contain prompt text,
+//     generated code, and evaluation output that reveal internal grading
+//     rubrics or proprietary prompts.
+//   - Do not run `hyoka serve` on an untrusted network without first placing
+//     an authenticating proxy (nginx, caddy) in front of it.
+//
+// These expectations are also printed as a banner at startup.
 package serve
 
 import (
@@ -87,21 +116,31 @@ func Start(opts Options) error {
 	if opts.PromptsDir != "" {
 		fmt.Printf("   Prompts directory: %s\n", opts.PromptsDir)
 	}
+	fmt.Printf("\n")
+	fmt.Printf("   ⚠  No authentication. Reports are readable by anyone who\n")
+	fmt.Printf("      can reach this port. Do not expose on untrusted networks —\n")
+	fmt.Printf("      use an SSH tunnel or authenticating reverse proxy instead.\n")
+	fmt.Printf("\n")
 	fmt.Printf("   Press Ctrl+C to stop\n\n")
 
 	return http.Serve(listener, corsMiddleware(mux))
 }
 
 // buildMux creates the HTTP handler with all routes.
+//
+// Each call constructs a dedicated in-memory file cache (see cache.go). The
+// cache is scoped to the returned mux so tests and concurrent Start calls
+// don't share state.
 func buildMux(opts Options) *http.ServeMux {
 	mux := http.NewServeMux()
+	cache := newFileCache()
 
 	// --- API: runs ---
 	mux.HandleFunc("/api/runs", func(w http.ResponseWriter, r *http.Request) {
-		handleAPIRuns(w, r, opts.ReportsDir)
+		handleAPIRuns(w, r, opts.ReportsDir, cache)
 	})
 	mux.HandleFunc("/api/runs/", func(w http.ResponseWriter, r *http.Request) {
-		handleAPIRunDetail(w, r, opts.ReportsDir)
+		handleAPIRunDetail(w, r, opts.ReportsDir, cache)
 	})
 
 	// --- API: docs ---
@@ -126,7 +165,7 @@ func buildMux(opts Options) *http.ServeMux {
 	})
 
 	// --- Dashboard routes (comparison, trends, drill-down) ---
-	registerDashboardRoutes(mux, opts)
+	registerDashboardRoutes(mux, opts, cache)
 
 	// --- Static file serving for raw report files ---
 	reportFS := http.FileServer(http.Dir(opts.ReportsDir))
@@ -154,8 +193,8 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 // --- Runs API handlers ---
 
-func handleAPIRuns(w http.ResponseWriter, _ *http.Request, reportsDir string) {
-	runs, err := listRunSummaries(reportsDir)
+func handleAPIRuns(w http.ResponseWriter, _ *http.Request, reportsDir string, cache *fileCache) {
+	runs, err := listRunSummaries(reportsDir, cache)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -163,7 +202,7 @@ func handleAPIRuns(w http.ResponseWriter, _ *http.Request, reportsDir string) {
 	writeJSON(w, runs)
 }
 
-func handleAPIRunDetail(w http.ResponseWriter, r *http.Request, reportsDir string) {
+func handleAPIRunDetail(w http.ResponseWriter, r *http.Request, reportsDir string, cache *fileCache) {
 	// Route: /api/runs/{runId} or /api/runs/{runId}/eval?path=...
 	rest := strings.TrimPrefix(r.URL.Path, "/api/runs/")
 	if rest == "" {
@@ -184,50 +223,43 @@ func handleAPIRunDetail(w http.ResponseWriter, r *http.Request, reportsDir strin
 	if len(parts) == 2 {
 		switch parts[1] {
 		case "eval":
-			handleAPIEval(w, r, reportsDir, runID)
+			handleAPIEval(w, r, reportsDir, runID, cache)
 		case "graders":
-			handleAPIGraders(w, r, reportsDir, runID)
+			handleAPIGraders(w, r, reportsDir, runID, cache)
 		case "timeline":
-			handleAPITimeline(w, r, reportsDir, runID)
+			handleAPITimeline(w, r, reportsDir, runID, cache)
 		case "score-breakdown":
-			handleAPIScoreBreakdown(w, r, reportsDir, runID)
+			handleAPIScoreBreakdown(w, r, reportsDir, runID, cache)
 		case "comparisons":
 			handleAPIRunComparisons(w, r, reportsDir, runID)
+		case "pairwise":
+			handleAPIPairwise(w, r, reportsDir, runID, cache)
 		default:
 			http.NotFound(w, r)
 		}
 		return
 	}
 
-	// /api/runs/{runId}/graders
-	if len(parts) == 2 && parts[1] == "graders" {
-		handleAPIGraders(w, r, reportsDir, runID)
-		return
-	}
-
-	// /api/runs/{runId}/timeline
-	if len(parts) == 2 && parts[1] == "timeline" {
-		handleAPITimeline(w, r, reportsDir, runID)
-		return
-	}
-
-	// /api/runs/{runId}/score-breakdown
-	if len(parts) == 2 && parts[1] == "score-breakdown" {
-		handleAPIScoreBreakdown(w, r, reportsDir, runID)
-		return
-	}
-
 	// /api/runs/{runId} — return full summary.json
 	if len(parts) == 1 {
 		summaryPath := filepath.Join(reportsDir, runID, "summary.json")
-		serveJSONFile(w, r, summaryPath)
+		serveJSONFile(w, r, summaryPath, cache)
 		return
 	}
 
 	http.NotFound(w, r)
 }
 
-func handleAPIEval(w http.ResponseWriter, r *http.Request, reportsDir, runID string) {
+// handleAPIPairwise returns the pairwise.json contents for a run, or 404 if
+// the run has no pairwise analysis. This makes pairwise results a first-class
+// part of the run detail API rather than requiring the site to fish them out
+// of summary.json (#360 R140).
+func handleAPIPairwise(w http.ResponseWriter, r *http.Request, reportsDir, runID string, cache *fileCache) {
+	pairwisePath := filepath.Join(reportsDir, runID, "pairwise.json")
+	serveJSONFile(w, r, pairwisePath, cache)
+}
+
+func handleAPIEval(w http.ResponseWriter, r *http.Request, reportsDir, runID string, cache *fileCache) {
 	relPath := r.URL.Query().Get("path")
 	if relPath == "" {
 		http.Error(w, `missing "path" query parameter`, http.StatusBadRequest)
@@ -242,7 +274,7 @@ func handleAPIEval(w http.ResponseWriter, r *http.Request, reportsDir, runID str
 	}
 
 	fullPath := filepath.Join(reportsDir, runID, cleaned)
-	serveJSONFile(w, r, fullPath)
+	serveJSONFile(w, r, fullPath, cache)
 }
 
 // --- Docs API handlers ---
@@ -380,8 +412,10 @@ func spaHandler(siteDir string) http.HandlerFunc {
 
 // --- Data helpers ---
 
-// listRunSummaries reads run directories and returns their full summary.json content.
-func listRunSummaries(reportsDir string) ([]json.RawMessage, error) {
+// listRunSummaries reads run directories and returns their full summary.json
+// content. Summaries are served through the file cache so repeated list
+// requests don't re-read unchanged summary.json files from disk.
+func listRunSummaries(reportsDir string, cache *fileCache) ([]json.RawMessage, error) {
 	entries, err := os.ReadDir(reportsDir)
 	if err != nil {
 		return nil, fmt.Errorf("reading reports dir: %w", err)
@@ -399,7 +433,7 @@ func listRunSummaries(reportsDir string) ([]json.RawMessage, error) {
 		}
 
 		summaryPath := filepath.Join(reportsDir, e.Name(), "summary.json")
-		data, err := os.ReadFile(summaryPath)
+		data, err := cache.ReadFile(summaryPath)
 		if err != nil {
 			// Include a minimal entry for runs without summary.json
 			minimal, _ := json.Marshal(map[string]string{"run_id": e.Name()})
@@ -474,8 +508,12 @@ func writeJSON(w http.ResponseWriter, v any) {
 	}
 }
 
-func serveJSONFile(w http.ResponseWriter, _ *http.Request, path string) {
-	data, err := os.ReadFile(path)
+// serveJSONFile reads the named JSON file through the cache and writes it to
+// the response, or responds 404 on any read error. Using the cache makes
+// repeated reads of unchanged report files (summary.json, report.json, etc.)
+// a memory hit rather than a disk + JSON re-parse round-trip.
+func serveJSONFile(w http.ResponseWriter, _ *http.Request, path string, cache *fileCache) {
+	data, err := cache.ReadFile(path)
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/hyoka/internal/serve/serve_test.go
+++ b/hyoka/internal/serve/serve_test.go
@@ -69,7 +69,7 @@ func setupTestSite(t *testing.T) string {
 
 func TestListRunSummaries(t *testing.T) {
 	dir := setupTestReports(t)
-	runs, err := listRunSummaries(dir)
+	runs, err := listRunSummaries(dir, newFileCache())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestListRunSummaries(t *testing.T) {
 
 func TestListRunSummariesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	runs, err := listRunSummaries(dir)
+	runs, err := listRunSummaries(dir, newFileCache())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/site/src/__tests__/api.test.ts
+++ b/site/src/__tests__/api.test.ts
@@ -8,6 +8,7 @@ import {
   fetchPrompts,
   fetchPrompt,
   fetchCompareConfigs,
+  fetchPairwise,
 } from "../app/data/api";
 
 describe("API module", () => {
@@ -123,5 +124,29 @@ describe("API module", () => {
   it("fetchCompareConfigs throws on server error", async () => {
     mockFetchError(404, "Not Found");
     await expect(fetchCompareConfigs("a", "b")).rejects.toThrow("API error 404: Not Found");
+  });
+
+  // ── fetchPairwise ──────────────────────────────────────────────────
+
+  it("fetchPairwise calls the correct endpoint", async () => {
+    mockFetchOk({ run_id: "run-1", timestamp: "t", reports: [] });
+    const result = await fetchPairwise("run-1");
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/runs/run-1/pairwise");
+    expect(result).toEqual({ run_id: "run-1", timestamp: "t", reports: [] });
+  });
+
+  it("fetchPairwise returns null on 404 (run has no pairwise data)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    } as Response);
+    const result = await fetchPairwise("run-without-pairwise");
+    expect(result).toBeNull();
+  });
+
+  it("fetchPairwise throws on non-404 server errors", async () => {
+    mockFetchError(500, "Internal Server Error");
+    await expect(fetchPairwise("run-1")).rejects.toThrow("API error 500: Internal Server Error");
   });
 });

--- a/site/src/app/data/api.ts
+++ b/site/src/app/data/api.ts
@@ -1,4 +1,4 @@
-import type { RunSummary, EvalReport, DocEntry, DocDetail } from "./types";
+import type { RunSummary, EvalReport, DocEntry, DocDetail, PairwiseRunReport } from "./types";
 import type { ComparisonResult } from "./types";
 
 const API_BASE = "";
@@ -63,4 +63,18 @@ export async function fetchCompareConfigs(configA: string, configB: string): Pro
   return fetchJSON<ComparisonResult>(
     `/api/compare/configs?a=${encodeURIComponent(configA)}&b=${encodeURIComponent(configB)}`
   );
+}
+
+/**
+ * Fetch pairwise tool-ablation results for a run. Returns `null` if the run
+ * has no pairwise data (404 from the API), so callers can render an empty
+ * state without a try/catch.
+ */
+export async function fetchPairwise(runId: string): Promise<PairwiseRunReport | null> {
+  const res = await fetch(`/api/runs/${encodeURIComponent(runId)}/pairwise`);
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`API error ${res.status}: ${res.statusText}`);
+  }
+  return res.json();
 }

--- a/site/src/app/data/types.ts
+++ b/site/src/app/data/types.ts
@@ -223,6 +223,16 @@ export interface PairwiseReport {
   impacts: ToolImpact[];
 }
 
+// Mirrors hyoka/internal/report.PairwiseRunReport — the payload returned by
+// GET /api/runs/{runId}/pairwise. `aggregate_impacts` is optional because
+// runs without any togglable tools produce no aggregate entries.
+export interface PairwiseRunReport {
+  run_id: string;
+  timestamp: string;
+  reports: PairwiseReport[];
+  aggregate_impacts?: ToolImpact[];
+}
+
 export interface RunSummary {
   run_id: string;
   timestamp: string;


### PR DESCRIPTION
Closes #361.

## What

1. **In-memory file cache** (`hyoka/internal/serve/cache.go`) backs all per-run JSON reads. Keyed by absolute path, fingerprinted by (mtime, size). A cache hit serves straight from memory; any mtime or size change transparently busts the entry. Errors evict stale entries so failed reads never poison the cache.
2. **`GET /api/runs/{runID}/pairwise`** endpoint — serves `pairwise.json` or 404, matching the rest of the sub-resource API. Supports #360 R140 ("integrate pairwise into standard reports"). Site gets `fetchPairwise(runId)` helper + `PairwiseRunReport` type mirroring the Go struct.
3. **Security documentation** — expanded package doc block on threat model (no auth, permissive CORS, exposes prompt text + generated source). Startup banner prints the no-auth warning.

## Caching wiring

- `serveJSONFile` — summary.json, report.json, pairwise.json
- `listRunSummaries` — repeated list requests no longer re-read every summary.json
- `loadRunEvals` — graders/timeline/score-breakdown endpoints share parsed report.json bytes

Cache is scoped per `buildMux` call so tests and concurrent Start calls don't share state. `sync.RWMutex` guards the map.

## Test coverage

- Cache hit, mtime bust, size change, error-eviction paths
- 50×20 concurrent readers (race detector enforces mutex discipline)
- Pairwise endpoint happy path + 404-when-missing
- Updated existing test call sites to pass the cache

## Verification

- ✅ `go test -race ./hyoka/...` all packages green
- ✅ `npm --prefix site test` — 56 passing (was 53; +3 for fetchPairwise)
- ✅ `npm --prefix site run build` — clean build
- ✅ `grep "as unknown as" site/src/app/data/{api,types}.ts` — zero casts

## Guardrails followed

- Go JSON tags drive TS field names: `PairwiseRunReport` → `run_id`, `timestamp`, `reports`, `aggregate_impacts` — verbatim match
- No new TS types coined beyond the Go source of truth
- No `as unknown as` casts