### PR TITLE
feat(#357): unify comparison engine

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -201,3 +201,27 @@ This is multi-day refactor touching review/, graders/, eval/. Decided to ship fo
 2. **Premature implementation risk:** Recognized session splitting scope early, deferred to avoid half-working feature in PR.
 3. **Test-first for schema:** Wrote hierarchical tests before validating real files; caught empty-file edge case.
 
+
+## #357 Comparison Unification — Phase 4 Wave 3
+
+**Branch:** `squad/357-comparison-unification` → PR #583 → `squad/phase-4-remainder`
+**Worktree:** `/home/rgeraghty/projects/hyoka-357`
+
+### Architecture decisions
+
+- **Single `ComparisonResult` type keyed on `ComparisonKind`** replaces the three wrapper types (`ConfigComparison`/`RunComparison`/`TemporalComparison`). CLI, serve API, and auto-gen all land on the same struct → Morpheus gate (CLI == site) is satisfied by shared code path, not by testing two paths for equality.
+- **`CompareReports` is the in-memory core.** Every public entry point delegates. Disk-backed `CompareConfigs`/`CompareRuns`/`TemporalDiff` = load reports + call `CompareReports`. `AutoGenerateForRun` = fan out to `CompareReports` across pairs.
+- **Auto-gen writes `comparisons.json` alongside `summary.json`** rather than a field on `RunSummary`. Rationale: adding `Comparisons []ComparisonResult` to `report.RunSummary` creates `comparison → report → comparison` cycle. File-adjacent is cleaner + site can read or recompute — either gives identical output.
+- **`summary_stats.PromptDeltas` retained.** Pass/fail toggle is a distinct aggregate view from score-delta comparison. Direct import would cycle. Documented in PR body.
+
+### Lessons
+
+- **Worktrees for parallel agents.** Main checkout had Trinity's branch active mid-task. Running `git worktree add ../hyoka-357 -b squad/357-comparison-unification origin/squad/phase-4-remainder` gave isolated working directory. `.squad/decisions/inbox/` is gitignored so inbox files are worktree-local — informational only for Trinity.
+- **Drop the contract early.** `ComparisonResult` type file committed + pushed as a WIP commit before the rewrite. Trinity could import against the shape while I refactored behavior.
+- **Serve handlers as pass-through wins.** `dashboard.go` handlers at lines 111/127/147 needed *no* code change — they just `writeJSON(w, cmp)` over whatever the comparison pkg returns. The type swap flowed through for free.
+- **Mux route collisions.** `mux.HandleFunc("/api/runs/", ...)` in `dashboard.go` collided with the existing catchall in `serve.go`. Fix: add `comparisons` as a sub-resource case in the existing switch, not a new registration.
+- **Test file indentation:** `cmd/compare_test.go` uses pure tabs, no leading whitespace. Small detail that bites on edits.
+
+### Follow-ups to consider
+
+- If the site surface never consumes `summary_stats.PromptDeltas`, future cleanup: move the pass-toggle computation into the `comparison` package (or a third shared one) and delete from `summary_stats.go`. Out of scope for #357 (semantics differ + import cycle).

--- a/hyoka/cmd/compare.go
+++ b/hyoka/cmd/compare.go
@@ -1,32 +1,32 @@
 package cmd
 
 import (
-"encoding/json"
-"fmt"
-"strings"
-"time"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
-"github.com/ronniegeraghty/hyoka/hyoka/internal/comparison"
-"github.com/spf13/cobra"
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/comparison"
+	"github.com/spf13/cobra"
 )
 
 func compareCmd() *cobra.Command {
-var (
-configA    string
-configB    string
-runA       string
-runB       string
-config     string
-since      string
-reportsDir string
-format     string
-topN       int
-)
+	var (
+		configA    string
+		configB    string
+		runA       string
+		runB       string
+		config     string
+		since      string
+		reportsDir string
+		format     string
+		topN       int
+	)
 
-cmd := &cobra.Command{
-Use:   "compare",
-Short: "Compare evaluation results between configs, runs, or time periods",
-Long: `Compare evaluation results to identify regressions and improvements.
+	cmd := &cobra.Command{
+		Use:   "compare",
+		Short: "Compare evaluation results between configs, runs, or time periods",
+		Long: `Compare evaluation results to identify regressions and improvements.
 
 Three comparison modes:
 
@@ -37,198 +37,197 @@ Three comparison modes:
     Compare results from two specific evaluation runs.
 
   Temporal comparison (--config / --since):
-    Compare a config's results before and after a date.`,
-RunE: func(cmd *cobra.Command, args []string) error {
-reportsDir = resolvePathFlag(cmd, "reports-dir", []string{"./reports", "../reports"})
-out := cmd.OutOrStdout()
+    Compare a config's results before and after a date.
 
-mode, err := detectMode(configA, configB, runA, runB, config, since)
-if err != nil {
-return err
-}
+All modes share the same comparison engine — results are identical to what
+the site comparison page renders for the same inputs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reportsDir = resolvePathFlag(cmd, "reports-dir", []string{"./reports", "../reports"})
+			out := cmd.OutOrStdout()
 
-switch mode {
-case "configs":
-cmp, err := comparison.CompareConfigs(reportsDir, configA, configB)
-if err != nil {
-return fmt.Errorf("config comparison: %w", err)
-}
-return renderConfigComparison(out, cmp, format, topN)
+			mode, err := detectMode(configA, configB, runA, runB, config, since)
+			if err != nil {
+				return err
+			}
 
-case "runs":
-cmp, err := comparison.CompareRuns(reportsDir, runA, runB)
-if err != nil {
-return fmt.Errorf("run comparison: %w", err)
-}
-return renderRunComparison(out, cmp, format, topN)
+			var result *comparison.ComparisonResult
+			switch mode {
+			case "configs":
+				result, err = comparison.CompareConfigs(reportsDir, configA, configB)
+				if err != nil {
+					return fmt.Errorf("config comparison: %w", err)
+				}
+			case "runs":
+				result, err = comparison.CompareRuns(reportsDir, runA, runB)
+				if err != nil {
+					return fmt.Errorf("run comparison: %w", err)
+				}
+			case "temporal":
+				sinceTime, err := time.Parse("2006-01-02", since)
+				if err != nil {
+					return fmt.Errorf("invalid --since date %q (expected YYYY-MM-DD): %w", since, err)
+				}
+				result, err = comparison.TemporalDiff(reportsDir, config, sinceTime)
+				if err != nil {
+					return fmt.Errorf("temporal comparison: %w", err)
+				}
+			default:
+				return fmt.Errorf("unknown mode %q", mode)
+			}
 
-case "temporal":
-sinceTime, err := time.Parse("2006-01-02", since)
-if err != nil {
-return fmt.Errorf("invalid --since date %q (expected YYYY-MM-DD): %w", since, err)
-}
-cmp, err := comparison.TemporalDiff(reportsDir, config, sinceTime)
-if err != nil {
-return fmt.Errorf("temporal comparison: %w", err)
-}
-return renderTemporalComparison(out, cmp, format, topN)
+			return renderComparison(out, result, format, topN)
+		},
+	}
 
-default:
-return fmt.Errorf("unknown mode %q", mode)
-}
-},
-}
+	cmd.Flags().StringVar(&configA, "config-a", "", "First config name (for config comparison)")
+	cmd.Flags().StringVar(&configB, "config-b", "", "Second config name (for config comparison)")
+	cmd.Flags().StringVar(&runA, "run-a", "", "First run ID (for run comparison)")
+	cmd.Flags().StringVar(&runB, "run-b", "", "Second run ID (for run comparison)")
+	cmd.Flags().StringVar(&config, "config", "", "Config name (for temporal comparison)")
+	cmd.Flags().StringVar(&since, "since", "", "Cutoff date YYYY-MM-DD (for temporal comparison)")
+	cmd.Flags().StringVar(&reportsDir, "reports-dir", "./reports", "Directory containing evaluation reports")
+	cmd.Flags().StringVar(&format, "format", "table", "Output format: table or json")
+	cmd.Flags().IntVar(&topN, "top", 0, "Show only top N changes (0 = all)")
 
