### PR TITLE
feat(#360): pairwise methodology + tool usage chart + run-detail cross-link

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -84,3 +84,21 @@ Critical drift: `workspace_delta` TS field names (`files_created`, `files_modifi
 - Two `GraderResult` types exist in Go: `graders.GraderResult` (internal, uses `Kind`/`Name`/`Score`/`Pass`/`Message`) and `report.GraderResult` (serialized, uses `GraderName`/`GraderType`/`OverallScore`/`Summary`). TS must match the *report* version since that's what JSON contains.
 - `EvalResult` (lean summary) vs `EvalReport` (full detail) type split in TS is causing widespread `as unknown as Record<string, unknown>` casting. Must resolve before #359/#360 or the pattern will compound.
 - `review` field changed from required to optional in #572 — correct for forward compat, but any TS code assuming non-null `review` will break.
+
+### Wave 3 Review — PRs #581, #582, #583 (2026-04-17)
+
+**Verdicts:** #581 APPROVE, #582 APPROVE, #583 REQUEST_CHANGES. Report at `.squad/decisions/morpheus-wave3-review.md`.
+
+**Blocker (#583):** Go→TS drift. `ComparisonResult` renamed `config_a`/`config_b` → `label_a`/`label_b` + added `kind` discriminator, but `site/src/app/data/types.ts:309-314 ConfigComparison` was not updated. `comparison-page.tsx:546,549` will render `undefined` column headers on merge. Confirmed same drift class as Wave 1 (`workspace_delta` fields). **Pattern, not incident** — filing decision to make Go↔TS type sync a PR-level requirement in squad conventions.
+
+**Architectural wins (#583):** `ComparisonResult` + `Kind` discriminator collapses 3 wrapper types. `CompareReports` is the single in-memory primitive; all 4 entry points (CLI, 2 serve endpoints, auto-gen) delegate. `WriteForRun` writes `comparisons.json` alongside `summary.json` — file-adjacent correctly avoids the `comparison→report→comparison` import cycle. `TestAutoGenerateForRun_UsesSameEngine` (inmem_test.go:181) proves shared-core equivalence byte-for-byte.
+
+**Gate item 1 (CLI≡site identical):** Accepted shared-core argument. All 4 surfaces funnel through `CompareReports`. Disk-backed paths differ only in loading, not in comparison logic. Recommended a snapshot test for Switch as belt-and-suspenders, not gate blocker.
+
+**Gate item 2 (#582 proxy chart):** Accepted for 0.3.1. Explicitly labeled as proxy, ground-truth path documented (per-eval `ToolAvailability`). Backend aggregation endpoint filed as 0.3.2/0.4 follow-up.
+
+**Gate item 3 (retain `PromptDeltas`):** Sign-off. Pass-toggle is semantically distinct from score-delta; direct unification creates import cycle. Phase 5 cleanup issue filed.
+
+**Merge conflict detected:** `git merge-tree` confirms #581 ↔ #583 content conflict in `hyoka/internal/serve/serve.go` — both add cases to `handleAPIRunDetail` switch. Recommended merge order: **#583 first → Switch coverage re-run on rewritten `comparison/` pkg → #581 rebased (cache wired into #583's comparisons handler) → #582 (site-only, trivial).**
+
+**Phase 4 go-live: NO-GO** until #583 TS fix + Switch re-run. After that, GO for 0.3.1. Phase 4 complete once consolidation PR `squad/phase-4-remainder → ronniegeraghty/dev` merges green.

--- a/.squad/agents/switch/history.md
+++ b/.squad/agents/switch/history.md
@@ -199,6 +199,28 @@ Reviewed #568 (Oracle — examples update) and #570 (Trinity — site branding):
 - **#568:** `go run . validate` ✅ — 89 prompts valid, 12 configs valid, 25 graders valid
 - **#570:** `npm test` (43 tests pass) + `npm run build` (✅ clean build) — site branding/content changes safe
 
+---
+
+## 2026-04-18 — Phase 4 Wave 3 Review (#581, #582, #583)
+
+**Status:** COMPLETE — review at `.squad/decisions/switch-wave3-review.md`
+**Gate:** Phase 4 criterion #4 (CLI↔site parity) now test-enforced.
+
+**Primary deliverable — CLI↔site equivalence test.** Neo's #583 claimed the gate is "satisfied by construction" via shared `CompareReports`. I codified the claim in `hyoka/internal/serve/equivalence_test.go` (commit `e91997a5` on `squad/357-comparison-unification`):
+- `TestCLISiteEquivalence_AutoGenComparisons` — on-demand path (no `comparisons.json`; API recomputes via `AutoGenerateForRun`).
+- `TestCLISiteEquivalence_LoadedComparisonsFile` — cached path (`WriteForRun` writes, API reads from disk).
+Both `reflect.DeepEqual` on wire-format-roundtripped structs. Passed `-race -count=3`.
+
+**Per-PR verdicts:** #581 LGTM (file cache + pairwise endpoint, 83.7% pkg cov). #582 LGTM w/ notes (239 new lines, zero new FE tests — pairwise-page stmt cov 44.85%). #583 LGTM (total Go cov 64.4%, above 64% baseline).
+
+**Merge order flagged:** #581 and #583 both edit `dashboard.go`/`serve.go`. Recommended order: #582 → #581 → #583 (rebased). One rebase is unavoidable.
+
+**Key learnings:**
+1. "Shared core" claims need tests that compare both paths byte-for-byte. Marshal+unmarshal both sides before DeepEqual so `omitempty` asymmetry is normalized at wire-format level.
+2. `AutoGenerateForRun` returns nil for <2 configs — equivalence test must seed ≥2 configs or silently pass on empty slices. Also assert `len(apiResults) == expected` to catch that.
+3. The earlier "94% site baseline" number was test-count, not statement coverage. Real statement coverage is 66.66%. Future reviews should distinguish.
+4. When two PRs refactor the same handler signatures, the second merger rebases — flag this in the review rather than letting the merge-bot surprise the team.
+
 Both PRs approved with "LGTM ✅" comments.
 
 **NOT IN SCOPE:**

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -71,3 +71,24 @@ Implemented site embedding per Morpheus's architecture proposal. Key decisions a
 ## 2026-04-16 — Phase 3 Merged to Dev (Neo)
 
 Neo completed Phase 3 merge sequence: main→dev (hotfix #567 integrated), dev→Phase3 (clean), Phase3→dev (PR #562 squash-merged). Dev branch now has both Phase 3 features and starter-aware guardrail fix. All tests pass, CI green.
+
+### Session 2026-04-19 (Phase 4 Wave 3 — #360, #361)
+
+**#361 — Serve package caching + pairwise endpoint + security docs (PR #581)**
+
+- **Per-buildMux file cache:** `fileCache` struct scoped to one `buildMux` call (NOT a package-level global). Tests and concurrent `Start()` calls stay isolated. Fingerprint is `(mtime, size)` — any change busts the entry. Errors evict the entry so a failed read can't poison subsequent requests.
+- **Race-tested with 50×20 concurrent readers** under `-race`. RWMutex with upgrade pattern: read-lock for cache lookup, release, re-acquire write-lock to populate.
+- **`loadRunEvals` signature changed** to accept `*fileCache` — ripple updates required in `serve_test.go` (pass `newFileCache()`). Any future caller needs the same update.
+- **Pairwise endpoint pattern:** `GET /api/runs/{id}/pairwise` serves `pairwise.json` directly; returns 404 if missing. `fetchPairwise()` on the frontend special-cases 404 → `null` (as opposed to throwing) so consumers can branch on "no data" without try/catch.
+- **Security docblock expansion:** package comment on `serve.go` now spells out "no auth, bind to localhost or put behind a reverse proxy" explicitly. Startup-time `log.Println("⚠ hyoka serve has no authentication...")` warning makes it impossible to miss.
+
+**#360 — Pairwise page polish**
+
+- **URL sync via useSearchParams:** `?run=<run_id>` deep-links from run-detail. Two-way binding — reading on mount for selection, writing on change via `setSearchParams(..., {replace: true})` so the back button doesn't get polluted.
+- **Tool Usage Frequency chart — proxy signal, clearly labeled:** the ground-truth `tool_availability` field lives on per-eval `EvalReport.ToolAvailability`, NOT aggregated in summary.json. Rather than add a backend aggregation endpoint for this PR, I derived frequency from pairwise impact data already on the page: "used" = impact ≠ 0 OR baseline_pass ≠ without_pass, "available-unused" = in impacts list but no measurable effect, "not available" = tool not in that prompt's impacts. Labeled the chart explicitly as a proxy and pointed at the eval detail page for ground truth. Follow-up issue worth filing if anyone wants the exact invocation counts.
+- **Methodology info box:** collapsible `<button>` + state-driven expansion (not `<details>` — styled consistency with the rest of the design system). Explains baseline vs without-X, impact formula, thresholds, and limitations (always_on / pairwise-off tools don't appear).
+- **Cross-link from run-detail:** amber-accented banner with `<Zap>` icon, shown only when `run.pairwise_results?.length > 0`. Linking via `to={\`/pairwise?run=\${encodeURIComponent(runId)}\`}` — `encodeURIComponent` matters because run IDs can contain slashes depending on the generator.
+
+**Reusable patterns:**
+- For "needs ground truth, but can fake it from existing page data" decisions: ship with the proxy + explicit label + follow-up note, rather than blocking on a new backend endpoint. Keeps PR scope tight.
+- Stacked horizontal bar with percent widths + title attributes (hover tooltip) + inline numeric labels (only when segment > 12%) is a clean, dependency-free alternative to pulling in yet another chart variant from recharts.

--- a/.squad/decisions/morpheus-wave3-review.md
+++ b/.squad/decisions/morpheus-wave3-review.md
@@ -1,0 +1,224 @@
+# Wave 3 Architectural Review — PRs #581 / #582 / #583
+
+**Author:** Morpheus 🕶️
+**Date:** 2026-04-17
+**Base:** `squad/phase-4-remainder`
+**Scope:** Phase 4 final wave — Trinity #361 (serve cache + pairwise endpoint), Trinity #360 (pairwise page polish + proxy chart), Neo #357 (unified ComparisonResult + auto-gen).
+
+---
+
+## TL;DR
+
+| PR | Verdict | Blocker |
+|----|---------|---------|
+| **#581** (#361 serve cache + pairwise) | **APPROVE** | — |
+| **#582** (#360 pairwise polish)        | **APPROVE** | — |
+| **#583** (#357 comparison unification) | **REQUEST_CHANGES** | Go↔TS drift: comparison page will render `undefined` labels after merge. One-file fix. |
+
+**Phase 4 gate: NO-GO as currently stacked.** Flip to GO once #583's TS drift is fixed and Switch re-runs coverage on the rewritten `comparison/` package. ETA to GO: hours, not days.
+
+---
+
+## PR #581 — Trinity #361 serve cache + pairwise endpoint + security docs
+
+**Verdict: APPROVE.**
+
+Clean, scoped, well-tested. Cache design is correct for the workload.
+
+### What's right
+
+- `cache.go:44-61` — `(mtime, size)` fingerprint is the right primitive for a report-dir filesystem. Writers (new eval runs landing on disk) transparently bust entries with zero explicit invalidation. Error path at `cache.go:46-49,57-60` evicts stale entries so a transient failure can't poison subsequent reads. This is the safe design.
+- `cache.go:15` — `sync.RWMutex` with a read-lock for lookups, release, re-acquire write-lock for population. No upgrade races — a concurrent writer just re-does the stat+read, which is idempotent. 50×20 concurrent reader test at `cache_test.go:108-139` under `-race` covers the mutex discipline.
+- `serve.go:131` — cache is scoped to `buildMux`, NOT package-global. Tests and concurrent `Start()` calls stay isolated. Correct design.
+- `serve.go:3-31` — security docblock calls out exactly what it should: no auth, permissive CORS, exposes prompt text + generated source. Startup banner at `serve.go:119-122` makes it impossible to miss. This satisfies the Phase 4 security documentation requirement.
+- `api.ts:72-79` — `fetchPairwise` returns `null` on 404 rather than throwing. Correct pattern: "no pairwise data" is expected, not an error. Keeps caller code linear.
+- `types.ts:226-234` — `PairwiseRunReport` JSON field names match Go struct tags verbatim (`run_id`, `timestamp`, `reports`, `aggregate_impacts`). No `as unknown as` casts anywhere. This is the Wave 1 lesson landing.
+
+### Minor
+
+- `dashboard.go:24` — `_ = cache` placeholder for future comparison endpoint caching. Fine as a marker, but note that after #583 merges and adds `handleAPIRunComparisons`, that handler will bypass the cache (reads `comparisons.json` directly via `os.ReadFile`). Not a regression, but post-merge rebase should wire it through.
+
+### Merge coordination note (not blocking #581)
+
+This PR conflicts with #583 on `hyoka/internal/serve/serve.go` — both add a new case to the `handleAPIRunDetail` switch. Verified via `git merge-tree`. Whichever merges second needs a trivial rebase to add its case alongside the other's. #581's handler signature change (cache threading) also needs to propagate into #583's `handleAPIRunComparisons` on rebase. **Suggest merge order: #583 first (stable type foundation), then rebase #581 on top** so cache wiring covers the comparisons endpoint in one pass.
+
+---
+
+## PR #582 — Trinity #360 pairwise methodology + tool usage chart + deep-link
+
+**Verdict: APPROVE.** Ship it for 0.3.1.
+
+### Tool Usage Frequency chart — accept the proxy
+
+**Question 2 adjudicated: proxy is acceptable for 0.3.1.**
+
+The reasoning is correct. At `pairwise-page.tsx:368-378`, "used" is defined as `imp.impact !== 0 || imp.baseline_pass !== imp.without_pass`. That's impact signal, not observation. Ground truth lives on per-eval `EvalReport.ToolAvailability`, not aggregated in summary.json.
+
+Three reasons to accept:
+
+1. **Labeled.** `pairwise-page.tsx:347-355` comment block explicitly calls it a proxy and directs readers to eval detail for ground truth. `pairwise-page.tsx:672-675` ships the same disclaimer user-visible. No false-precision claim is being made.
+2. **Correct scope.** Adding a backend aggregation endpoint would widen #360 by at least another backend handler + TS type + tests. Out of scope for the pairwise-page polish issue.
+3. **Actionable follow-up.** Easy to replace later: when a `GET /api/runs/{id}/tool-availability` endpoint exists, swap `computeToolFrequency` to read from it and delete the proxy logic. Zero-risk future change.
+
+**File a follow-up issue** — "Backend tool-availability aggregation endpoint + ground-truth frequency chart" — target 0.3.2 or 0.4.
+
+### What else is right
+
+- `pairwise-page.tsx:483,502-510` — `useSearchParams` for `?run=<id>` is correctly two-way bound with `{replace: true}`, so back-button history doesn't pollute. Deep-link from run-detail → pairwise works.
+- `run-detail-page.tsx:153-172` — conditional render on `run.pairwise_results?.length > 0`. `encodeURIComponent(run.run_id)` correctly handles slash-containing run IDs.
+- `MethodologyInfo` at `pairwise-page.tsx:297-353` — collapsible state-driven rather than `<details>`, keeps design-system consistency. Positive/negative/zero impact semantics spelled out with color coding. Good.
+
+### Nit (not blocking)
+
+- PR description says "amber" banner on run-detail but `run-detail-page.tsx:155` uses emerald. Either is fine; description cosmetic.
+
+---
+
+## PR #583 — Neo #357 comparison unification
+
+**Verdict: REQUEST_CHANGES.**
+
+The Go architecture is excellent. The TS side was not updated. One file-fix unblocks merge.
+
+### What's right (architecturally significant)
+
+- `result.go:40-48` — `ComparisonResult` with discriminator `Kind` replaces three wrapper types. Right call. Kind-switched rendering at `compare.go:92-101` collapses three near-identical render functions into one. Net `-347` lines.
+- `comparison.go:167-187` — `CompareReports` is the in-memory primitive. Every public entry point (`CompareConfigs`, `CompareRuns`, `TemporalDiff`, `AutoGenerateForRun`) delegates to it. This is exactly the shape I asked for in the kickoff brief §3 Neo guidance.
+- `comparison.go:189-220` — `AutoGenerateForRun` emits pairs alphabetically (`sort.Strings(configs)` + `i<j` nested loop). Deterministic. Test at `inmem_test.go:99-126` proves it.
+- `autogen.go:24-51` — `WriteForRun` writes `comparisons.json` alongside `summary.json`. The file-adjacent decision over adding `Comparisons []ComparisonResult` to `RunSummary` is correct — the `comparison → report → comparison` import cycle is real, and a file is easier to evolve than a struct field. Noted in the PR body.
+- `engine.go:706-721` — auto-gen wiring is defensive. Failure is `slog.Warn`, not a run failure. Correct.
+- `dashboard.go:171-222` — comparisons endpoint computes on-demand for legacy runs that pre-date auto-generation. Legacy compatibility done right.
+- `inmem_test.go:181-225` — `TestAutoGenerateForRun_UsesSameEngine` proves auto-gen output matches direct-path output byte-for-byte. This is real coverage of the shared-core claim.
+
+### 🔴 BLOCKER: TS drift — comparison page will break on merge
+
+`site/src/app/data/types.ts:309-314` still declares:
+
+```ts
+export interface ConfigComparison {
+  config_a: string;
+  config_b: string;
+  per_prompt: PromptDiff[];
+  summary: ComparisonSummary;
+}
+```
+
+After this PR merges, `GET /api/compare/configs` returns `{kind: "configs", label_a, label_b, per_prompt, summary}` — the field rename is breaking. Confirmed at `comparison-page.tsx:546,549`:
+
+```tsx
+<TableHead>{comparison.config_a}</TableHead>  // → undefined
+<TableHead>{comparison.config_b}</TableHead>  // → undefined
+```
+
+**The comparison page will render blank column headers as soon as this merges.** This is the exact class of Go↔TS drift I flagged in Wave 1. Tests don't catch it because `fetchCompareConfigs` is mocked in `__tests__/api.test.ts` and `comparison-page.test.tsx`.
+
+Same drift affects `/api/compare/runs` and `/api/compare/temporal` (see `dashboard_test.go:226-240,295-310` — tests were updated, but TS consumers were not).
+
+### Punch list for Neo (one PR revision)
+
+1. **Update `site/src/app/data/types.ts:309-314`** — replace `ConfigComparison` with a union that matches the Go discriminator:
+   ```ts
+   export type ComparisonKind = "configs" | "runs" | "temporal";
+
+   export interface ComparisonResult {
+     kind: ComparisonKind;
+     label_a: string;
+     label_b: string;
+     config?: string;    // only for kind === "temporal"
+     since?: string;     // only for kind === "temporal"
+     per_prompt: PromptDiff[];
+     summary: ComparisonSummary;
+   }
+   ```
+   Keep `ConfigComparison` as a deprecated alias for one release OR remove and update call sites — either works; pick one and commit.
+2. **Update `site/src/app/data/api.ts:62-66`** — change return type to `ComparisonResult`.
+3. **Update `site/src/app/components/comparison-page.tsx`** — rename `comparison.config_a` → `comparison.label_a`, `config_b` → `label_b` (lines 231, 257, 546, 549, and state type at line 231).
+4. **Update `site/src/__tests__/comparison-page.test.tsx`** — fixture field names.
+5. **Add TS mirror for the new `/api/runs/{id}/comparisons` endpoint** — `fetchRunComparisons(runId): Promise<ComparisonResult[]>` in `api.ts`. The site consumer of this endpoint lands in Phase 5, but publishing the TS type now closes the contract.
+
+### Other item: `summary_stats.PromptDeltas` retention
+
+**Question 3 adjudicated: SIGN-OFF, retain as-is for 0.3.1.**
+
+Neo's justification is legitimate on both grounds:
+
+1. **Different semantic.** `summary_stats.PromptDeltas` is a per-prompt pass/fail toggle between configs — a binary transition aggregated across a run. `comparison.PromptDiff` is a numeric score-delta. Unifying them means losing the pass-toggle view or coercing it into score-delta (which reports a 1.0 delta for a pass-flip — lossy and misleading).
+2. **Import cycle.** `comparison` already imports `report`. `report/summary_stats.go` importing `comparison` would close the cycle. Breaking it would require a third package, which is scope creep for this PR.
+
+Keep. File a Phase 5 cleanup issue: *"Move pass-toggle aggregate into a shared view package and delete `summary_stats.PromptDeltas`."*
+
+---
+
+## Cross-cutting items
+
+### 1. Gate: "CLI and site produce identical results" — shared-core argument is sufficient
+
+**Accept the construction-based claim for 0.3.1.** All three surfaces funnel through `comparison.CompareReports`:
+
+- CLI: `CompareConfigs(reportsDir, ...)` → `loadReportsByConfig` → `CompareReports` → `renderComparison(out, cmp)`
+- Serve `/api/compare/configs`: same `CompareConfigs` → `writeJSON(w, cmp)`
+- Serve `/api/runs/{id}/comparisons`: `LoadForRun` OR `loadRunReports + AutoGenerateForRun` → `writeJSON(w, results)`
+- End-of-run auto-gen: `eval/engine.go:710` → `comparison.WriteForRun` → `AutoGenerateForRun` → `CompareReports`
+
+All four paths share the same map-build (`latestByPrompt` or `indexByPromptConfig`) and `buildSummary` code. `inmem_test.go:181-225` already proves equivalence between the auto-gen and direct in-memory paths. The disk-backed paths differ only in how reports are loaded — same reports, same result.
+
+**Coordinate with Switch** — recommend a snapshot test in `hyoka/internal/comparison/` that:
+1. Builds two fixture runs on disk.
+2. Calls `CompareConfigs(dir, "a", "b")` → marshals to JSON (S1).
+3. Loads the same reports manually and calls `CompareReports` directly → marshals (S2).
+4. `assert.Equal(S1, S2)` byte-for-byte.
+
+This is belt-and-suspenders, not a gate blocker. Ship Wave 3 without it; file as a test-hardening follow-up for Switch.
+
+### 4. Contract coherence across PRs
+
+**Clean on the Go side. Drift on the TS side (see #583 blocker).**
+
+Go boundary:
+- #583 publishes `ComparisonResult` in `hyoka/internal/comparison/result.go` and exposes `/api/runs/{id}/comparisons`.
+- #581 exposes `/api/runs/{id}/pairwise` with a separate type (`report.PairwiseRunReport`) — no overlap with `ComparisonResult`.
+- #582 consumes only existing `PairwiseReport` / `ToolImpact` types from Wave 1 — no new dependency on #583's types.
+
+The two endpoints are orthogonal. No type coupling between #581 and #583 beyond the file they both touch (`serve.go` switch).
+
+TS boundary:
+- #581 adds `PairwiseRunReport` TS type correctly matching Go.
+- #583 does NOT add a TS mirror for `ComparisonResult` AND does not update the existing `ConfigComparison` type, which will now be stale. **This is the drift.**
+
+Fix #583's punch list, contract is clean.
+
+### 5. Phase 4 go-live gate — status
+
+Running down the kickoff brief §6 criteria:
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | All 9 items closed (#355–#363, +#566) | #566 ✅ #355/#356 ✅ #357 🟡 (#583 in review) #358 ✅ #359 ✅ #360 🟡 (#582 in review) #361 🟡 (#581 in review) #362 ✅ #363 ✅ |
+| 2 | Switch's test review green; `go test -race`, `npm test` | ⚠️ Switch's #375 audit at `switch-375-test-review.md` reports `comparison 91.6%`. That coverage is against the **pre-#583** package. Post-#583 the package is rewritten (+137/-125 lines on `comparison.go`, two new files). **Switch must re-run coverage after #583 lands.** |
+| 3 | Site renders real eval data | ✅ achieved in Wave 2 (#358, #359) |
+| 4 | `hyoka compare` CLI and site page produce identical results | ✅ satisfied by #583 shared-core, **once TS drift is fixed** |
+| 5 | Branding updated (general AI, zero Azure SDK) | ✅ #362 landed |
+| 6 | Examples pass `go run ./hyoka validate` | ✅ #363 landed |
+| 7 | All Phase 4 work merged to `ronniegeraghty/dev`, CI passing | 🟡 pending consolidation PR `phase-4-remainder → dev` after Wave 3 |
+
+### Go-live decision
+
+**NO-GO until:**
+
+1. **#583** revises per punch list (TS types + comparison page). Non-negotiable — the comparison page visibly breaks on merge otherwise.
+2. **Switch** re-runs `go test -race -cover ./hyoka/internal/comparison/...` after #583 lands on `squad/phase-4-remainder`. Must remain ≥85%. Quick spot-check; not a full audit re-run.
+3. **Merge order:** #583 first → Switch re-runs → #581 rebased + merged → #582 merged (trivially clean, site-only).
+4. **Consolidation PR** `squad/phase-4-remainder → ronniegeraghty/dev` opened with CI green.
+
+After those: **GO for 0.3.1.** Phase 4 complete.
+
+---
+
+## Appendix: decisions to file
+
+- **A1.** Accept pairwise tool usage chart as proxy for 0.3.1; file follow-up for backend aggregation endpoint (0.3.2 or 0.4).
+- **A2.** Retain `summary_stats.PromptDeltas` for 0.3.1; file Phase 5 cleanup for shared view package.
+- **A3.** Add Switch follow-up: snapshot test proving CLI JSON ≡ serve API JSON ≡ auto-gen JSON for identical inputs. Belt-and-suspenders over the shared-core argument.
+- **A4.** Add Go↔TS drift rule to squad conventions: "When a Go response type's JSON field names change, the matching TS type in `site/src/app/data/types.ts` MUST be updated in the same PR." This is now the second wave where this class of bug appeared (Wave 1: `workspace_delta` field-name mismatch; Wave 3: `config_a`/`config_b` → `label_a`/`label_b`). Pattern, not incident.
+
+—Morpheus

--- a/.squad/decisions/switch-wave3-review.md
+++ b/.squad/decisions/switch-wave3-review.md
@@ -1,0 +1,79 @@
+# Wave 3 PR Review — #581 / #582 / #583
+
+**Author:** Switch 🤍
+**Date:** 2026-04-18
+**Base:** `squad/phase-4-remainder`
+**Gate ref:** `.squad/decisions/archive/morpheus-phase4-kickoff.md` §6
+
+## Summary
+
+| PR  | Title                           | Verdict           | Go cov (pkg) | Site tests |
+|-----|---------------------------------|-------------------|--------------|------------|
+| #581 | #361 serve cache + pairwise    | ✅ LGTM          | serve 83.7%  | 56/56 pass |
+| #582 | #360 pairwise methodology/chart| 🟡 LGTM w/ notes | n/a (FE)     | 53/53 pass |
+| #583 | #357 comparison unification    | ✅ LGTM          | comparison 91.6% · serve 80.0% · total 64.4% | — |
+
+Go suite runs **race-clean 3×** on all three branches.
+
+## Phase 4 Gate Criterion #4 — CLI↔site parity
+
+**Status: ENFORCED IN TESTS.** Neo's "satisfied by construction" claim is now load-bearing rather than aspirational.
+
+Added `hyoka/internal/serve/equivalence_test.go` to `squad/357-comparison-unification` — **commit `e91997a5`**. Two tests:
+
+1. `TestCLISiteEquivalence_AutoGenComparisons` — forces on-demand path (no `comparisons.json` on disk) → the API recomputes via `AutoGenerateForRun`. Compares the engine's direct output to the JSON returned by `GET /api/runs/{runID}/comparisons` via `reflect.DeepEqual` on wire-format-roundtripped structs.
+2. `TestCLISiteEquivalence_LoadedComparisonsFile` — uses `comparison.WriteForRun` (end-of-run path) → API reads from disk. Same equivalence assertion.
+
+Both passed under `-race -count=3`. If the shared-core invariant ever regresses, these tests fail.
+
+## Per-PR notes
+
+### PR #581 — LGTM ✅
+- File cache is correct: mtime+size fingerprint busts on modification (`TestFileCache_MtimeChangeBustsCache`) and survives file removal (`TestFileCache_ReadThenCacheHit`). Race-clean.
+- Pairwise endpoint (`/api/runs/{runID}/pairwise`) has 404 coverage for missing runs.
+- **Minor:** `registerDashboardRoutes` receives `cache` but currently only stashes it as `_ = cache`. Dead-flag acceptable as reserved capacity — comment says so explicitly.
+
+### PR #582 — 🟡 LGTM with documented test gaps
+- 239 lines added to `pairwise-page.tsx` (MethodologyInfo, ToolUsageFrequencyChart, `computeToolFrequency`) and 21 lines to `run-detail-page.tsx` (cross-link), **no new frontend tests**. Existing 53 tests still pass and the build is clean, so this isn't a blocker, but I'm flagging it.
+- Site statement coverage on `pairwise-page.tsx` is **44.85%** (uncovered: 287–292, 501–565 — exactly the new code). The "94% site baseline" in my earlier review was test-count, not statement coverage; the actual all-files statement coverage is **66.66%**. The new code pushes this down slightly, not up.
+- `computeToolFrequency` is pure and cheap to test — recommend a follow-up issue to add at least one table-driven test over it.
+- Integration: #582 reads `pairwise_results` embedded in `RunSummary` (existing plumbing). It does **not** consume #581's new `/api/runs/{runID}/pairwise` endpoint. They are independent features — no wiring gap, but also no cross-PR synergy realized yet.
+
+### PR #583 — LGTM ✅
+- `ComparisonResult` is a clean unification; `CompareReports` is the correct seam. Existing tests (`inmem_test.go`, `autogen_test.go`) plus the new equivalence tests give end-to-end coverage.
+- CLI refactor in `cmd/compare.go` is mostly deletions (−208) — good sign that shared-core claim is real.
+- Total Go coverage **64.4%**, just above the 64% baseline. No regression.
+
+## Cross-PR integration / merge-order
+
+**Both #581 and #583 modify `hyoka/internal/serve/dashboard.go` and `serve.go` — non-trivial conflicts expected.**
+
+- #581 renames `handleAPIGraders`, `handleAPITimeline`, `handleAPIScoreBreakdown` signatures to accept `cache *fileCache` and routes them through `registerDashboardRoutes(mux, opts, cache)`.
+- #583 adds a new handler `handleAPIRunComparisons` and a `/api/runs/{runID}/comparisons` mux route.
+
+**Recommended merge order:**
+
+1. **#582 first** — frontend-only (site/ + trinity history). Zero overlap with #581/#583.
+2. **#581 second** — cache refactor lands cleanly on `squad/phase-4-remainder`.
+3. **#583 last, rebased onto #581** — Neo must rebase `squad/357-comparison-unification` after #581 merges, reapply `handleAPIRunComparisons` on top of the cache-aware registration. At that point the new handler should also take `*fileCache` for consistency (even if unused initially, like the current `_ = cache`).
+
+Alternate: #583 before #581 also works (smaller rebase surface for Neo), but then #581 must adopt the cache pattern in `handleAPIRunComparisons` when it rebases. Either way, **one of the two will rebase.**
+
+## Coverage check vs baseline
+
+| Surface | Baseline | Wave 3 | Status |
+|---------|----------|--------|--------|
+| Go total | 64% | 64.4% (@#583) | ✅ no regression |
+| Go comparison | (new) | 91.6% | ✅ healthy |
+| Go serve | ~75% | 80.0% (#583) / 83.7% (#581) | ✅ improved |
+| Site statement | 66.66% actual | 66.66% (#582) | ⚠ flat — new FE code uncovered |
+
+## Flakiness
+
+`go test -race -count=3` on each branch: **zero flakes** across serve, comparison, and full `./hyoka/...` suites.
+
+## Action items
+
+1. **Neo:** rebase onto merged #581; re-run equivalence tests post-merge on the combined base before dismissing the gate.
+2. **Trinity (follow-up issue, non-blocking):** add a `pairwise-page.test.tsx` covering `computeToolFrequency` and rendering of the methodology explainer / tool usage chart. Target 60%+ stmt coverage on `pairwise-page.tsx`.
+3. **Morpheus:** Phase 4 gate criterion #4 can be checked — test-enforced, not hand-waved.

--- a/site/src/app/components/pairwise-page.tsx
+++ b/site/src/app/components/pairwise-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo } from "react";
+import { useSearchParams } from "react-router";
 import {
   BarChart,
   Bar,
@@ -17,6 +18,10 @@ import {
   BarChart3,
   Zap,
   AlertTriangle,
+  Info,
+  ChevronDown,
+  ChevronRight,
+  Activity,
 } from "lucide-react";
 import { fetchRuns } from "../data/api";
 import type { RunSummary, PairwiseReport, ToolImpact } from "../data/types";
@@ -287,6 +292,189 @@ function ToolImpactHeatmap({ reports }: { reports: PairwiseReport[] }) {
   );
 }
 
+// ── Methodology explainer (R152) ─────────────────────────────────────
+
+function MethodologyInfo() {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="mb-6 rounded-xl border border-blue-500/15 bg-blue-500/[0.03]">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full items-center gap-2 px-5 py-3 text-left transition hover:bg-blue-500/[0.06]"
+      >
+        <Info className="h-4 w-4 text-blue-400" />
+        <span className="text-blue-400" style={{ fontSize: 13, fontWeight: 500 }}>
+          How are tool impact scores calculated?
+        </span>
+        <span className="ml-auto text-blue-400/60">
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </span>
+      </button>
+      {expanded && (
+        <div className="space-y-3 border-t border-blue-500/10 px-5 py-4 text-white/70" style={{ fontSize: 13, lineHeight: 1.65 }}>
+          <p>
+            Pairwise evaluation runs each prompt <strong className="text-white">N+1 times</strong>:
+            once with every tool enabled (the <em>baseline</em>), and once with each togglable tool
+            individually removed (<em>without-X</em> variants).
+          </p>
+          <p>
+            For each tool X:
+          </p>
+          <pre className="overflow-x-auto rounded bg-black/40 p-3 text-blue-300" style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}>
+{`impact(X) = baseline_score - without_X_score`}
+          </pre>
+          <ul className="list-disc space-y-1 pl-5 text-white/65">
+            <li><strong className="text-emerald-400">Positive impact</strong> — removing the tool hurt the score, so the tool <em>helped</em>.</li>
+            <li><strong className="text-red-400">Negative impact</strong> — removing the tool improved the score, so the tool <em>hurt</em>.</li>
+            <li><strong className="text-white/50">Zero impact</strong> — the tool had no measurable effect on this prompt.</li>
+          </ul>
+          <p>
+            The <strong className="text-white">Tool Contribution</strong> bar chart shows each
+            tool's impact averaged across all prompts in the run. The <strong className="text-white">Heatmap</strong>
+            breaks it down per prompt. Aggregate pass/fail columns (<em>Breaks</em> / <em>Fixes</em>)
+            flag tools whose presence flipped the pass state.
+          </p>
+          <p className="text-white/40" style={{ fontSize: 12 }}>
+            Tools marked <code className="rounded bg-white/5 px-1 text-white/60">always_on</code> or
+            <code className="rounded bg-white/5 px-1 text-white/60">pairwise: off</code> in the
+            config are never toggled and therefore have no impact entry.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Tool Usage Frequency (R152) ──────────────────────────────────────
+//
+// For each tool in the run, count across all prompts:
+//   - "available and used"   — tool appears in the prompt's pairwise impacts
+//     AND the impact signal is measurable (|impact| > 0 or baseline_pass
+//     differs from without_pass)
+//   - "available but unused" — tool appears in impacts but showed no
+//     measurable effect when removed (likely loaded but never invoked, or
+//     redundant with another tool)
+//   - "not available"        — tool appears in SOME prompts' impacts but
+//     not this one (not in this variant's togglable set)
+//
+// The signal is derived from the pairwise impact data already on this page;
+// it's a proxy for "did the agent actually invoke this tool?" rather than
+// ground truth. For exact invocation counts, see each eval's tool_availability
+// field on the eval detail page.
+
+interface ToolFrequencyRow {
+  tool_name: string;
+  available_used: number;
+  available_unused: number;
+  not_available: number;
+  total_prompts: number;
+}
+
+function computeToolFrequency(reports: PairwiseReport[]): ToolFrequencyRow[] {
+  if (reports.length === 0) return [];
+
+  // Union of every tool name seen across the run.
+  const allTools = new Set<string>();
+  for (const r of reports) {
+    for (const imp of r.impacts) allTools.add(imp.tool_name);
+  }
+
+  const rows: ToolFrequencyRow[] = [];
+  for (const tool of allTools) {
+    let used = 0;
+    let unused = 0;
+    let absent = 0;
+    for (const r of reports) {
+      const imp = r.impacts.find((i) => i.tool_name === tool);
+      if (!imp) {
+        absent += 1;
+        continue;
+      }
+      const hadEffect = imp.impact !== 0 || imp.baseline_pass !== imp.without_pass;
+      if (hadEffect) used += 1;
+      else unused += 1;
+    }
+    rows.push({
+      tool_name: tool,
+      available_used: used,
+      available_unused: unused,
+      not_available: absent,
+      total_prompts: reports.length,
+    });
+  }
+
+  // Sort: most-used first, then alphabetical.
+  rows.sort((a, b) => b.available_used - a.available_used || a.tool_name.localeCompare(b.tool_name));
+  return rows;
+}
+
+function ToolUsageFrequencyChart({ reports }: { reports: PairwiseReport[] }) {
+  const rows = useMemo(() => computeToolFrequency(reports), [reports]);
+
+  if (rows.length === 0) {
+    return <p className="py-8 text-center text-white/30" style={{ fontSize: 13 }}>No tool usage data</p>;
+  }
+
+  const total = rows[0].total_prompts;
+
+  return (
+    <div className="space-y-2">
+      {rows.map((r) => {
+        const usedPct = (r.available_used / total) * 100;
+        const unusedPct = (r.available_unused / total) * 100;
+        const absentPct = (r.not_available / total) * 100;
+        return (
+          <div key={r.tool_name} className="flex items-center gap-3">
+            <div
+              className="truncate text-white/65"
+              style={{ fontSize: 12, fontFamily: "'JetBrains Mono', monospace", width: 160, flexShrink: 0 }}
+              title={r.tool_name}
+            >
+              {r.tool_name}
+            </div>
+            <div className="flex h-6 flex-1 overflow-hidden rounded bg-white/[0.04]">
+              {r.available_used > 0 && (
+                <div
+                  className="flex items-center justify-center bg-emerald-500/70 text-white"
+                  style={{ width: `${usedPct}%`, fontSize: 10, fontFamily: "'JetBrains Mono', monospace" }}
+                  title={`Available and used: ${r.available_used}/${total}`}
+                >
+                  {usedPct > 12 ? r.available_used : ""}
+                </div>
+              )}
+              {r.available_unused > 0 && (
+                <div
+                  className="flex items-center justify-center bg-amber-500/50 text-white/90"
+                  style={{ width: `${unusedPct}%`, fontSize: 10, fontFamily: "'JetBrains Mono', monospace" }}
+                  title={`Available but unused: ${r.available_unused}/${total}`}
+                >
+                  {unusedPct > 12 ? r.available_unused : ""}
+                </div>
+              )}
+              {r.not_available > 0 && (
+                <div
+                  className="flex items-center justify-center bg-white/10 text-white/50"
+                  style={{ width: `${absentPct}%`, fontSize: 10, fontFamily: "'JetBrains Mono', monospace" }}
+                  title={`Not available: ${r.not_available}/${total}`}
+                >
+                  {absentPct > 12 ? r.not_available : ""}
+                </div>
+              )}
+            </div>
+            <div
+              className="text-white/40"
+              style={{ fontSize: 11, fontFamily: "'JetBrains Mono', monospace", width: 60, textAlign: "right", flexShrink: 0 }}
+            >
+              {r.available_used}/{total}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // ── Main Page ────────────────────────────────────────────────────────
 
 export function PairwisePage() {
@@ -294,18 +482,35 @@ export function PairwisePage() {
   const [selectedRunId, setSelectedRunId] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     fetchRuns()
       .then((data) => {
         setRuns(data);
-        // Auto-select the most recent run that has pairwise data
         const withPairwise = data.filter((r) => r.pairwise_results && r.pairwise_results.length > 0);
-        if (withPairwise.length > 0) setSelectedRunId(withPairwise[0].run_id);
+        // Deep-link support: ?run=<run_id> wins over auto-selection as long as
+        // the requested run actually has pairwise data.
+        const requested = searchParams.get("run");
+        const requestedMatch = requested && withPairwise.find((r) => r.run_id === requested);
+        if (requestedMatch) {
+          setSelectedRunId(requestedMatch.run_id);
+        } else if (withPairwise.length > 0) {
+          setSelectedRunId(withPairwise[0].run_id);
+        }
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Keep the URL in sync with the user's selection so the page is shareable.
+  useEffect(() => {
+    if (!selectedRunId) return;
+    if (searchParams.get("run") === selectedRunId) return;
+    setSearchParams({ run: selectedRunId }, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRunId]);
 
   const selectedRun = runs.find((r) => r.run_id === selectedRunId);
   const pairwiseReports = selectedRun?.pairwise_results ?? [];
@@ -404,6 +609,9 @@ export function PairwisePage() {
           </div>
         ) : (
           <>
+            {/* Methodology explainer */}
+            <MethodologyInfo />
+
             {/* Impact Summary Cards */}
             <div className="mb-8">
               <ImpactSummaryCard impacts={aggregatedImpacts} />
@@ -454,6 +662,35 @@ export function PairwisePage() {
               ) : (
                 <p className="py-8 text-center text-white/30" style={{ fontSize: 13 }}>No heatmap data</p>
               )}
+            </div>
+
+            {/* Tool Usage Frequency */}
+            <div className="mb-8 rounded-xl border border-white/8 bg-white/[0.03] p-6">
+              <div className="mb-1 flex items-center gap-2">
+                <Activity className="h-4 w-4 text-emerald-400" />
+                <h3 className="text-white" style={{ fontSize: 15 }}>Tool Usage Frequency</h3>
+                <span className="ml-2 text-white/30" style={{ fontSize: 12 }}>
+                  How often each tool was available vs. actually exercised
+                </span>
+              </div>
+              <p className="mb-5 text-white/35" style={{ fontSize: 12 }}>
+                Derived from the pairwise impact signal — a tool is counted as "used" when its
+                presence changed the score or pass state on that prompt. For exact invocation
+                counts, see each eval's tool_availability on the detail page.
+              </p>
+              <ToolUsageFrequencyChart reports={pairwiseReports} />
+              <div className="mt-5 flex flex-wrap justify-center gap-4">
+                {[
+                  { label: "Available and used", color: "rgba(16,185,129,0.7)" },
+                  { label: "Available but unused", color: "rgba(245,158,11,0.5)" },
+                  { label: "Not available on this prompt", color: "rgba(255,255,255,0.1)" },
+                ].map((l) => (
+                  <div key={l.label} className="flex items-center gap-1.5">
+                    <div className="h-2.5 w-6 rounded-sm" style={{ background: l.color }} />
+                    <span className="text-white/40" style={{ fontSize: 11 }}>{l.label}</span>
+                  </div>
+                ))}
+              </div>
             </div>
 
             {/* Detailed Table */}

--- a/site/src/app/components/run-detail-page.tsx
+++ b/site/src/app/components/run-detail-page.tsx
@@ -2,7 +2,7 @@ import { useParams, Link, useNavigate } from "react-router";
 import { useState, useEffect } from "react";
 import { fetchRun } from "../data/api";
 import type { RunSummary, EvalResult, EvalReport } from "../data/types";
-import { CheckCircle2, XCircle, Clock, FileCode2, ArrowLeft, Loader2, Tag } from "lucide-react";
+import { CheckCircle2, XCircle, Clock, FileCode2, ArrowLeft, Loader2, Tag, Zap } from "lucide-react";
 import { GraderResultRow } from "./GraderResultRow";
 
 const mono = { fontFamily: "'JetBrains Mono', monospace" };
@@ -148,6 +148,26 @@ export function RunDetailPage() {
               {run.analysis}
             </p>
           </div>
+        )}
+
+        {run.pairwise_results && run.pairwise_results.length > 0 && (
+          <Link
+            to={`/pairwise?run=${encodeURIComponent(run.run_id)}`}
+            className="mb-8 flex items-center justify-between rounded-xl border border-emerald-500/20 bg-emerald-500/[0.04] p-4 no-underline transition hover:border-emerald-500/40 hover:bg-emerald-500/[0.08]"
+          >
+            <div className="flex items-center gap-3">
+              <Zap className="h-4 w-4 text-emerald-400" />
+              <div>
+                <div className="text-emerald-400" style={{ fontSize: 13, fontWeight: 500 }}>
+                  Pairwise tool-ablation available
+                </div>
+                <div className="text-white/40" style={{ fontSize: 12 }}>
+                  {run.pairwise_results.length} prompt{run.pairwise_results.length === 1 ? "" : "s"} with per-tool impact analysis
+                </div>
+              </div>
+            </div>
+            <span className="text-emerald-400/70" style={{ ...mono, fontSize: 12 }}>View →</span>
+          </Link>
         )}
 
         <div className="mb-4 flex items-center justify-between">


### PR DESCRIPTION
Closes #360.

## Summary

Pairwise page polish: adds a methodology explainer, a tool usage frequency chart, and `?run=<id>` deep-linking so run-detail can cross-link into the pairwise view.

## Changes

**`site/src/app/components/pairwise-page.tsx`**
- **MethodologyInfo** — collapsible info box at the top of the page. Explains baseline vs without-X, the `impact = baseline_score - without_score` formula, threshold semantics (positive = helped / negative = hurt / zero = no effect), and the always_on / pairwise-off exclusions.
- **ToolUsageFrequencyChart** — stacked horizontal bar per tool showing:
  - _Available and used_ — tool appears in prompt's impacts AND `impact != 0` or `baseline_pass != without_pass`
  - _Available but unused_ — tool appears but had no measurable effect
  - _Not available_ — tool not in that prompt's impacts
  
  Derived from pairwise impact data already on the page. Labeled as a proxy signal — exact invocation counts live on per-eval `tool_availability`. A follow-up issue can add a backend aggregation endpoint if ground truth is needed.
- **`?run=<run_id>` URL param** — `useSearchParams` for two-way binding. Reads on mount to pick an initial run, writes via `setSearchParams(..., {replace: true})` on change.

**`site/src/app/components/run-detail-page.tsx`**
- Amber "View pairwise analysis →" banner with `<Zap>` icon. Only renders when `run.pairwise_results?.length > 0`. Links to `/pairwise?run=<encoded runId>`.

## Verification

- `npm --prefix site test` — 53/53 passing
- `npm --prefix site run build` — clean (existing 1.17MB chunk warning only)
- Cast check: `grep "as unknown as" site/src/app/components/pairwise-page.tsx site/src/app/components/run-detail-page.tsx` — no hits
- No new TS types coined; uses existing `RunSummary`, `PairwiseReport`, `ToolImpact` from `data/types.ts`

## Base

Based on and PRs back to `squad/phase-4-remainder` (companion to #581 for #361).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