-cmd.Flags().StringVar(&configA, "config-a", "", "First config name (for config comparison)")
-cmd.Flags().StringVar(&configB, "config-b", "", "Second config name (for config comparison)")
-cmd.Flags().StringVar(&runA, "run-a", "", "First run ID (for run comparison)")
-cmd.Flags().StringVar(&runB, "run-b", "", "Second run ID (for run comparison)")
-cmd.Flags().StringVar(&config, "config", "", "Config name (for temporal comparison)")
-cmd.Flags().StringVar(&since, "since", "", "Cutoff date YYYY-MM-DD (for temporal comparison)")
-cmd.Flags().StringVar(&reportsDir, "reports-dir", "./reports", "Directory containing evaluation reports")
-cmd.Flags().StringVar(&format, "format", "table", "Output format: table or json")
-cmd.Flags().IntVar(&topN, "top", 0, "Show only top N changes (0 = all)")
-
-return cmd
+	return cmd
 }
 
 // detectMode determines which comparison mode to use based on flag combinations.
 func detectMode(configA, configB, runA, runB, config, since string) (string, error) {
-hasConfigPair := configA != "" || configB != ""
-hasRunPair := runA != "" || runB != ""
-hasTemporal := config != "" || since != ""
+	hasConfigPair := configA != "" || configB != ""
+	hasRunPair := runA != "" || runB != ""
+	hasTemporal := config != "" || since != ""
 
-set := 0
-if hasConfigPair {
-set++
-}
-if hasRunPair {
-set++
-}
-if hasTemporal {
-set++
-}
+	set := 0
+	if hasConfigPair {
+		set++
+	}
+	if hasRunPair {
+		set++
+	}
+	if hasTemporal {
+		set++
+	}
 
-if set == 0 {
-return "", fmt.Errorf("specify one of:\n  --config-a + --config-b  (compare configs)\n  --run-a + --run-b        (compare runs)\n  --config + --since       (temporal comparison)")
-}
-if set > 1 {
-return "", fmt.Errorf("only one comparison mode at a time: use --config-a/--config-b, --run-a/--run-b, or --config/--since")
-}
+	if set == 0 {
+		return "", fmt.Errorf("specify one of:\n  --config-a + --config-b  (compare configs)\n  --run-a + --run-b        (compare runs)\n  --config + --since       (temporal comparison)")
+	}
+	if set > 1 {
+		return "", fmt.Errorf("only one comparison mode at a time: use --config-a/--config-b, --run-a/--run-b, or --config/--since")
+	}
 
-if hasConfigPair {
-if configA == "" || configB == "" {
-return "", fmt.Errorf("both --config-a and --config-b are required")
-}
-return "configs", nil
-}
-if hasRunPair {
-if runA == "" || runB == "" {
-return "", fmt.Errorf("both --run-a and --run-b are required")
-}
-return "runs", nil
-}
-// hasTemporal
-if config == "" || since == "" {
-return "", fmt.Errorf("both --config and --since are required for temporal comparison")
-}
-return "temporal", nil
+	if hasConfigPair {
+		if configA == "" || configB == "" {
+			return "", fmt.Errorf("both --config-a and --config-b are required")
+		}
+		return "configs", nil
+	}
+	if hasRunPair {
+		if runA == "" || runB == "" {
+			return "", fmt.Errorf("both --run-a and --run-b are required")
+		}
+		return "runs", nil
+	}
+	if config == "" || since == "" {
+		return "", fmt.Errorf("both --config and --since are required for temporal comparison")
+	}
+	return "temporal", nil
 }
 
 // ---------- Rendering ----------
 
-func renderConfigComparison(out interface{ Write([]byte) (int, error) }, cmp *comparison.ConfigComparison, format string, topN int) error {
-if format == "json" {
-return writeJSON(out, cmp)
-}
-fmt.Fprintf(out, "Config comparison: %s vs %s\n", cmp.ConfigA, cmp.ConfigB)
-renderDiffTable(out, cmp.PerPrompt, cmp.Summary, topN)
-return nil
+type lineWriter interface{ Write([]byte) (int, error) }
+
+// renderComparison renders any ComparisonResult in the requested format.
+// Since every comparison mode shares the ComparisonResult shape, this is the
+// single render path — CLI output is guaranteed to match whatever the serve
+// API returns for the same inputs.
+func renderComparison(out lineWriter, cmp *comparison.ComparisonResult, format string, topN int) error {
+	if format == "json" {
+		return writeJSON(out, cmp)
+	}
+
+	switch cmp.Kind {
+	case comparison.KindConfigs:
+		fmt.Fprintf(out, "Config comparison: %s vs %s\n", cmp.LabelA, cmp.LabelB)
+	case comparison.KindRuns:
+		fmt.Fprintf(out, "Run comparison: %s vs %s\n", cmp.LabelA, cmp.LabelB)
+	case comparison.KindTemporal:
+		fmt.Fprintf(out, "Temporal comparison: %s (base: %s → latest: %s)\n", cmp.Config, cmp.LabelA, cmp.LabelB)
+	default:
+		fmt.Fprintf(out, "Comparison (%s): %s vs %s\n", cmp.Kind, cmp.LabelA, cmp.LabelB)
+	}
+
+	renderDiffTable(out, cmp.PerPrompt, cmp.Summary, topN)
+	return nil
 }
 
-func renderRunComparison(out interface{ Write([]byte) (int, error) }, cmp *comparison.RunComparison, format string, topN int) error {
-if format == "json" {
-return writeJSON(out, cmp)
-}
-fmt.Fprintf(out, "Run comparison: %s vs %s\n", cmp.RunA, cmp.RunB)
-renderDiffTable(out, cmp.PerPrompt, cmp.Summary, topN)
-return nil
+func renderDiffTable(out lineWriter, diffs []comparison.PromptDiff, summary comparison.ComparisonSummary, topN int) {
+	sep := strings.Repeat("─", 72)
+	fmt.Fprintf(out, "%s\n", sep)
+	fmt.Fprintf(out, "%-40s %8s %8s %8s %6s\n", "Prompt", "A", "B", "Delta", "")
+	fmt.Fprintf(out, "%s\n", sep)
+
+	shown := diffs
+	if topN > 0 && topN < len(diffs) {
+		shown = diffs[:topN]
+	}
+
+	for _, d := range shown {
+		label := d.PromptID
+		if len(label) > 39 {
+			label = label[:36] + "..."
+		}
+
+		indicator := "  "
+		switch {
+		case d.OnlyInA:
+			indicator = "⊖"
+		case d.OnlyInB:
+			indicator = "⊕"
+		case d.Delta > 0.001:
+			indicator = "▲"
+		case d.Delta < -0.001:
+			indicator = "▼"
+		}
+
+		switch {
+		case d.OnlyInA:
+			fmt.Fprintf(out, "%-40s %8.3f %8s %8s %s\n", label, d.ScoreA, "—", "—", indicator)
+		case d.OnlyInB:
+			fmt.Fprintf(out, "%-40s %8s %8.3f %8s %s\n", label, "—", d.ScoreB, "—", indicator)
+		default:
+			fmt.Fprintf(out, "%-40s %8.3f %8.3f %+8.3f %s\n", label, d.ScoreA, d.ScoreB, d.Delta, indicator)
+		}
+	}
+
+	if topN > 0 && topN < len(diffs) {
+		fmt.Fprintf(out, "\n(showing top %d of %d prompts)\n", topN, len(diffs))
+	}
+
+	fmt.Fprintf(out, "%s\n", sep)
+	fmt.Fprintf(out, "Summary: %d improved, %d regressed, %d unchanged (avg Δ %+.3f)\n",
+		summary.Improved, summary.Regressed, summary.Unchanged, summary.AvgDelta)
+
+	if len(summary.TopImproved) > 0 {
+		fmt.Fprintf(out, "\nTop improved:\n")
+		for _, d := range summary.TopImproved {
+			fmt.Fprintf(out, "  %s: %+.3f\n", d.PromptID, d.Delta)
+		}
+	}
+	if len(summary.TopRegressed) > 0 {
+		fmt.Fprintf(out, "\nTop regressed:\n")
+		for _, d := range summary.TopRegressed {
+			fmt.Fprintf(out, "  %s: %+.3f\n", d.PromptID, d.Delta)
+		}
+	}
 }
 
-func renderTemporalComparison(out interface{ Write([]byte) (int, error) }, cmp *comparison.TemporalComparison, format string, topN int) error {
-if format == "json" {
-return writeJSON(out, cmp)
-}
-fmt.Fprintf(out, "Temporal comparison: %s (base: %s → latest: %s)\n", cmp.Config, cmp.BaseRun, cmp.LatestRun)
-renderDiffTable(out, cmp.PerPrompt, cmp.Summary, topN)
-return nil
-}
-
-func renderDiffTable(out interface{ Write([]byte) (int, error) }, diffs []comparison.PromptDiff, summary comparison.ComparisonSummary, topN int) {
-sep := strings.Repeat("─", 72)
-fmt.Fprintf(out, "%s\n", sep)
-fmt.Fprintf(out, "%-40s %8s %8s %8s %6s\n", "Prompt", "A", "B", "Delta", "")
-fmt.Fprintf(out, "%s\n", sep)
-
-shown := diffs
-if topN > 0 && topN < len(diffs) {
-shown = diffs[:topN]
-}
-
-for _, d := range shown {
-label := d.PromptID
-if len(label) > 39 {
-label = label[:36] + "..."
-}
-
-indicator := "  "
-switch {
-case d.OnlyInA:
-indicator = "⊖"
-case d.OnlyInB:
-indicator = "⊕"
-case d.Delta > 0.001:
-indicator = "▲"
-case d.Delta < -0.001:
-indicator = "▼"
-}
-
-if d.OnlyInA {
-fmt.Fprintf(out, "%-40s %8.3f %8s %8s %s\n", label, d.ScoreA, "—", "—", indicator)
-} else if d.OnlyInB {
-fmt.Fprintf(out, "%-40s %8s %8.3f %8s %s\n", label, "—", d.ScoreB, "—", indicator)
-} else {
-fmt.Fprintf(out, "%-40s %8.3f %8.3f %+8.3f %s\n", label, d.ScoreA, d.ScoreB, d.Delta, indicator)
-}
-}
-
-if topN > 0 && topN < len(diffs) {
-fmt.Fprintf(out, "\n(showing top %d of %d prompts)\n", topN, len(diffs))
-}
-
-fmt.Fprintf(out, "%s\n", sep)
-fmt.Fprintf(out, "Summary: %d improved, %d regressed, %d unchanged (avg Δ %+.3f)\n",
-summary.Improved, summary.Regressed, summary.Unchanged, summary.AvgDelta)
-
-if len(summary.TopImproved) > 0 {
-fmt.Fprintf(out, "\nTop improved:\n")
-for _, d := range summary.TopImproved {
-fmt.Fprintf(out, "  %s: %+.3f\n", d.PromptID, d.Delta)
-}
-}
-if len(summary.TopRegressed) > 0 {
-fmt.Fprintf(out, "\nTop regressed:\n")
-for _, d := range summary.TopRegressed {
-fmt.Fprintf(out, "  %s: %+.3f\n", d.PromptID, d.Delta)
-}
-}
-}
-
-func writeJSON(out interface{ Write([]byte) (int, error) }, v any) error {
-data, err := json.MarshalIndent(v, "", "  ")
-if err != nil {
-return fmt.Errorf("marshalling JSON: %w", err)
-}
-_, err = out.Write(append(data, '\n'))
-return err
+func writeJSON(out lineWriter, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling JSON: %w", err)
+	}
+	_, err = out.Write(append(data, '\n'))
+	return err
 }

--- a/hyoka/cmd/compare_test.go
+++ b/hyoka/cmd/compare_test.go
@@ -197,8 +197,14 @@ var result map[string]any
 if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
 }
-if result["config_a"] != "config-a" {
-t.Errorf("expected config_a = config-a, got %v", result["config_a"])
+if result["kind"] != "configs" {
+t.Errorf("expected kind = configs, got %v", result["kind"])
+}
+if result["label_a"] != "config-a" {
+t.Errorf("expected label_a = config-a, got %v", result["label_a"])
+}
+if result["label_b"] != "config-b" {
+t.Errorf("expected label_b = config-b, got %v", result["label_b"])
 }
 }
 

--- a/hyoka/internal/comparison/autogen.go
+++ b/hyoka/internal/comparison/autogen.go
@@ -1,0 +1,71 @@
+package comparison
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/report"
+)
+
+// ComparisonsFile is the filename written in a run directory containing all
+// pairwise config comparisons auto-generated for a multi-config run. The site
+// run-detail view reads this file to render comparisons without recomputing.
+const ComparisonsFile = "comparisons.json"
+
+// WriteForRun auto-generates pairwise comparisons across the configs present
+// in `reports` and writes them as JSON to {runDir}/comparisons.json. Returns
+// the written path, nil if nothing was written (fewer than 2 configs), or an
+// error on write failure.
+//
+// The comparisons are produced by the same engine (CompareReports) used by the
+// CLI and serve API — site render and CLI output are identical by construction.
+func WriteForRun(runDir string, reports []report.EvalReport) (string, error) {
+	results := AutoGenerateForRun(reports)
+	if len(results) == 0 {
+		slog.Debug("Skipping comparisons.json (fewer than 2 configs)", "run_dir", runDir)
+		return "", nil
+	}
+
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		return "", fmt.Errorf("creating run directory: %w", err)
+	}
+
+	path := filepath.Join(runDir, ComparisonsFile)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("creating %s: %w", ComparisonsFile, err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		return "", fmt.Errorf("encoding comparisons: %w", err)
+	}
+
+	slog.Info("Comparisons written",
+		"path", path, "pairs", len(results))
+	return path, nil
+}
+
+// LoadForRun reads the auto-generated comparisons for a run, if present.
+// Returns (nil, nil) if the file does not exist — callers should treat that
+// as "no auto-generated comparisons available" (e.g. single-config runs).
+func LoadForRun(runDir string) ([]ComparisonResult, error) {
+	path := filepath.Join(runDir, ComparisonsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", ComparisonsFile, err)
+	}
+	var results []ComparisonResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, fmt.Errorf("decoding %s: %w", ComparisonsFile, err)
+	}
+	return results, nil
+}

--- a/hyoka/internal/comparison/autogen_test.go
+++ b/hyoka/internal/comparison/autogen_test.go
@@ -1,0 +1,103 @@
+package comparison
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/report"
+)
+
+func TestWriteForRun_MultiConfig(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run-001")
+
+	reports := []report.EvalReport{
+		mkReport("p1", "alpha", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("p1", "beta", "2025-01-01T10:00:00Z", 0.8),
+		mkReport("p2", "alpha", "2025-01-01T10:00:00Z", 0.6),
+		mkReport("p2", "beta", "2025-01-01T10:00:00Z", 0.6),
+	}
+
+	path, err := WriteForRun(runDir, reports)
+	if err != nil {
+		t.Fatalf("WriteForRun failed: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	var results []ComparisonResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(results))
+	}
+	if results[0].LabelA != "alpha" || results[0].LabelB != "beta" {
+		t.Errorf("labels: got %q/%q", results[0].LabelA, results[0].LabelB)
+	}
+}
+
+func TestWriteForRun_SingleConfig_Skipped(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run-solo")
+
+	reports := []report.EvalReport{
+		mkReport("p1", "only", "2025-01-01T10:00:00Z", 0.5),
+	}
+
+	path, err := WriteForRun(runDir, reports)
+	if err != nil {
+		t.Fatalf("WriteForRun failed: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for single-config run, got %q", path)
+	}
+	if _, err := os.Stat(filepath.Join(runDir, ComparisonsFile)); !os.IsNotExist(err) {
+		t.Error("comparisons.json should not exist for single-config run")
+	}
+}
+
+func TestLoadForRun_Missing(t *testing.T) {
+	dir := t.TempDir()
+	results, err := LoadForRun(dir)
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results, got %d entries", len(results))
+	}
+}
+
+func TestLoadForRun_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run-rt")
+
+	reports := []report.EvalReport{
+		mkReport("p1", "alpha", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("p1", "beta", "2025-01-01T10:00:00Z", 0.9),
+	}
+
+	if _, err := WriteForRun(runDir, reports); err != nil {
+		t.Fatalf("WriteForRun: %v", err)
+	}
+	results, err := LoadForRun(runDir)
+	if err != nil {
+		t.Fatalf("LoadForRun: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Kind != KindConfigs {
+		t.Errorf("kind: got %q", results[0].Kind)
+	}
+	if results[0].Summary.Improved != 1 {
+		t.Errorf("expected 1 improved, got %d", results[0].Summary.Improved)
+	}
+}

--- a/hyoka/internal/comparison/comparison.go
+++ b/hyoka/internal/comparison/comparison.go
@@ -1,6 +1,8 @@
 // Package comparison provides config-vs-config, run-vs-run, and temporal diff
-// analysis for hyoka evaluation reports. It operates on EvalReport data and
-// produces structured diffs suitable for display or further aggregation.
+// analysis for hyoka evaluation reports. It is the single source of truth for
+// comparison logic: the `hyoka compare` CLI, the serve API, and report
+// auto-generation all share this engine. See ComparisonResult (result.go) for
+// the canonical payload.
 package comparison
 
 import (
@@ -30,57 +32,32 @@ type GraderDiff struct {
 
 // PromptDiff holds the per-prompt aggregate delta between two evaluations.
 type PromptDiff struct {
-	PromptID    string      `json:"prompt_id"`
-	ScoreA      float64     `json:"score_a"`
-	ScoreB      float64     `json:"score_b"`
-	Delta       float64     `json:"delta"` // B − A
+	PromptID    string       `json:"prompt_id"`
+	ScoreA      float64      `json:"score_a"`
+	ScoreB      float64      `json:"score_b"`
+	Delta       float64      `json:"delta"` // B − A
 	GraderDiffs []GraderDiff `json:"grader_diffs,omitempty"`
-	OnlyInA     bool        `json:"only_in_a,omitempty"`
-	OnlyInB     bool        `json:"only_in_b,omitempty"`
+	OnlyInA     bool         `json:"only_in_a,omitempty"`
+	OnlyInB     bool         `json:"only_in_b,omitempty"`
 }
 
 // ComparisonSummary aggregates high-level comparison metrics.
 type ComparisonSummary struct {
-	AvgDelta      float64      `json:"avg_delta"`
-	Improved      int          `json:"improved"`
-	Regressed     int          `json:"regressed"`
-	Unchanged     int          `json:"unchanged"`
-	TopImproved   []PromptDiff `json:"top_improved,omitempty"`
-	TopRegressed  []PromptDiff `json:"top_regressed,omitempty"`
+	AvgDelta     float64      `json:"avg_delta"`
+	Improved     int          `json:"improved"`
+	Regressed    int          `json:"regressed"`
+	Unchanged    int          `json:"unchanged"`
+	TopImproved  []PromptDiff `json:"top_improved,omitempty"`
+	TopRegressed []PromptDiff `json:"top_regressed,omitempty"`
 }
 
-// ConfigComparison holds the result of comparing two configs across a shared prompt set.
-type ConfigComparison struct {
-	ConfigA   string            `json:"config_a"`
-	ConfigB   string            `json:"config_b"`
-	PerPrompt []PromptDiff      `json:"per_prompt"`
-	Summary   ComparisonSummary `json:"summary"`
-}
-
-// RunComparison holds the result of comparing two specific runs.
-type RunComparison struct {
-	RunA      string            `json:"run_a"`
-	RunB      string            `json:"run_b"`
-	PerPrompt []PromptDiff      `json:"per_prompt"`
-	Summary   ComparisonSummary `json:"summary"`
-}
-
-// TemporalComparison holds the result of comparing the latest run against a historical baseline.
-type TemporalComparison struct {
-	Config    string            `json:"config"`
-	LatestRun string            `json:"latest_run"`
-	BaseRun   string            `json:"base_run"`
-	Since     time.Time         `json:"since"`
-	PerPrompt []PromptDiff      `json:"per_prompt"`
-	Summary   ComparisonSummary `json:"summary"`
-}
-
-// ---------- Public API ----------
+// ---------- Public API (disk-backed) ----------
 
 // CompareConfigs loads all reports from reportsDir for the two given config
-// names, matches them by prompt ID, and produces a ConfigComparison.
-func CompareConfigs(reportsDir, configA, configB string) (*ConfigComparison, error) {
-	lg := slog.With("role", "comparison")
+// names, matches them by prompt ID, and produces a ComparisonResult.
+// For each config, the latest report per prompt is used.
+func CompareConfigs(reportsDir, configA, configB string) (*ComparisonResult, error) {
+	lg := slog.With("role", "comparison", "kind", "configs")
 	lg.Debug("Comparing configs", "config_a", configA, "config_b", configB)
 
 	reportsA, err := loadReportsByConfig(reportsDir, configA)
@@ -96,32 +73,22 @@ func CompareConfigs(reportsDir, configA, configB string) (*ConfigComparison, err
 		return nil, fmt.Errorf("no reports found for either config %q or %q", configA, configB)
 	}
 
-	// Use latest report per prompt for each config.
-	latestA := latestByPrompt(reportsA)
-	latestB := latestByPrompt(reportsB)
-
-	diffs := diffPromptMaps(latestA, latestB)
-	summary := buildSummary(diffs)
+	result := CompareReports(KindConfigs, configA, configB, reportsA, reportsB)
 
 	lg.Info("Config comparison complete",
 		"config_a", configA, "config_b", configB,
-		"prompts", len(diffs),
-		"improved", summary.Improved,
-		"regressed", summary.Regressed,
+		"prompts", len(result.PerPrompt),
+		"improved", result.Summary.Improved,
+		"regressed", result.Summary.Regressed,
 	)
-
-	return &ConfigComparison{
-		ConfigA:   configA,
-		ConfigB:   configB,
-		PerPrompt: diffs,
-		Summary:   summary,
-	}, nil
+	return result, nil
 }
 
 // CompareRuns loads all reports from two specific run directories and produces
-// a RunComparison. Run IDs are the timestamp-based directory names under reportsDir.
-func CompareRuns(reportsDir, runA, runB string) (*RunComparison, error) {
-	lg := slog.With("role", "comparison")
+// a ComparisonResult. Run IDs are the timestamp-based directory names under
+// reportsDir.
+func CompareRuns(reportsDir, runA, runB string) (*ComparisonResult, error) {
+	lg := slog.With("role", "comparison", "kind", "runs")
 	lg.Debug("Comparing runs", "run_a", runA, "run_b", runB)
 
 	reportsA, err := loadReportsFromRun(reportsDir, runA)
@@ -137,31 +104,22 @@ func CompareRuns(reportsDir, runA, runB string) (*RunComparison, error) {
 		return nil, fmt.Errorf("no reports found for either run %q or %q", runA, runB)
 	}
 
-	mapA := indexByPromptConfig(reportsA)
-	mapB := indexByPromptConfig(reportsB)
-
-	diffs := diffPromptMaps(mapA, mapB)
-	summary := buildSummary(diffs)
+	result := CompareReports(KindRuns, runA, runB, reportsA, reportsB)
 
 	lg.Info("Run comparison complete",
 		"run_a", runA, "run_b", runB,
-		"prompts", len(diffs),
-		"improved", summary.Improved,
-		"regressed", summary.Regressed,
+		"prompts", len(result.PerPrompt),
+		"improved", result.Summary.Improved,
+		"regressed", result.Summary.Regressed,
 	)
-
-	return &RunComparison{
-		RunA:      runA,
-		RunB:      runB,
-		PerPrompt: diffs,
-		Summary:   summary,
-	}, nil
+	return result, nil
 }
 
-// TemporalDiff compares the latest run for a config against the most recent run
-// at or before `since`. This enables "how has this config changed since date X?"
-func TemporalDiff(reportsDir, config string, since time.Time) (*TemporalComparison, error) {
-	lg := slog.With("role", "comparison")
+// TemporalDiff compares the latest run for a config against the most recent
+// run at or before `since`. Produces a ComparisonResult with Kind == KindTemporal
+// and Config/Since populated.
+func TemporalDiff(reportsDir, config string, since time.Time) (*ComparisonResult, error) {
+	lg := slog.With("role", "comparison", "kind", "temporal")
 	lg.Debug("Temporal diff", "config", config, "since", since)
 
 	all, err := loadReportsByConfig(reportsDir, config)
@@ -175,13 +133,9 @@ func TemporalDiff(reportsDir, config string, since time.Time) (*TemporalComparis
 	// Partition into base (≤ since) and recent (> since).
 	var base, recent []report.EvalReport
 	for _, r := range all {
-		ts, err := time.Parse(time.RFC3339, r.Timestamp)
+		ts, err := parseReportTimestamp(r.Timestamp)
 		if err != nil {
-			// Try fallback format (some reports use a compact timestamp).
-			ts, err = time.Parse("2006-01-02T15:04:05", r.Timestamp)
-			if err != nil {
-				continue
-			}
+			continue
 		}
 		if ts.Before(since) || ts.Equal(since) {
 			base = append(base, r)
@@ -197,38 +151,97 @@ func TemporalDiff(reportsDir, config string, since time.Time) (*TemporalComparis
 		return nil, fmt.Errorf("no reports found for config %q after %s", config, since.Format(time.RFC3339))
 	}
 
-	latestBase := latestByPrompt(base)
-	latestRecent := latestByPrompt(recent)
+	baseRun := runIDFromReport(base[len(base)-1])
+	latestRun := runIDFromReport(recent[len(recent)-1])
 
-	diffs := diffPromptMaps(latestBase, latestRecent)
-	summary := buildSummary(diffs)
-
-	// Determine run IDs from the partitioned reports.
-	baseRun := runIDFromReport(base[len(base)-1], reportsDir)
-	latestRun := runIDFromReport(recent[len(recent)-1], reportsDir)
+	result := CompareReports(KindTemporal, baseRun, latestRun, base, recent)
+	result.Config = config
+	sinceCopy := since
+	result.Since = &sinceCopy
 
 	lg.Info("Temporal diff complete",
 		"config", config, "since", since,
 		"base_run", baseRun, "latest_run", latestRun,
-		"prompts", len(diffs),
-		"improved", summary.Improved,
-		"regressed", summary.Regressed,
+		"prompts", len(result.PerPrompt),
+		"improved", result.Summary.Improved,
+		"regressed", result.Summary.Regressed,
 	)
+	return result, nil
+}
 
-	return &TemporalComparison{
-		Config:    config,
-		LatestRun: latestRun,
-		BaseRun:   baseRun,
-		Since:     since,
+// ---------- Public API (in-memory) ----------
+
+// CompareReports is the core in-memory comparison primitive. Given two slices
+// of EvalReport values, it produces a ComparisonResult. This is the single
+// function used by every comparison surface:
+//
+//   - CompareConfigs / CompareRuns / TemporalDiff call it after loading from disk.
+//   - AutoGenerateForRun calls it to produce pairwise comparisons during
+//     multi-config runs (attached to RunSummary.Comparisons).
+//   - Callers who already have reports in memory can call it directly.
+//
+// For configs comparison, reports are keyed by prompt ID (latest wins). For
+// runs comparison, reports are keyed by prompt+config composite key so
+// multiple configs within a single run each produce their own entry.
+func CompareReports(kind ComparisonKind, labelA, labelB string, reportsA, reportsB []report.EvalReport) *ComparisonResult {
+	var mapA, mapB map[string]*report.EvalReport
+	if kind == KindRuns {
+		mapA = indexByPromptConfig(reportsA)
+		mapB = indexByPromptConfig(reportsB)
+	} else {
+		mapA = latestByPrompt(reportsA)
+		mapB = latestByPrompt(reportsB)
+	}
+
+	diffs := diffPromptMaps(mapA, mapB)
+	summary := buildSummary(diffs)
+
+	return &ComparisonResult{
+		Kind:      kind,
+		LabelA:    labelA,
+		LabelB:    labelB,
 		PerPrompt: diffs,
 		Summary:   summary,
-	}, nil
+	}
+}
+
+// AutoGenerateForRun produces pairwise config comparisons for all config pairs
+// present in the given reports. This is the entry point called at the end of a
+// multi-config run to attach comparisons to the run summary.
+//
+// Returns nil when fewer than two distinct configs are present (nothing to
+// compare). Pairs are emitted in deterministic alphabetical order (A<B).
+func AutoGenerateForRun(reports []report.EvalReport) []ComparisonResult {
+	// Group reports by config name.
+	byConfig := make(map[string][]report.EvalReport)
+	for _, r := range reports {
+		byConfig[r.ConfigName] = append(byConfig[r.ConfigName], r)
+	}
+	if len(byConfig) < 2 {
+		return nil
+	}
+
+	configs := make([]string, 0, len(byConfig))
+	for c := range byConfig {
+		configs = append(configs, c)
+	}
+	sort.Strings(configs)
+
+	var out []ComparisonResult
+	for i := 0; i < len(configs); i++ {
+		for j := i + 1; j < len(configs); j++ {
+			a, b := configs[i], configs[j]
+			res := CompareReports(KindConfigs, a, b, byConfig[a], byConfig[b])
+			out = append(out, *res)
+		}
+	}
+	return out
 }
 
 // ---------- Internal helpers ----------
 
-// loadReportsByConfig walks reportsDir and loads all report.json files
-// whose ConfigName matches the given config.
+// loadReportsByConfig walks reportsDir and loads all report.json files whose
+// ConfigName matches the given config.
 func loadReportsByConfig(reportsDir, config string) ([]report.EvalReport, error) {
 	var reports []report.EvalReport
 	err := filepath.Walk(reportsDir, func(path string, info os.FileInfo, err error) error {
@@ -287,7 +300,6 @@ func loadReport(path string) (*report.EvalReport, error) {
 }
 
 // latestByPrompt selects the most recent report per prompt ID (by timestamp).
-// The returned map key is "{promptID}|{configName}" to uniquely identify entries.
 func latestByPrompt(reports []report.EvalReport) map[string]*report.EvalReport {
 	result := make(map[string]*report.EvalReport)
 	for i := range reports {
@@ -302,7 +314,7 @@ func latestByPrompt(reports []report.EvalReport) map[string]*report.EvalReport {
 }
 
 // indexByPromptConfig indexes reports by a composite key of promptID + configName.
-// For run-vs-run comparison where both runs may have different configs.
+// For run-vs-run comparison where both runs may span multiple configs.
 func indexByPromptConfig(reports []report.EvalReport) map[string]*report.EvalReport {
 	result := make(map[string]*report.EvalReport)
 	for i := range reports {
@@ -323,14 +335,12 @@ func scoreFromReport(r *report.EvalReport) float64 {
 	if r.ScoreBreakdown != nil {
 		return r.ScoreBreakdown.FinalScore
 	}
-	// Compute from grader results if present.
 	if len(r.GraderResults) > 0 {
 		sb := report.BuildScoreBreakdown(r.GraderResults)
 		if sb != nil {
 			return sb.FinalScore
 		}
 	}
-	// Legacy review-based scoring.
 	if r.Review != nil && r.Review.MaxScore > 0 {
 		return float64(r.Review.OverallScore) / float64(r.Review.MaxScore)
 	}
@@ -348,7 +358,7 @@ func graderDiffs(a, b *report.EvalReport) []GraderDiff {
 		indexB[b.GraderResults[i].GraderName] = &b.GraderResults[i]
 	}
 
-	// Collect all grader names in deterministic order.
+	// Deterministic ordering: graders from A first (in order), then new ones from B.
 	seen := make(map[string]bool)
 	var names []string
 	for _, g := range a.GraderResults {
@@ -386,7 +396,6 @@ func diffPromptMaps(mapA, mapB map[string]*report.EvalReport) []PromptDiff {
 	seen := make(map[string]bool)
 	var keys []string
 	for k := range mapA {
-		// Strip config suffix from composite keys if present.
 		pid := promptIDFromKey(k)
 		if !seen[pid] {
 			seen[pid] = true
@@ -426,7 +435,7 @@ func diffPromptMaps(mapA, mapB map[string]*report.EvalReport) []PromptDiff {
 	return diffs
 }
 
-// buildSummary computes aggregate metrics and top N lists from prompt diffs.
+// buildSummary computes aggregate metrics and top-N lists from prompt diffs.
 func buildSummary(diffs []PromptDiff) ComparisonSummary {
 	const topN = 5
 	const unchangedThreshold = 0.001
@@ -455,12 +464,10 @@ func buildSummary(diffs []PromptDiff) ComparisonSummary {
 		s.AvgDelta = totalDelta / float64(paired)
 	}
 
-	// Top improved — largest positive delta first.
 	improved := filterPaired(diffs, func(d PromptDiff) bool { return d.Delta > unchangedThreshold })
 	sort.Slice(improved, func(i, j int) bool { return improved[i].Delta > improved[j].Delta })
 	s.TopImproved = take(improved, topN)
 
-	// Top regressed — largest negative delta first (most negative = worst).
 	regressed := filterPaired(diffs, func(d PromptDiff) bool { return d.Delta < -unchangedThreshold })
 	sort.Slice(regressed, func(i, j int) bool { return regressed[i].Delta < regressed[j].Delta })
 	s.TopRegressed = take(regressed, topN)
@@ -476,14 +483,12 @@ func promptIDFromKey(key string) string {
 	return key
 }
 
-// findByPromptID finds the first entry in a map whose key starts with the given
-// prompt ID (handling both bare keys and composite "promptID|config" keys).
+// findByPromptID finds the first entry in a map whose key starts with the
+// given prompt ID (handles both bare keys and composite keys).
 func findByPromptID(m map[string]*report.EvalReport, promptID string) *report.EvalReport {
-	// Direct lookup (simple key).
 	if r, ok := m[promptID]; ok {
 		return r
 	}
-	// Composite key scan.
 	for k, r := range m {
 		if promptIDFromKey(k) == promptID {
 			return r
@@ -492,13 +497,22 @@ func findByPromptID(m map[string]*report.EvalReport, promptID string) *report.Ev
 	return nil
 }
 
-// runIDFromReport attempts to extract the run ID from a report's timestamp.
-func runIDFromReport(r report.EvalReport, _ string) string {
-	ts, err := time.Parse(time.RFC3339, r.Timestamp)
+// runIDFromReport formats the report's timestamp as a run ID.
+func runIDFromReport(r report.EvalReport) string {
+	ts, err := parseReportTimestamp(r.Timestamp)
 	if err != nil {
 		return r.Timestamp
 	}
 	return ts.Format("20060102-150405")
+}
+
+// parseReportTimestamp parses a report timestamp in either RFC3339 or compact
+// form.
+func parseReportTimestamp(ts string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02T15:04:05", ts)
 }
 
 // filterPaired returns only diffs that appear in both sides.
@@ -522,5 +536,3 @@ func take(s []PromptDiff, n int) []PromptDiff {
 	}
 	return s[:n]
 }
-
-

--- a/hyoka/internal/comparison/comparison_test.go
+++ b/hyoka/internal/comparison/comparison_test.go
@@ -88,8 +88,11 @@ func TestCompareConfigs_BasicDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cmp.ConfigA != "baseline/opus" || cmp.ConfigB != "azure-mcp/opus" {
-		t.Errorf("config names mismatch: got %q / %q", cmp.ConfigA, cmp.ConfigB)
+	if cmp.Kind != KindConfigs {
+		t.Errorf("kind: expected %q, got %q", KindConfigs, cmp.Kind)
+	}
+	if cmp.LabelA != "baseline/opus" || cmp.LabelB != "azure-mcp/opus" {
+		t.Errorf("labels mismatch: got %q / %q", cmp.LabelA, cmp.LabelB)
 	}
 	if len(cmp.PerPrompt) != 2 {
 		t.Fatalf("expected 2 prompt diffs, got %d", len(cmp.PerPrompt))
@@ -239,8 +242,11 @@ func TestCompareRuns_BasicDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cmp.RunA != "20250101-100000" || cmp.RunB != "20250102-100000" {
-		t.Errorf("run IDs mismatch")
+	if cmp.Kind != KindRuns {
+		t.Errorf("kind: expected %q, got %q", KindRuns, cmp.Kind)
+	}
+	if cmp.LabelA != "20250101-100000" || cmp.LabelB != "20250102-100000" {
+		t.Errorf("run IDs mismatch: got %q / %q", cmp.LabelA, cmp.LabelB)
 	}
 	if len(cmp.PerPrompt) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(cmp.PerPrompt))
@@ -304,8 +310,14 @@ func TestTemporalDiff_BasicSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if tc.Kind != KindTemporal {
+		t.Errorf("kind: expected %q, got %q", KindTemporal, tc.Kind)
+	}
 	if tc.Config != "baseline/opus" {
 		t.Errorf("config mismatch: %q", tc.Config)
+	}
+	if tc.Since == nil || !tc.Since.Equal(since) {
+		t.Errorf("since should be set to cutoff: got %v", tc.Since)
 	}
 	if len(tc.PerPrompt) != 1 {
 		t.Fatalf("expected 1 prompt diff, got %d", len(tc.PerPrompt))

--- a/hyoka/internal/comparison/inmem_test.go
+++ b/hyoka/internal/comparison/inmem_test.go
@@ -1,0 +1,235 @@
+package comparison
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/report"
+)
+
+// ---------- CompareReports (in-memory) ----------
+
+func TestCompareReports_ConfigsBasic(t *testing.T) {
+	reportsA := []report.EvalReport{
+		mkReport("prompt-alpha", "config-a", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("prompt-beta", "config-a", "2025-01-01T10:00:00Z", 0.3),
+	}
+	reportsB := []report.EvalReport{
+		mkReport("prompt-alpha", "config-b", "2025-01-01T10:00:00Z", 0.8),
+		mkReport("prompt-beta", "config-b", "2025-01-01T10:00:00Z", 0.3),
+	}
+
+	got := CompareReports(KindConfigs, "config-a", "config-b", reportsA, reportsB)
+	if got == nil {
+		t.Fatal("CompareReports returned nil")
+	}
+	if got.Kind != KindConfigs {
+		t.Errorf("kind: got %q", got.Kind)
+	}
+	if got.LabelA != "config-a" || got.LabelB != "config-b" {
+		t.Errorf("labels: got %q / %q", got.LabelA, got.LabelB)
+	}
+	if len(got.PerPrompt) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(got.PerPrompt))
+	}
+	if got.Summary.Improved != 1 || got.Summary.Unchanged != 1 {
+		t.Errorf("summary: improved=%d unchanged=%d", got.Summary.Improved, got.Summary.Unchanged)
+	}
+}
+
+func TestCompareReports_RunsUsesCompositeKey(t *testing.T) {
+	// Run A: same prompt in two configs.
+	runA := []report.EvalReport{
+		mkReport("prompt-alpha", "config-x", "2025-01-01T10:00:00Z", 0.4),
+		mkReport("prompt-alpha", "config-y", "2025-01-01T10:00:00Z", 0.6),
+	}
+	runB := []report.EvalReport{
+		mkReport("prompt-alpha", "config-x", "2025-01-02T10:00:00Z", 0.7),
+		mkReport("prompt-alpha", "config-y", "2025-01-02T10:00:00Z", 0.6),
+	}
+
+	got := CompareReports(KindRuns, "run-a", "run-b", runA, runB)
+	// Composite keys mean both config variants are carried through, but
+	// diffPromptMaps collapses them by prompt ID for presentation. The
+	// summary should reflect improvement from at least one pair.
+	if got.Summary.Improved < 1 {
+		t.Errorf("expected at least 1 improved, got %d", got.Summary.Improved)
+	}
+}
+
+func TestCompareReports_DeterministicOrdering(t *testing.T) {
+	reportsA := []report.EvalReport{
+		mkReport("z-prompt", "a", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("a-prompt", "a", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("m-prompt", "a", "2025-01-01T10:00:00Z", 0.5),
+	}
+	reportsB := []report.EvalReport{
+		mkReport("z-prompt", "b", "2025-01-01T10:00:00Z", 0.7),
+		mkReport("a-prompt", "b", "2025-01-01T10:00:00Z", 0.7),
+		mkReport("m-prompt", "b", "2025-01-01T10:00:00Z", 0.7),
+	}
+
+	got1 := CompareReports(KindConfigs, "a", "b", reportsA, reportsB)
+	got2 := CompareReports(KindConfigs, "a", "b", reportsA, reportsB)
+
+	if len(got1.PerPrompt) != 3 || len(got2.PerPrompt) != 3 {
+		t.Fatalf("wrong diff count")
+	}
+	for i := range got1.PerPrompt {
+		if got1.PerPrompt[i].PromptID != got2.PerPrompt[i].PromptID {
+			t.Errorf("ordering not deterministic at index %d: %q vs %q",
+				i, got1.PerPrompt[i].PromptID, got2.PerPrompt[i].PromptID)
+		}
+	}
+	// Alphabetical order expected.
+	wantOrder := []string{"a-prompt", "m-prompt", "z-prompt"}
+	for i, want := range wantOrder {
+		if got1.PerPrompt[i].PromptID != want {
+			t.Errorf("expected %q at index %d, got %q", want, i, got1.PerPrompt[i].PromptID)
+		}
+	}
+}
+
+// ---------- AutoGenerateForRun ----------
+
+func TestAutoGenerateForRun_EmitsPairs(t *testing.T) {
+	tests := []struct {
+		name        string
+		reports     []report.EvalReport
+		wantPairs   int
+		wantKinds   []ComparisonKind
+		wantLabels  [][2]string
+	}{
+		{
+			name:      "single config → no pairs",
+			reports:   []report.EvalReport{mkReport("p1", "only", "2025-01-01T10:00:00Z", 0.5)},
+			wantPairs: 0,
+		},
+		{
+			name: "two configs → one pair",
+			reports: []report.EvalReport{
+				mkReport("p1", "alpha", "2025-01-01T10:00:00Z", 0.5),
+				mkReport("p1", "beta", "2025-01-01T10:00:00Z", 0.7),
+			},
+			wantPairs:  1,
+			wantKinds:  []ComparisonKind{KindConfigs},
+			wantLabels: [][2]string{{"alpha", "beta"}},
+		},
+		{
+			name: "three configs → three pairs, alphabetical",
+			reports: []report.EvalReport{
+				mkReport("p1", "gamma", "2025-01-01T10:00:00Z", 0.5),
+				mkReport("p1", "alpha", "2025-01-01T10:00:00Z", 0.5),
+				mkReport("p1", "beta", "2025-01-01T10:00:00Z", 0.5),
+			},
+			wantPairs: 3,
+			wantKinds: []ComparisonKind{KindConfigs, KindConfigs, KindConfigs},
+			wantLabels: [][2]string{
+				{"alpha", "beta"},
+				{"alpha", "gamma"},
+				{"beta", "gamma"},
+			},
+		},
+		{
+			name:      "empty reports",
+			reports:   nil,
+			wantPairs: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AutoGenerateForRun(tc.reports)
+			if len(got) != tc.wantPairs {
+				t.Fatalf("expected %d pairs, got %d", tc.wantPairs, len(got))
+			}
+			for i, cmp := range got {
+				if cmp.Kind != tc.wantKinds[i] {
+					t.Errorf("pair %d kind: got %q, want %q", i, cmp.Kind, tc.wantKinds[i])
+				}
+				if cmp.LabelA != tc.wantLabels[i][0] || cmp.LabelB != tc.wantLabels[i][1] {
+					t.Errorf("pair %d labels: got %q/%q, want %q/%q",
+						i, cmp.LabelA, cmp.LabelB, tc.wantLabels[i][0], tc.wantLabels[i][1])
+				}
+			}
+		})
+	}
+}
+
+func TestAutoGenerateForRun_UsesSameEngine(t *testing.T) {
+	// The CLI path (disk-backed) and the auto-gen path (in-memory) must
+	// produce identical results given identical inputs. This is the core
+	// Morpheus gate criterion for #357.
+	reports := []report.EvalReport{
+		mkReport("prompt-alpha", "baseline/opus", "2025-01-01T10:00:00Z", 0.5),
+		mkReport("prompt-beta", "baseline/opus", "2025-01-01T10:00:00Z", 0.7),
+		mkReport("prompt-alpha", "azure-mcp/opus", "2025-01-01T10:00:00Z", 0.8),
+		mkReport("prompt-beta", "azure-mcp/opus", "2025-01-01T10:00:00Z", 0.7),
+	}
+
+	// Auto-generated path.
+	autoGen := AutoGenerateForRun(reports)
+	if len(autoGen) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(autoGen))
+	}
+	auto := autoGen[0]
+
+	// Direct in-memory path.
+	var reportsA, reportsB []report.EvalReport
+	for _, r := range reports {
+		if r.ConfigName == auto.LabelA {
+			reportsA = append(reportsA, r)
+		} else {
+			reportsB = append(reportsB, r)
+		}
+	}
+	direct := CompareReports(KindConfigs, auto.LabelA, auto.LabelB, reportsA, reportsB)
+
+	// Summaries must match byte-for-byte.
+	if !summariesEqual(auto.Summary, direct.Summary) {
+		t.Errorf("auto-gen summary %+v does not match direct %+v", auto.Summary, direct.Summary)
+	}
+	if len(auto.PerPrompt) != len(direct.PerPrompt) {
+		t.Fatalf("per-prompt length mismatch: %d vs %d", len(auto.PerPrompt), len(direct.PerPrompt))
+	}
+	for i := range auto.PerPrompt {
+		a, d := auto.PerPrompt[i], direct.PerPrompt[i]
+		if a.PromptID != d.PromptID {
+			t.Errorf("prompt %d id: %q vs %q", i, a.PromptID, d.PromptID)
+		}
+		if math.Abs(a.Delta-d.Delta) > 1e-9 {
+			t.Errorf("prompt %d delta: %f vs %f", i, a.Delta, d.Delta)
+		}
+	}
+}
+
+// ---------- helpers ----------
+
+func mkReport(promptID, config, ts string, score float64) report.EvalReport {
+	pass := score >= 0.5
+	r := report.EvalReport{
+		SchemaVersion: 2,
+		PromptID:      promptID,
+		ConfigName:    config,
+		Timestamp:     ts,
+		Success:       pass,
+		GraderResults: []report.GraderResult{
+			{
+				GraderName: "correctness",
+				GraderType: "prompt",
+				Score:      score,
+				Weight:     1.0,
+				Pass:       &pass,
+			},
+		},
+	}
+	r.ScoreBreakdown = report.BuildScoreBreakdown(r.GraderResults)
+	return r
+}
+
+func summariesEqual(a, b ComparisonSummary) bool {
+	return a.Improved == b.Improved &&
+		a.Regressed == b.Regressed &&
+		a.Unchanged == b.Unchanged &&
+		math.Abs(a.AvgDelta-b.AvgDelta) < 1e-9
+}

--- a/hyoka/internal/comparison/result.go
+++ b/hyoka/internal/comparison/result.go
@@ -1,0 +1,48 @@
+// Package comparison provides config-vs-config, run-vs-run, and temporal diff
+// analysis for hyoka evaluation reports.
+//
+// ComparisonResult is the canonical, unified result type produced by every
+// comparison entry point (CLI, serve API, auto-generated run summaries). It
+// replaces the previous trio of ConfigComparison/RunComparison/TemporalComparison
+// so that the `hyoka compare` CLI and the site comparison page render
+// byte-identical data for the same inputs.
+package comparison
+
+import "time"
+
+// ComparisonKind identifies which comparison variant produced a result.
+type ComparisonKind string
+
+const (
+	// KindConfigs is a pairwise comparison of two configs' latest results
+	// across their shared prompt set.
+	KindConfigs ComparisonKind = "configs"
+	// KindRuns is a comparison of results from two specific evaluation runs.
+	KindRuns ComparisonKind = "runs"
+	// KindTemporal is a before/after comparison for a single config around a
+	// cutoff timestamp.
+	KindTemporal ComparisonKind = "temporal"
+)
+
+// ComparisonResult is the canonical comparison payload. All three comparison
+// modes (configs, runs, temporal) produce this struct. Consumers should switch
+// on Kind to interpret LabelA/LabelB appropriately:
+//
+//   - Kind == KindConfigs  → LabelA/LabelB are config names
+//   - Kind == KindRuns     → LabelA/LabelB are run IDs
+//   - Kind == KindTemporal → LabelA is the base run ID, LabelB is the latest
+//     run ID, Config names the tracked config, and Since is the cutoff
+//     timestamp.
+//
+// This type is the shared interface boundary between the comparison engine
+// and any consumer (CLI renderer, serve API JSON handler, site frontend,
+// auto-generated run summaries).
+type ComparisonResult struct {
+	Kind      ComparisonKind    `json:"kind"`
+	LabelA    string            `json:"label_a"`
+	LabelB    string            `json:"label_b"`
+	Config    string            `json:"config,omitempty"` // only set for KindTemporal
+	Since     *time.Time        `json:"since,omitempty"`  // only set for KindTemporal
+	PerPrompt []PromptDiff      `json:"per_prompt"`
+	Summary   ComparisonSummary `json:"summary"`
+}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/comparison"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/config"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/config/tool"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/criteria"
@@ -699,6 +700,23 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 		summary.PairwiseResults = pairwiseReports
 		if _, err := report.WritePairwiseReport(runID, pairwiseReports, pairwiseImpacts, e.opts.OutputDir); err != nil {
 			slog.Warn("Failed to write pairwise report", "error", err)
+		}
+	}
+
+	// Auto-generate pairwise comparisons for multi-config runs (#357). Written
+	// to {runDir}/comparisons.json so the site comparison surface can render
+	// without recomputing and is guaranteed to match what `hyoka compare`
+	// prints for the same inputs.
+	if len(summary.Results) > 0 {
+		runDir := filepath.Join(e.opts.OutputDir, runID)
+		derefReports := make([]report.EvalReport, 0, len(summary.Results))
+		for _, r := range summary.Results {
+			if r != nil {
+				derefReports = append(derefReports, *r)
+			}
+		}
+		if _, err := comparison.WriteForRun(runDir, derefReports); err != nil {
+			slog.Warn("Failed to write auto-generated comparisons", "error", err)
 		}
 	}
 

--- a/hyoka/internal/serve/dashboard.go
+++ b/hyoka/internal/serve/dashboard.go
@@ -168,6 +168,65 @@ func handleAPICompareTemporal(w http.ResponseWriter, r *http.Request, reportsDir
 	writeJSON(w, cmp)
 }
 
+// handleAPIRunComparisons returns the auto-generated comparisons for a run
+// (written by comparison.WriteForRun at end-of-run). Reads {runDir}/comparisons.json
+// if present; on miss, computes on-demand by loading the run's reports so the
+// site always gets a result even for runs that pre-date auto-generation.
+func handleAPIRunComparisons(w http.ResponseWriter, _ *http.Request, reportsDir, runID string) {
+	if strings.Contains(runID, "..") || runID == "" {
+		http.Error(w, "invalid run ID", http.StatusBadRequest)
+		return
+	}
+	runDir := filepath.Join(reportsDir, runID)
+	if info, err := os.Stat(runDir); err != nil || !info.IsDir() {
+		http.Error(w, "run not found", http.StatusNotFound)
+		return
+	}
+
+	results, err := comparison.LoadForRun(runDir)
+	if err != nil {
+		slog.Error("loading run comparisons", "error", err, "run", runID)
+		http.Error(w, "failed to load comparisons", http.StatusInternalServerError)
+		return
+	}
+	if results == nil {
+		// Legacy run without comparisons.json — compute on demand using the
+		// same engine so the response matches what end-of-run would have
+		// produced.
+		reports, err := loadRunReports(runDir)
+		if err != nil {
+			slog.Error("loading run reports", "error", err, "run", runID)
+			http.Error(w, "failed to load reports", http.StatusInternalServerError)
+			return
+		}
+		results = comparison.AutoGenerateForRun(reports)
+	}
+	if results == nil {
+		results = []comparison.ComparisonResult{}
+	}
+	writeJSON(w, results)
+}
+
+// loadRunReports walks a run directory and decodes every report.json it finds.
+func loadRunReports(runDir string) ([]report.EvalReport, error) {
+	var out []report.EvalReport
+	err := filepath.Walk(runDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || info.Name() != "report.json" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var r report.EvalReport
+		if err := json.Unmarshal(data, &r); err == nil {
+			out = append(out, r)
+		}
+		return nil
+	})
+	return out, err
+}
+
 func handleAPITrends(w http.ResponseWriter, r *http.Request, reportsDir string) {
 	q := r.URL.Query()
 	opts := trends.TrendOptions{

--- a/hyoka/internal/serve/dashboard_test.go
+++ b/hyoka/internal/serve/dashboard_test.go
@@ -226,11 +226,14 @@ var result map[string]any
 if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 t.Fatalf("failed to decode: %v", err)
 }
-if result["config_a"] != "baseline/opus" {
-t.Errorf("expected config_a baseline/opus, got %v", result["config_a"])
+if result["kind"] != "configs" {
+t.Errorf("expected kind configs, got %v", result["kind"])
 }
-if result["config_b"] != "azure-mcp/opus" {
-t.Errorf("expected config_b azure-mcp/opus, got %v", result["config_b"])
+if result["label_a"] != "baseline/opus" {
+t.Errorf("expected label_a baseline/opus, got %v", result["label_a"])
+}
+if result["label_b"] != "azure-mcp/opus" {
+t.Errorf("expected label_b azure-mcp/opus, got %v", result["label_b"])
 }
 perPrompt, ok := result["per_prompt"].([]any)
 if !ok {
@@ -295,11 +298,14 @@ var result map[string]any
 if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 t.Fatalf("failed to decode: %v", err)
 }
-if result["run_a"] != "run-000" {
-t.Errorf("expected run_a run-000, got %v", result["run_a"])
+if result["kind"] != "runs" {
+t.Errorf("expected kind runs, got %v", result["kind"])
 }
-if result["run_b"] != "run-001" {
-t.Errorf("expected run_b run-001, got %v", result["run_b"])
+if result["label_a"] != "run-000" {
+t.Errorf("expected label_a run-000, got %v", result["label_a"])
+}
+if result["label_b"] != "run-001" {
+t.Errorf("expected label_b run-001, got %v", result["label_b"])
 }
 }
 

--- a/hyoka/internal/serve/equivalence_test.go
+++ b/hyoka/internal/serve/equivalence_test.go
@@ -1,0 +1,186 @@
+package serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/comparison"
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/report"
+)
+
+// TestCLISiteEquivalence_AutoGenComparisons is the Phase 4 gate criterion
+// enforcement: the `hyoka compare` CLI and the site comparison page MUST
+// produce identical results for the same inputs. Both paths funnel through
+// comparison.CompareReports / comparison.AutoGenerateForRun — this test
+// verifies that contract holds end-to-end by comparing:
+//
+//  1. Direct call to comparison.AutoGenerateForRun(reports) (the engine used
+//     by the CLI and the auto-generator at end-of-run).
+//  2. JSON payload returned by GET /api/runs/{runID}/comparisons (the path
+//     the site frontend consumes).
+//
+// If Neo's claim that equivalence is "satisfied by construction" via the
+// shared core, these two MUST be byte-identical for the same reports.
+func TestCLISiteEquivalence_AutoGenComparisons(t *testing.T) {
+	// Arrange: build a multi-config run so AutoGenerateForRun has something
+	// to emit (requires ≥2 distinct configs).
+	dir := t.TempDir()
+	runID := "20260418-000000"
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatalf("mkdir runDir: %v", err)
+	}
+
+	pass := true
+	mkReport := func(promptID, config string, score float64) report.EvalReport {
+		r := report.EvalReport{
+			SchemaVersion: 2,
+			PromptID:      promptID,
+			ConfigName:    config,
+			Timestamp:     "2026-04-18T00:00:00Z",
+			Success:       true,
+			GraderResults: []report.GraderResult{
+				{GraderName: "correctness", GraderType: "prompt", Score: score, Weight: 1.0, Pass: &pass},
+			},
+		}
+		r.ScoreBreakdown = report.BuildScoreBreakdown(r.GraderResults)
+		return r
+	}
+
+	// Two configs × two prompts, with varied scores so the summary has
+	// non-trivial improved/regressed counts.
+	reports := []report.EvalReport{
+		mkReport("prompt-alpha", "baseline/opus", 0.6),
+		mkReport("prompt-beta", "baseline/opus", 0.8),
+		mkReport("prompt-alpha", "azure-mcp/opus", 0.9),
+		mkReport("prompt-beta", "azure-mcp/opus", 0.7),
+	}
+
+	// Write each report to disk under the run directory so the serve
+	// handler's on-demand path (loadRunReports → AutoGenerateForRun) can
+	// discover them. We deliberately do NOT write comparisons.json — that
+	// forces the API to recompute via the shared engine, which is the
+	// strictest form of equivalence test.
+	for _, r := range reports {
+		cfgDir := filepath.Join(runDir, "results", r.PromptID, filepath.FromSlash(r.ConfigName))
+		if err := os.MkdirAll(cfgDir, 0755); err != nil {
+			t.Fatalf("mkdir cfgDir: %v", err)
+		}
+		data, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal report: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cfgDir, "report.json"), data, 0644); err != nil {
+			t.Fatalf("write report: %v", err)
+		}
+	}
+
+	// Path A — direct engine call (CLI path).
+	cliResults := comparison.AutoGenerateForRun(reports)
+	if len(cliResults) == 0 {
+		t.Fatal("AutoGenerateForRun returned no results for 2-config input")
+	}
+
+	// Path B — HTTP API (site path).
+	mux := buildMux(Options{ReportsDir: dir})
+	req := httptest.NewRequest("GET", "/api/runs/"+runID+"/comparisons", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET comparisons: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var apiResults []comparison.ComparisonResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &apiResults); err != nil {
+		t.Fatalf("decode API response: %v", err)
+	}
+
+	// Assert: CLI engine output and API JSON roundtrip must be deep-equal.
+	// We roundtrip the CLI slice through JSON too so any omit/marshal
+	// asymmetry (e.g. Since pointers, omitempty) is normalized on both
+	// sides — equivalence is measured at the wire-format level, which is
+	// what the site actually consumes.
+	cliJSON, err := json.Marshal(cliResults)
+	if err != nil {
+		t.Fatalf("marshal CLI results: %v", err)
+	}
+	var cliRoundtripped []comparison.ComparisonResult
+	if err := json.Unmarshal(cliJSON, &cliRoundtripped); err != nil {
+		t.Fatalf("unmarshal CLI results: %v", err)
+	}
+
+	if !reflect.DeepEqual(cliRoundtripped, apiResults) {
+		t.Errorf("CLI and site produced divergent comparison results\nCLI:  %s\nSITE: %s",
+			string(cliJSON), rec.Body.String())
+	}
+
+	// Also assert the list is non-empty and covers the single config pair
+	// we seeded, so a silent return of [] doesn't trivially pass.
+	if len(apiResults) != 1 {
+		t.Errorf("expected 1 pairwise comparison (2 configs → 1 pair), got %d", len(apiResults))
+	}
+}
+
+// TestCLISiteEquivalence_LoadedComparisonsFile verifies the on-disk path:
+// when comparisons.json IS present (auto-generated at end-of-run), the API
+// returns exactly what was written, which is exactly what the CLI engine
+// produced. This closes the other half of the equivalence contract.
+func TestCLISiteEquivalence_LoadedComparisonsFile(t *testing.T) {
+	dir := t.TempDir()
+	runID := "20260418-000001"
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatalf("mkdir runDir: %v", err)
+	}
+
+	pass := true
+	mk := func(promptID, config string, score float64) report.EvalReport {
+		r := report.EvalReport{
+			SchemaVersion: 2, PromptID: promptID, ConfigName: config,
+			Timestamp: "2026-04-18T00:00:00Z", Success: true,
+			GraderResults: []report.GraderResult{
+				{GraderName: "g", GraderType: "prompt", Score: score, Weight: 1.0, Pass: &pass},
+			},
+		}
+		r.ScoreBreakdown = report.BuildScoreBreakdown(r.GraderResults)
+		return r
+	}
+	reports := []report.EvalReport{
+		mk("p1", "cfg-a", 0.5), mk("p1", "cfg-b", 0.9),
+		mk("p2", "cfg-a", 0.7), mk("p2", "cfg-b", 0.7),
+	}
+
+	// Write comparisons.json via the same writer used at end-of-run.
+	if _, err := comparison.WriteForRun(runDir, reports); err != nil {
+		t.Fatalf("WriteForRun: %v", err)
+	}
+
+	// CLI-equivalent: what the engine would emit right now.
+	cliResults := comparison.AutoGenerateForRun(reports)
+
+	// Site path: GET the API.
+	mux := buildMux(Options{ReportsDir: dir})
+	req := httptest.NewRequest("GET", "/api/runs/"+runID+"/comparisons", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var apiResults []comparison.ComparisonResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &apiResults); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	cliJSON, _ := json.Marshal(cliResults)
+	var cliRT []comparison.ComparisonResult
+	_ = json.Unmarshal(cliJSON, &cliRT)
+
+	if !reflect.DeepEqual(cliRT, apiResults) {
+		t.Errorf("on-disk comparisons diverged from engine output\nCLI:  %s\nSITE: %s",
+			string(cliJSON), rec.Body.String())
+	}
+}

--- a/hyoka/internal/serve/serve.go
+++ b/hyoka/internal/serve/serve.go
@@ -191,6 +191,8 @@ func handleAPIRunDetail(w http.ResponseWriter, r *http.Request, reportsDir strin
 			handleAPITimeline(w, r, reportsDir, runID)
 		case "score-breakdown":
 			handleAPIScoreBreakdown(w, r, reportsDir, runID)
+		case "comparisons":
+			handleAPIRunComparisons(w, r, reportsDir, runID)
 		default:
 			http.NotFound(w, r)
 		}

--- a/site/src/__tests__/api.test.ts
+++ b/site/src/__tests__/api.test.ts
@@ -113,7 +113,7 @@ describe("API module", () => {
   // ── fetchCompareConfigs ────────────────────────────────────────────
 
   it("fetchCompareConfigs encodes both config names", async () => {
-    mockFetchOk({ config_a: "a", config_b: "b", per_prompt: [], summary: {} });
+    mockFetchOk({ kind: "configs", label_a: "a", label_b: "b", per_prompt: [], summary: {} });
     await fetchCompareConfigs("baseline/opus", "azure-mcp/opus");
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/compare/configs?a=baseline%2Fopus&b=azure-mcp%2Fopus"

--- a/site/src/__tests__/comparison-page.test.tsx
+++ b/site/src/__tests__/comparison-page.test.tsx
@@ -28,8 +28,9 @@ const mockRuns = [
 ];
 
 const mockComparison = {
-  config_a: "baseline/claude-opus-4.6",
-  config_b: "azure-mcp/claude-opus-4.6",
+  kind: "configs",
+  label_a: "baseline/claude-opus-4.6",
+  label_b: "azure-mcp/claude-opus-4.6",
   per_prompt: [
     { prompt_id: "identity-dp-python-auth", score_a: 0.9, score_b: 0.95, delta: 0.05 },
     { prompt_id: "storage-dp-python-crud", score_a: 0.7, score_b: 0.65, delta: -0.05 },

--- a/site/src/app/components/comparison-page.tsx
+++ b/site/src/app/components/comparison-page.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { fetchRuns, fetchCompareConfigs } from "../data/api";
-import type { RunSummary, ConfigComparison, PromptDiff, GraderDiff } from "../data/types";
+import type { RunSummary, ComparisonResult, PromptDiff, GraderDiff } from "../data/types";
 import {
   Select,
   SelectContent,
@@ -228,7 +228,7 @@ export function ComparisonPage() {
   const [configNames, setConfigNames] = useState<string[]>([]);
   const [configA, setConfigA] = useState<string>("");
   const [configB, setConfigB] = useState<string>("");
-  const [comparison, setComparison] = useState<ConfigComparison | null>(null);
+  const [comparison, setComparison] = useState<ComparisonResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [runsLoading, setRunsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -543,10 +543,10 @@ export function ComparisonPage() {
                       Prompt
                     </TableHead>
                     <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      {comparison.config_a}
+                      {comparison.label_a}
                     </TableHead>
                     <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      {comparison.config_b}
+                      {comparison.label_b}
                     </TableHead>
                     <TableHead className="text-white/50" style={{ fontSize: 12 }}>
                       Delta (B − A)

--- a/site/src/app/data/api.ts
+++ b/site/src/app/data/api.ts
@@ -1,5 +1,5 @@
 import type { RunSummary, EvalReport, DocEntry, DocDetail } from "./types";
-import type { ConfigComparison } from "./types";
+import type { ComparisonResult } from "./types";
 
 const API_BASE = "";
 
@@ -59,8 +59,8 @@ export async function fetchPrompt(promptId: string): Promise<PromptInfo> {
   return fetchJSON<PromptInfo>(`/api/prompts/${encodeURIComponent(promptId)}`);
 }
 
-export async function fetchCompareConfigs(configA: string, configB: string): Promise<ConfigComparison> {
-  return fetchJSON<ConfigComparison>(
+export async function fetchCompareConfigs(configA: string, configB: string): Promise<ComparisonResult> {
+  return fetchJSON<ComparisonResult>(
     `/api/compare/configs?a=${encodeURIComponent(configA)}&b=${encodeURIComponent(configB)}`
   );
 }

--- a/site/src/app/data/types.ts
+++ b/site/src/app/data/types.ts
@@ -306,9 +306,14 @@ export interface ComparisonSummary {
   top_regressed?: PromptDiff[];
 }
 
-export interface ConfigComparison {
-  config_a: string;
-  config_b: string;
+export type ComparisonKind = "configs" | "runs" | "temporal";
+
+export interface ComparisonResult {
+  kind: ComparisonKind;
+  label_a: string;
+  label_b: string;
+  config?: string;
+  since?: string;
   per_prompt: PromptDiff[];
   summary: ComparisonSummary;
 }


### PR DESCRIPTION
## Summary

Merges the two separate comparison systems (`internal/comparison/` disk-backed CLI path and `internal/report/summary_stats.go` per-report pass/fail aggregate) into a single engine at the score-delta layer. The CLI `hyoka compare`, the `/api/compare/*` serve endpoints, and end-of-run auto-generation all now call the same core function (`comparison.CompareReports`) and produce identical JSON for identical inputs.

**Morpheus gate (0.3.1):** ✅ `hyoka compare` CLI and site comparison page produce identical results — verified by shared engine path + integration tests.

Closes #357

## Changes

### Core: single `ComparisonResult` type

- New `ComparisonResult` struct keyed on `ComparisonKind` (`configs` / `runs` / `temporal`).
- Old `ConfigComparison` / `RunComparison` / `TemporalComparison` wrapper types deleted — Trinity picks up the shared contract for #361.
- `CompareReports(kind, labelA, labelB, reportsA, reportsB)` is the in-memory core. All public entry points (`CompareConfigs`, `CompareRuns`, `TemporalDiff`, `AutoGenerateForRun`) delegate to it.

### Auto-generation during multi-config runs

- `comparison.WriteForRun(runDir, reports)` writes `comparisons.json` next to `summary.json` at end-of-run.
- Wired into `eval.engine` after `collectPairwiseReports`.
- Pairs emitted alphabetically (A<B) for deterministic output.
- Chose file-alongside over `RunSummary.Comparisons` field to avoid the `comparison → report → comparison` import cycle.

### Serve endpoint

- `GET /api/runs/{runID}/comparisons` — reads `comparisons.json` if present, or computes on-demand using the same engine for legacy runs without the file. Either path yields the same JSON the CLI prints.

### CLI simplification

- `cmd/compare.go`: three per-type render functions collapsed into one `renderComparison` keyed on `cmp.Kind`.

### Scope note: `summary_stats.PromptDeltas` retained

The issue's acceptance criterion says "Merged comparison logic replaces both `internal/comparison/` and `report/summary_stats.go`." In practice, `summary_stats.PromptDeltas` answers a different question (per-prompt pass/fail *toggle* between configs) than the score-delta machinery in `comparison` (per-grader score Δ). Unifying the *score-delta* engine is what matters for the Morpheus gate. Deleting `PromptDeltas` would remove a distinct aggregate view; replacing it with a `comparison` import would create a cycle (comparison depends on report). Left as-is; happy to revisit if the site never consumes it.

## Testing

- `go test -race ./hyoka/... -timeout 3m` — all packages pass.
- `go vet ./hyoka/...` — clean.
- New tests:
  - `comparison/inmem_test.go` — `CompareReports` table-driven across kinds; proves `AutoGenerateForRun` output matches direct-path output for identical inputs.
  - `comparison/autogen_test.go` — `WriteForRun` / `LoadForRun` round-trip + missing-file nil handling.

## Breaking changes

Internal-only package; the old wrapper type names are gone. No external consumers.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>