### PR TITLE
feat(#365): Compare page redesign

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -262,3 +262,24 @@ Implemented all requirements from R155 (docs page observations) for Phase 5 on b
 
 **Next:** Phase 6 planning will prioritize these based on dependency graph. Morpheus's review is in `.squad/reviews/phase-5-arch-review-2026-04-20T200455Z.md`.
 
+
+### Session 2026-04-20 (Phase 6 — Issue #365 Compare Page Redesign)
+
+**Branch:** `ronniegeraghty/issue-365-compare-redesign` → **PR #601** (target `phase-6`)
+
+**What shipped:**
+- Replaced static A vs B compare page with N-way group-based comparison tool inspired by devex-reviews.
+- New pure-function lib `site/src/app/lib/comparison-groups.ts` — model, catalog extraction from real eval data, filter logic (OR-within-dimension, AND-across-dimensions, empty=match-all), metric computation (pass rate / avg score / per-service / per-language / score-distribution histogram), localStorage persistence with shape validation.
+- New `group-builder.tsx` component — chip-cluster multi-select per dimension, color picker, match-count badge, collapse/expand, remove.
+- Rewrote `comparison-page.tsx` — two-column layout with groups + chart toggles on left, summary cards + configurable charts (6 chart types) on right. Edge-case banners for 0/1/empty/uneven groups.
+- Tests: 21 lib tests + 10 page tests. Full suite 99/99 green; build 6.13s.
+
+## Learnings
+
+- **Worktree discipline matters more than I thought.** The shared workdir was concurrently checked out to issue-598 by another agent (saw uncommitted .go files I didn't write); my untracked files got clobbered mid-session. Recovered by spinning up an isolated worktree at `~/projects/hyoka-365` via `git worktree add`. **Rule for Phase 6 going forward: if you suspect anyone else is working in the same root, create a worktree first.** Saved into agent-collaboration consideration.
+- **jsdom in this project doesn't expose a working `localStorage`.** Some node `--localstorage-file` flag interaction breaks both `.clear()` and `.removeItem()`. Pattern that works: install a per-test in-memory shim via `Object.defineProperty(window, "localStorage", { value: shim, configurable: true, writable: true })` in `beforeEach`. Production code is untouched — `safeLocalStorage()` falls back to a shim when `window.localStorage` is missing, which is the same defensive pattern.
+- **Recharts per-bar coloring requires `<Cell>`, not `fill` on `<Bar>`.** Tried `<Bar dataKey="value" fill={d.color}>` first — doesn't work because Bar only accepts a single fill. Correct pattern: `<Bar><Cell fill={d.color}/>...</Bar>`. For grouped breakdowns (multiple series), one `<Bar fill={...}>` per group is fine and gives a free legend.
+- **Pure-function lib + thin React orchestrator is a force multiplier for testing.** 21 fast lib tests covering all the comparison semantics (filter ANDs/ORs, score-bin boundaries, persistence round-trips, malformed-data tolerance) without ever rendering a component. The page tests are then free to focus on user-visible behavior, not arithmetic.
+- **Empty-state messaging deserves design time.** Five distinct edge cases: 0 groups, 1 group, all-empty, partial-empty, uneven counts. Each gets its own banner with appropriate severity color (sky / amber / grey). This is the difference between a tool that "works" and one users trust.
+- **Skill captured:** `.squad/skills/group-based-comparison-ui/SKILL.md` documents the pattern for any future N-way comparison UI in this codebase.
+- **Decision filed:** `.squad/decisions/inbox/trinity-issue-365-compare.md` for Scribe.

--- a/.squad/skills/group-based-comparison-ui/SKILL.md
+++ b/.squad/skills/group-based-comparison-ui/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: "group-based-comparison-ui"
+description: "Pattern for building flexible N-way comparison UIs over data with arbitrary attributes — groups defined by composable filters, configurable visualizations, localStorage persistence."
+domain: "frontend, ux, data-viz"
+confidence: "high"
+source: "earned (#365 / WI-047 — Compare page redesign, PR #601)"
+---
+
+## Context
+
+Use this skill when designing any UI that lets users compare arbitrary subsets of a dataset (e.g. eval results, telemetry, A/B cohorts) and visualize differences. Beats the typical "pick A vs B" picker because:
+
+- It scales to N groups, not just 2.
+- It composes — a "group" can be filtered on many attributes at once.
+- It survives schema growth — adding a new attribute means adding it to the catalog, not redesigning the page.
+
+## Patterns
+
+### 1. Separate the model from the renderer
+
+Put the group model, filter logic, and metric computation in a pure-function lib (`lib/<feature>-groups.ts`). The page is a thin orchestrator that:
+- Loads raw data once.
+- Holds groups + chart selection in component state.
+- Delegates filtering/metrics to the lib.
+
+This shape pays off in test density (lib tests are fast and don't need DOM) and reusability (the model can be embedded in other surfaces).
+
+### 2. Filter semantics: OR within, AND across
+
+```ts
+filters: { languages: ["python", "go"], configs: ["baseline"] }
+// → (lang ∈ {python, go}) AND (config ∈ {baseline})
+```
+
+Empty array (or missing key) = "match all" for that dimension. Document this prominently — it's the part users get wrong.
+
+### 3. Build the catalog from real data
+
+Walk the loaded dataset once and extract the distinct values per dimension. Don't list values that don't appear in the data — that's how you get phantom filter chips with zero matches.
+
+```ts
+function buildCatalog(rows: Row[]): Catalog {
+  const sets = { lang: new Set(), service: new Set(), ... };
+  for (const r of rows) {
+    if (r.lang) sets.lang.add(r.lang);
+    // ...
+  }
+  return { lang: [...sets.lang].sort(), ... };
+}
+```
+
+### 4. Group identity = name + color
+
+Each group gets a stable color from a fixed palette. Reuse that color across summary cards, chart bars, and legend entries — it becomes the user's mental "shorthand" for the group. For single-metric bar charts in recharts, use `<Cell>` to color per-bar:
+
+```tsx
+<Bar dataKey="value">
+  {data.map((d, i) => <Cell key={i} fill={d.color} />)}
+</Bar>
+```
+
+For grouped breakdowns, use one `<Bar>` per group with `fill={group.color}` — that gives you a free legend.
+
+### 5. Persist with versioned key + shape validation
+
+```ts
+const STORAGE_KEY = "myapp:comparison:v1";
+
+function load(storage = window.localStorage): State | null {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    // Filter out malformed entries — never throw.
+    return { groups: parsed.groups.filter(isValidGroup), ... };
+  } catch {
+    return null;
+  }
+}
+```
+
+`saveState` should also `try/catch` (quota / privacy mode). The `:v1` suffix gives a migration path; don't skip it.
+
+### 6. Surface every edge case explicitly
+
+Don't render an empty chart and hope the user figures it out. Each of these deserves a banner:
+- 0 groups → CTA to create one
+- 1 group → hint: "add another to compare"
+- All groups empty → warning: filters too narrow
+- Some groups empty → warning + skip those bars
+- Wildly uneven group sizes → caveat: interpret with care
+
+### 7. Configurable visualizations, not a fixed layout
+
+Let users toggle which charts they care about. Default to a sensible 2–3 chart subset. Each chart should describe itself (label + one-line description) — it doubles as a tooltip for unfamiliar metrics.
+
+## Examples
+
+- `site/src/app/lib/comparison-groups.ts` — model + filtering + metrics + persistence (~290 LOC)
+- `site/src/app/components/group-builder.tsx` — single-group editor UI
+- `site/src/app/components/comparison-page.tsx` — orchestrator + chart panels
+- `site/src/__tests__/comparison-groups.test.ts` — 21 lib tests demonstrating the test discipline this pattern enables
+
+## Anti-Patterns
+
+- **Hardcoded N=2 comparison.** Don't. The moment a user wants 3 cohorts, you're rewriting.
+- **Computed metrics inside React components.** Move them to the lib so they're testable without rendering.
+- **Schema-driven UI without a catalog.** Letting users type filter values in a free-text box leads to typos and zero-match groups. Always offer chips from the catalog.
+- **Silent localStorage failures.** Wrap save in try/catch. Wrap load in try/catch + shape validation. Never let one corrupt entry break the page.
+- **Same chart color for every group.** Defeats the entire purpose of side-by-side viz.

--- a/site/src/__tests__/comparison-groups.test.ts
+++ b/site/src/__tests__/comparison-groups.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCatalog,
+  computeMetrics,
+  evalMatchesGroup,
+  filterGroup,
+  flattenResults,
+  loadState,
+  saveState,
+  describeFilters,
+  newGroupId,
+  nextGroupColor,
+  GROUP_COLORS,
+  STORAGE_KEY,
+  type ComparisonGroup,
+} from "../app/lib/comparison-groups";
+import type { EvalResult, RunSummary } from "../app/data/types";
+
+function evalRow(over: Partial<EvalResult> = {}): EvalResult {
+  return {
+    prompt_id: "identity-dp-python-auth",
+    config_name: "baseline/claude-opus-4.6",
+    success: true,
+    review: { overall_score: 9, max_score: 10, summary: "" },
+    duration_seconds: 10,
+    prompt_metadata: {
+      service: "identity",
+      plane: "data-plane",
+      language: "python",
+      category: "auth",
+      difficulty: "basic",
+    },
+    ...over,
+  };
+}
+
+function makeRun(results: EvalResult[]): RunSummary {
+  return {
+    run_id: "r",
+    timestamp: "2026-04-21T00:00:00Z",
+    total_evaluations: results.length,
+    passed: results.filter((r) => r.success).length,
+    failed: results.filter((r) => !r.success).length,
+    errors: 0,
+    duration_seconds: 0,
+    results,
+  };
+}
+
+const sampleResults: EvalResult[] = [
+  evalRow({
+    prompt_id: "identity-dp-python-auth",
+    config_name: "baseline/claude-opus-4.6",
+    success: true,
+    review: { overall_score: 9, max_score: 10, summary: "" },
+    prompt_metadata: { service: "identity", plane: "data-plane", language: "python", category: "auth", difficulty: "basic" },
+  }),
+  evalRow({
+    prompt_id: "identity-dp-python-auth",
+    config_name: "azure-mcp/claude-opus-4.6",
+    success: true,
+    review: { overall_score: 10, max_score: 10, summary: "" },
+    prompt_metadata: { service: "identity", plane: "data-plane", language: "python", category: "auth", difficulty: "basic" },
+  }),
+  evalRow({
+    prompt_id: "storage-dp-dotnet-crud",
+    config_name: "baseline/claude-opus-4.6",
+    success: false,
+    review: { overall_score: 4, max_score: 10, summary: "" },
+    prompt_metadata: { service: "storage", plane: "data-plane", language: "dotnet", category: "crud", difficulty: "intermediate" },
+  }),
+  evalRow({
+    prompt_id: "storage-dp-dotnet-crud",
+    config_name: "azure-mcp/claude-opus-4.6",
+    success: true,
+    review: { overall_score: 8, max_score: 10, summary: "" },
+    prompt_metadata: { service: "storage", plane: "data-plane", language: "dotnet", category: "crud", difficulty: "intermediate" },
+  }),
+];
+
+describe("flattenResults / buildCatalog", () => {
+  it("flattens nested run.results", () => {
+    const runs = [makeRun(sampleResults.slice(0, 2)), makeRun(sampleResults.slice(2))];
+    expect(flattenResults(runs)).toHaveLength(4);
+  });
+
+  it("ignores runs without results", () => {
+    const runs = [makeRun(sampleResults), { ...makeRun([]), results: undefined as unknown as EvalResult[] }];
+    expect(flattenResults(runs)).toHaveLength(4);
+  });
+
+  it("builds catalog of distinct values across all dimensions, sorted", () => {
+    const cat = buildCatalog(sampleResults);
+    expect(cat.configs).toEqual(["azure-mcp/claude-opus-4.6", "baseline/claude-opus-4.6"]);
+    expect(cat.services).toEqual(["identity", "storage"]);
+    expect(cat.languages).toEqual(["dotnet", "python"]);
+    expect(cat.categories).toEqual(["auth", "crud"]);
+    expect(cat.difficulties).toEqual(["basic", "intermediate"]);
+    expect(cat.planes).toEqual(["data-plane"]);
+  });
+});
+
+describe("evalMatchesGroup / filterGroup", () => {
+  const baseGroup: ComparisonGroup = { id: "g1", name: "G1", color: "#10b981", filters: {} };
+
+  it("empty filters match all evals", () => {
+    expect(filterGroup(sampleResults, baseGroup)).toHaveLength(4);
+  });
+
+  it("filters by config_name", () => {
+    const g = { ...baseGroup, filters: { configs: ["baseline/claude-opus-4.6"] } };
+    const filtered = filterGroup(sampleResults, g);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every((r) => r.config_name === "baseline/claude-opus-4.6")).toBe(true);
+  });
+
+  it("filters by language", () => {
+    const g = { ...baseGroup, filters: { languages: ["python"] } };
+    expect(filterGroup(sampleResults, g)).toHaveLength(2);
+  });
+
+  it("AND-combines multiple dimensions", () => {
+    const g = { ...baseGroup, filters: { languages: ["python"], configs: ["baseline/claude-opus-4.6"] } };
+    expect(filterGroup(sampleResults, g)).toHaveLength(1);
+  });
+
+  it("OR-combines values within a dimension", () => {
+    const g = { ...baseGroup, filters: { languages: ["python", "dotnet"] } };
+    expect(filterGroup(sampleResults, g)).toHaveLength(4);
+  });
+
+  it("evalMatchesGroup returns false when prompt_metadata missing the filtered field", () => {
+    const r = evalRow({ prompt_metadata: undefined as any });
+    const g = { ...baseGroup, filters: { services: ["identity"] } };
+    expect(evalMatchesGroup(r, g)).toBe(false);
+  });
+});
+
+describe("computeMetrics", () => {
+  it("returns zero metrics for empty input", () => {
+    const m = computeMetrics([]);
+    expect(m.count).toBe(0);
+    expect(m.pass_rate).toBe(0);
+    expect(m.avg_score).toBe(0);
+    expect(m.avg_duration).toBe(0);
+    expect(m.score_distribution).toHaveLength(10);
+    expect(m.score_distribution.every((b) => b === 0)).toBe(true);
+  });
+
+  it("computes pass_rate, avg_score, breakdowns", () => {
+    const m = computeMetrics(sampleResults);
+    expect(m.count).toBe(4);
+    expect(m.pass_count).toBe(3);
+    expect(m.pass_rate).toBeCloseTo(0.75);
+    // (0.9 + 1.0 + 0.4 + 0.8) / 4 = 0.775
+    expect(m.avg_score).toBeCloseTo(0.775);
+    expect(m.by_service.identity).toEqual({ total: 2, passed: 2 });
+    expect(m.by_service.storage).toEqual({ total: 2, passed: 1 });
+    expect(m.by_language.python).toEqual({ total: 2, passed: 2 });
+    expect(m.by_language.dotnet).toEqual({ total: 2, passed: 1 });
+  });
+
+  it("score distribution puts 1.0 in the top bin (not overflow)", () => {
+    const r = evalRow({ review: { overall_score: 10, max_score: 10, summary: "" } });
+    const m = computeMetrics([r]);
+    expect(m.score_distribution[9]).toBe(1);
+  });
+
+  it("handles missing review max_score gracefully", () => {
+    const r = evalRow({ review: { overall_score: 0, max_score: 0, summary: "" } });
+    const m = computeMetrics([r]);
+    expect(m.avg_score).toBe(0);
+  });
+});
+
+describe("persistence", () => {
+  function memStorage(): Storage {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k) => map.get(k) ?? null,
+      setItem: (k, v) => void map.set(k, v),
+      removeItem: (k) => void map.delete(k),
+      clear: () => map.clear(),
+      key: (i) => Array.from(map.keys())[i] ?? null,
+      get length() {
+        return map.size;
+      },
+    } as Storage;
+  }
+
+  it("round-trips groups + charts through localStorage", () => {
+    const storage = memStorage();
+    const groups: ComparisonGroup[] = [
+      { id: "a", name: "A", color: "#10b981", filters: { languages: ["python"] } },
+    ];
+    saveState({ groups, charts: ["pass_rate", "avg_score"] }, storage);
+    const loaded = loadState(storage);
+    expect(loaded?.groups).toEqual(groups);
+    expect(loaded?.charts).toEqual(["pass_rate", "avg_score"]);
+  });
+
+  it("returns null for empty storage", () => {
+    expect(loadState(memStorage())).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    const s = memStorage();
+    s.setItem(STORAGE_KEY, "{not json");
+    expect(loadState(s)).toBeNull();
+  });
+
+  it("drops malformed group entries", () => {
+    const s = memStorage();
+    s.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        groups: [{ id: "ok", name: "OK", color: "#fff", filters: {} }, { bad: true }],
+        charts: ["pass_rate"],
+      })
+    );
+    const loaded = loadState(s);
+    expect(loaded?.groups).toHaveLength(1);
+    expect(loaded?.groups[0].id).toBe("ok");
+  });
+});
+
+describe("misc helpers", () => {
+  it("nextGroupColor cycles through palette", () => {
+    expect(nextGroupColor([])).toBe(GROUP_COLORS[0]);
+    expect(nextGroupColor([{} as ComparisonGroup])).toBe(GROUP_COLORS[1]);
+  });
+
+  it("newGroupId returns unique-looking strings", () => {
+    const a = newGroupId();
+    const b = newGroupId();
+    expect(a).not.toEqual(b);
+    expect(a).toMatch(/^g-/);
+  });
+
+  it("describeFilters summarizes selected dimensions", () => {
+    const g: ComparisonGroup = {
+      id: "x",
+      name: "X",
+      color: "#000",
+      filters: { languages: ["python"], services: ["identity"] },
+    };
+    const desc = describeFilters(g);
+    expect(desc).toContain("Language: python");
+    expect(desc).toContain("Service: identity");
+  });
+
+  it("describeFilters reports no filters", () => {
+    const g: ComparisonGroup = { id: "x", name: "X", color: "#000", filters: {} };
+    expect(describeFilters(g)).toMatch(/no filters/i);
+  });
+});

--- a/site/src/__tests__/comparison-page.test.tsx
+++ b/site/src/__tests__/comparison-page.test.tsx
@@ -1,15 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { ComparisonPage } from "../app/components/comparison-page";
+import { STORAGE_KEY } from "../app/lib/comparison-groups";
 
-// Mock the API module so ComparisonPage doesn't call the real backend
 vi.mock("../app/data/api", () => ({
   fetchRuns: vi.fn(),
-  fetchCompareConfigs: vi.fn(),
 }));
 
-import { fetchRuns, fetchCompareConfigs } from "../app/data/api";
+import { fetchRuns } from "../app/data/api";
 
 const mockRuns = [
   {
@@ -21,83 +20,190 @@ const mockRuns = [
     errors: 0,
     duration_seconds: 60,
     results: [
-      { prompt_id: "identity-dp-python-auth", config_name: "baseline/claude-opus-4.6", success: true, review: { overall_score: 9, max_score: 10, summary: "" }, duration_seconds: 10, prompt_metadata: { service: "identity", plane: "data-plane", language: "python", category: "auth", difficulty: "basic" } },
-      { prompt_id: "storage-dp-python-crud", config_name: "azure-mcp/claude-opus-4.6", success: true, review: { overall_score: 7, max_score: 10, summary: "" }, duration_seconds: 15, prompt_metadata: { service: "storage", plane: "data-plane", language: "python", category: "crud", difficulty: "intermediate" } },
+      {
+        prompt_id: "identity-dp-python-auth",
+        config_name: "baseline/claude-opus-4.6",
+        success: true,
+        review: { overall_score: 9, max_score: 10, summary: "" },
+        duration_seconds: 10,
+        prompt_metadata: { service: "identity", plane: "data-plane", language: "python", category: "auth", difficulty: "basic" },
+      },
+      {
+        prompt_id: "identity-dp-python-auth",
+        config_name: "azure-mcp/claude-opus-4.6",
+        success: true,
+        review: { overall_score: 10, max_score: 10, summary: "" },
+        duration_seconds: 12,
+        prompt_metadata: { service: "identity", plane: "data-plane", language: "python", category: "auth", difficulty: "basic" },
+      },
+      {
+        prompt_id: "storage-dp-dotnet-crud",
+        config_name: "baseline/claude-opus-4.6",
+        success: false,
+        review: { overall_score: 4, max_score: 10, summary: "" },
+        duration_seconds: 20,
+        prompt_metadata: { service: "storage", plane: "data-plane", language: "dotnet", category: "crud", difficulty: "intermediate" },
+      },
+      {
+        prompt_id: "storage-dp-dotnet-crud",
+        config_name: "azure-mcp/claude-opus-4.6",
+        success: true,
+        review: { overall_score: 8, max_score: 10, summary: "" },
+        duration_seconds: 18,
+        prompt_metadata: { service: "storage", plane: "data-plane", language: "dotnet", category: "crud", difficulty: "intermediate" },
+      },
     ],
   },
 ];
 
-const mockComparison = {
-  kind: "configs",
-  label_a: "baseline/claude-opus-4.6",
-  label_b: "azure-mcp/claude-opus-4.6",
-  per_prompt: [
-    { prompt_id: "identity-dp-python-auth", score_a: 0.9, score_b: 0.95, delta: 0.05 },
-    { prompt_id: "storage-dp-python-crud", score_a: 0.7, score_b: 0.65, delta: -0.05 },
-  ],
-  summary: { avg_delta: 0.0, improved: 1, regressed: 1, unchanged: 0 },
-};
+function installLocalStorageShim(): void {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+  Object.defineProperty(window, "localStorage", { value: shim, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installLocalStorageShim();
+  vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+});
+
+afterEach(() => {
+  // shim is reinstalled per-test; nothing else to do.
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ComparisonPage />
+    </MemoryRouter>
+  );
+}
 
 describe("ComparisonPage", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders the page heading after runs load", async () => {
-    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
-
-    render(
-      <MemoryRouter>
-        <ComparisonPage />
-      </MemoryRouter>
-    );
-
+    renderPage();
     await waitFor(() => {
-      expect(screen.getByText("Config Comparison")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Compare" })).toBeInTheDocument();
     });
   });
 
   it("shows loading spinner while fetching runs", () => {
-    vi.mocked(fetchRuns).mockReturnValue(new Promise(() => {})); // never resolves
-
-    render(
-      <MemoryRouter>
-        <ComparisonPage />
-      </MemoryRouter>
-    );
-
-    // The loader is present while runs load
+    vi.mocked(fetchRuns).mockReturnValue(new Promise(() => {}));
+    renderPage();
     expect(document.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it("shows config selector labels after runs load", async () => {
-    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
-
-    render(
-      <MemoryRouter>
-        <ComparisonPage />
-      </MemoryRouter>
-    );
-
+  it("shows empty state with create-first-group call to action when no groups", async () => {
+    renderPage();
     await waitFor(() => {
-      expect(screen.getByText("Config A (baseline)")).toBeInTheDocument();
-      expect(screen.getByText("Config B (comparison)")).toBeInTheDocument();
+      expect(screen.getByText(/no groups yet/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /create first group/i })).toBeInTheDocument();
     });
   });
 
-  it("shows empty state prompt before configs are selected", async () => {
-    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+  it("creates a group when 'Add group' is clicked and renders summary card", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Group 1")).toBeInTheDocument();
+      const cards = screen.getAllByTestId("summary-card");
+      expect(cards).toHaveLength(1);
+    });
+  });
 
-    render(
-      <MemoryRouter>
-        <ComparisonPage />
-      </MemoryRouter>
-    );
+  it("computes correct metrics for a group filtered by config", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+
+    await waitFor(() => screen.getByText("baseline/claude-opus-4.6"));
+    fireEvent.click(screen.getByText("baseline/claude-opus-4.6"));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Select two configurations above to see a side-by-side comparison.")
-      ).toBeInTheDocument();
+      const card = screen.getByTestId("summary-card");
+      expect(within(card).getByText("50.0%")).toBeInTheDocument();
+      expect(within(card).getByText("65.0%")).toBeInTheDocument();
+      expect(within(card).getByText("2")).toBeInTheDocument();
+    });
+  });
+
+  it("shows single-group hint when only one group is defined", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/add another to see side-by-side/i)).toBeInTheDocument();
+    });
+  });
+
+  it("warns when a group matches no evals", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+
+    await waitFor(() => screen.getByText("python"));
+    fireEvent.click(screen.getByText("python"));
+    fireEvent.click(screen.getByText("storage"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no evals match these filters/i)).toBeInTheDocument();
+    });
+  });
+
+  it("toggles charts via the visualizations panel", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+
+    await waitFor(() => expect(document.querySelector('[data-testid="chart-pass_rate"]')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /^pass rate$/i }));
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="chart-pass_rate"]')).toBeNull();
+    });
+  });
+
+  it("persists groups to localStorage and rehydrates on reload", async () => {
+    const { unmount } = renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+    await waitFor(() => screen.getByText("Group 1"));
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).toBeTruthy();
+      expect(raw).toContain("Group 1");
+    });
+
+    unmount();
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Group 1")).toBeInTheDocument();
+    });
+  });
+
+  it("removes a group when the Remove button is clicked", async () => {
+    renderPage();
+    await waitFor(() => screen.getByRole("button", { name: /add group/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add group/i }));
+    await waitFor(() => screen.getByText("Group 1"));
+
+    fireEvent.click(screen.getByRole("button", { name: /remove group/i }));
+    await waitFor(() => {
+      expect(screen.queryByText("Group 1")).not.toBeInTheDocument();
+      expect(screen.getByText(/no groups yet/i)).toBeInTheDocument();
     });
   });
 });

--- a/site/src/app/components/comparison-page.tsx
+++ b/site/src/app/components/comparison-page.tsx
@@ -1,305 +1,119 @@
-import { useState, useEffect, useMemo } from "react";
-import { fetchRuns, fetchCompareConfigs } from "../data/api";
-import type { RunSummary, ComparisonResult, PromptDiff, GraderDiff } from "../data/types";
+// Comparison page — group-based comparison tool (#365 / WI-047).
+//
+// Replaces the old A vs B config picker with a flexible system:
+//   • Users define named ComparisonGroups by filtering on any prompt or
+//     config attribute (catalog is computed from real eval data).
+//   • Multiple charts can be toggled to visualize differences across groups.
+//   • Group definitions and chart selections persist in localStorage.
+
+import { useEffect, useMemo, useState } from "react";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./ui/select";
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { GitCompareArrows, Loader2, Plus, Settings2 } from "lucide-react";
+import { fetchRuns } from "../data/api";
+import type { RunSummary } from "../data/types";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "./ui/table";
-import {
-  ArrowUpRight,
-  ArrowDownRight,
-  Minus,
-  Loader2,
-  GitCompareArrows,
-  TrendingUp,
-  TrendingDown,
-  Equal,
-  ChevronDown,
-  ChevronRight,
-  Filter,
-} from "lucide-react";
-import { motion, AnimatePresence } from "motion/react";
+  buildCatalog,
+  CHART_OPTIONS,
+  computeMetrics,
+  type ChartId,
+  type ComparisonGroup,
+  type GroupMetrics,
+  filterGroup,
+  flattenResults,
+  loadState,
+  newGroupId,
+  nextGroupColor,
+  saveState,
+} from "../lib/comparison-groups";
+import { GroupBuilder } from "./group-builder";
 
-function formatScore(score: number): string {
-  return (score * 100).toFixed(1) + "%";
+const mono = { fontFamily: "'JetBrains Mono', monospace" };
+
+const DEFAULT_CHARTS: ChartId[] = ["pass_rate", "avg_score", "by_service"];
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
 }
 
-function formatDelta(delta: number): string {
-  const pct = (delta * 100).toFixed(1);
-  if (delta > 0) return `+${pct}%`;
-  return `${pct}%`;
-}
-
-function deltaColor(delta: number): string {
-  if (delta > 0.001) return "text-emerald-400";
-  if (delta < -0.001) return "text-red-400";
-  return "text-white/40";
-}
-
-function deltaBg(delta: number): string {
-  if (delta > 0.001) return "bg-emerald-500/10";
-  if (delta < -0.001) return "bg-red-500/10";
-  return "bg-white/5";
-}
-
-function DeltaIcon({ delta }: { delta: number }) {
-  if (delta > 0.001)
-    return <ArrowUpRight className="h-3.5 w-3.5 text-emerald-400" />;
-  if (delta < -0.001)
-    return <ArrowDownRight className="h-3.5 w-3.5 text-red-400" />;
-  return <Minus className="h-3.5 w-3.5 text-white/30" />;
-}
-
-function extractConfigNames(runs: RunSummary[]): string[] {
-  const names = new Set<string>();
-  for (const run of runs) {
-    if (!run.results) continue;
-    for (const r of run.results) {
-      if (r.config_name) names.add(r.config_name);
-    }
-  }
-  return Array.from(names).sort();
-}
-
-function extractFilterValues(
-  diffs: PromptDiff[]
-): { languages: string[]; services: string[] } {
-  const languages = new Set<string>();
-  const services = new Set<string>();
-  for (const d of diffs) {
-    const parts = d.prompt_id.split("-");
-    // Pattern: {service}-{plane}-{language}-{rest}
-    if (parts.length >= 3) {
-      services.add(parts[0]);
-      // Language is after the plane abbreviation (dp/mp)
-      languages.add(parts[2]);
-    }
-  }
-  return {
-    languages: Array.from(languages).sort(),
-    services: Array.from(services).sort(),
-  };
-}
-
-function GraderDiffRow({ diff }: { diff: GraderDiff }) {
-  return (
-    <TableRow className="border-white/5 bg-white/[0.01]">
-      <TableCell className="pl-10 text-white/50" style={{ fontSize: 12 }}>
-        {diff.name}
-      </TableCell>
-      <TableCell
-        className="text-white/60"
-        style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
-      >
-        {diff.score_a.toFixed(2)}
-        <span className="ml-1.5 text-white/30">
-          {diff.pass_a ? "✓" : "✗"}
-        </span>
-      </TableCell>
-      <TableCell
-        className="text-white/60"
-        style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
-      >
-        {diff.score_b.toFixed(2)}
-        <span className="ml-1.5 text-white/30">
-          {diff.pass_b ? "✓" : "✗"}
-        </span>
-      </TableCell>
-      <TableCell>
-        <span
-          className={`inline-flex items-center gap-1 ${deltaColor(diff.delta)}`}
-          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
-        >
-          <DeltaIcon delta={diff.delta} />
-          {diff.delta > 0 ? "+" : ""}
-          {diff.delta.toFixed(2)}
-        </span>
-      </TableCell>
-    </TableRow>
-  );
-}
-
-function PromptDiffRow({ diff }: { diff: PromptDiff }) {
-  const [expanded, setExpanded] = useState(false);
-  const hasGraders = diff.grader_diffs && diff.grader_diffs.length > 0;
-  const isOneSided = diff.only_in_a || diff.only_in_b;
-
-  return (
-    <>
-      <TableRow
-        className={`cursor-pointer border-white/5 transition-colors hover:bg-white/[0.04] ${
-          hasGraders ? "" : "cursor-default"
-        }`}
-        onClick={() => hasGraders && setExpanded(!expanded)}
-      >
-        <TableCell>
-          <div className="flex items-center gap-2">
-            {hasGraders ? (
-              expanded ? (
-                <ChevronDown className="h-3.5 w-3.5 text-white/30" />
-              ) : (
-                <ChevronRight className="h-3.5 w-3.5 text-white/30" />
-              )
-            ) : (
-              <span className="w-3.5" />
-            )}
-            <span
-              className="text-emerald-400"
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 13,
-              }}
-            >
-              {diff.prompt_id}
-            </span>
-            {isOneSided && (
-              <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400" style={{ fontSize: 10 }}>
-                {diff.only_in_a ? "Only in A" : "Only in B"}
-              </span>
-            )}
-          </div>
-        </TableCell>
-        <TableCell
-          className="text-white/60"
-          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13 }}
-        >
-          {isOneSided && diff.only_in_b ? "—" : formatScore(diff.score_a)}
-        </TableCell>
-        <TableCell
-          className="text-white/60"
-          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13 }}
-        >
-          {isOneSided && diff.only_in_a ? "—" : formatScore(diff.score_b)}
-        </TableCell>
-        <TableCell>
-          {!isOneSided ? (
-            <span
-              className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 ${deltaBg(diff.delta)} ${deltaColor(diff.delta)}`}
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 13,
-              }}
-            >
-              <DeltaIcon delta={diff.delta} />
-              {formatDelta(diff.delta)}
-            </span>
-          ) : (
-            <span className="text-white/20">—</span>
-          )}
-        </TableCell>
-      </TableRow>
-      <AnimatePresence>
-        {expanded && hasGraders && (
-          <motion.tr
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-          >
-            <td colSpan={4} className="p-0">
-              <Table>
-                <TableBody>
-                  {diff.grader_diffs!.map((gd) => (
-                    <GraderDiffRow key={gd.name} diff={gd} />
-                  ))}
-                </TableBody>
-              </Table>
-            </td>
-          </motion.tr>
-        )}
-      </AnimatePresence>
-    </>
-  );
+interface NamedMetrics {
+  group: ComparisonGroup;
+  metrics: GroupMetrics;
 }
 
 export function ComparisonPage() {
   const [runs, setRuns] = useState<RunSummary[]>([]);
-  const [configNames, setConfigNames] = useState<string[]>([]);
-  const [configA, setConfigA] = useState<string>("");
-  const [configB, setConfigB] = useState<string>("");
-  const [comparison, setComparison] = useState<ComparisonResult | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [runsLoading, setRunsLoading] = useState(true);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Filters
-  const [filterLanguage, setFilterLanguage] = useState<string>("all");
-  const [filterService, setFilterService] = useState<string>("all");
+  const [groups, setGroups] = useState<ComparisonGroup[]>([]);
+  const [charts, setCharts] = useState<ChartId[]>(DEFAULT_CHARTS);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate from localStorage on mount.
+  useEffect(() => {
+    const persisted = loadState();
+    if (persisted) {
+      setGroups(persisted.groups);
+      if (persisted.charts.length > 0) setCharts(persisted.charts);
+    }
+    setHydrated(true);
+  }, []);
+
+  // Persist whenever groups or charts change (after initial hydration).
+  useEffect(() => {
+    if (!hydrated) return;
+    saveState({ groups, charts });
+  }, [groups, charts, hydrated]);
 
   useEffect(() => {
     fetchRuns()
-      .then((data) => {
-        setRuns(data);
-        setConfigNames(extractConfigNames(data));
-      })
-      .catch((e) => setError(e.message))
-      .finally(() => setRunsLoading(false));
-  }, []);
-
-  useEffect(() => {
-    if (!configA || !configB || configA === configB) {
-      setComparison(null);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    fetchCompareConfigs(configA, configB)
-      .then(setComparison)
+      .then((data) => setRuns(data))
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [configA, configB]);
+  }, []);
 
-  const filterValues = useMemo(
-    () => extractFilterValues(comparison?.per_prompt ?? []),
-    [comparison]
+  const allResults = useMemo(() => flattenResults(runs), [runs]);
+  const catalog = useMemo(() => buildCatalog(allResults), [allResults]);
+
+  const namedMetrics: NamedMetrics[] = useMemo(
+    () =>
+      groups.map((g) => ({
+        group: g,
+        metrics: computeMetrics(filterGroup(allResults, g)),
+      })),
+    [groups, allResults]
   );
 
-  const filteredDiffs = useMemo(() => {
-    if (!comparison) return [];
-    return comparison.per_prompt.filter((d) => {
-      const parts = d.prompt_id.split("-");
-      if (filterLanguage !== "all" && parts.length >= 3 && parts[2] !== filterLanguage)
-        return false;
-      if (filterService !== "all" && parts.length >= 1 && parts[0] !== filterService)
-        return false;
-      return true;
-    });
-  }, [comparison, filterLanguage, filterService]);
-
-  const filteredSummary = useMemo(() => {
-    let improved = 0,
-      regressed = 0,
-      unchanged = 0,
-      totalDelta = 0,
-      paired = 0;
-    for (const d of filteredDiffs) {
-      if (d.only_in_a || d.only_in_b) continue;
-      paired++;
-      totalDelta += d.delta;
-      if (d.delta > 0.001) improved++;
-      else if (d.delta < -0.001) regressed++;
-      else unchanged++;
-    }
-    return {
-      avg_delta: paired > 0 ? totalDelta / paired : 0,
-      improved,
-      regressed,
-      unchanged,
+  function addGroup() {
+    const next: ComparisonGroup = {
+      id: newGroupId(),
+      name: `Group ${groups.length + 1}`,
+      color: nextGroupColor(groups),
+      filters: {},
     };
-  }, [filteredDiffs]);
+    setGroups([...groups, next]);
+  }
+  function updateGroup(id: string, next: ComparisonGroup) {
+    setGroups(groups.map((g) => (g.id === id ? next : g)));
+  }
+  function removeGroup(id: string) {
+    setGroups(groups.filter((g) => g.id !== id));
+  }
+  function toggleChart(id: ChartId) {
+    setCharts((prev) => (prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]));
+  }
 
-  if (runsLoading) {
+  if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#0a0a0f]">
         <Loader2 className="h-6 w-6 animate-spin text-emerald-400" />
@@ -312,265 +126,441 @@ export function ComparisonPage() {
       className="min-h-screen bg-[#0a0a0f] px-4 py-8 sm:px-6"
       style={{ fontFamily: "'Inter', sans-serif" }}
     >
-      <div className="mx-auto max-w-6xl">
+      <div className="mx-auto max-w-7xl">
         {/* Header */}
         <div className="mb-8">
           <div className="mb-2 flex items-center gap-3">
             <GitCompareArrows className="h-6 w-6 text-emerald-400" />
-            <h1
-              className="text-white"
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: "clamp(1.5rem, 3vw, 2rem)",
-              }}
-            >
-              Config Comparison
+            <h1 className="text-white" style={{ ...mono, fontSize: "clamp(1.5rem, 3vw, 2rem)" }}>
+              Compare
             </h1>
           </div>
           <p className="text-white/40" style={{ fontSize: 14 }}>
-            Compare evaluation scores between two configurations side-by-side.
+            Define one or more groups by filtering on any property — model, service, language, plane,
+            category, or difficulty — then compare metrics across them. Group definitions persist in
+            your browser.
           </p>
         </div>
 
-        {/* Config selectors */}
-        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div>
-            <label
-              className="mb-1.5 block text-white/50"
-              style={{ fontSize: 12 }}
-            >
-              Config A (baseline)
-            </label>
-            <Select value={configA} onValueChange={setConfigA}>
-              <SelectTrigger className="border-white/10 bg-white/[0.03] text-white">
-                <SelectValue placeholder="Select config A…" />
-              </SelectTrigger>
-              <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
-                {configNames.map((name) => (
-                  <SelectItem key={name} value={name} disabled={name === configB}>
-                    {name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <label
-              className="mb-1.5 block text-white/50"
-              style={{ fontSize: 12 }}
-            >
-              Config B (comparison)
-            </label>
-            <Select value={configB} onValueChange={setConfigB}>
-              <SelectTrigger className="border-white/10 bg-white/[0.03] text-white">
-                <SelectValue placeholder="Select config B…" />
-              </SelectTrigger>
-              <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
-                {configNames.map((name) => (
-                  <SelectItem key={name} value={name} disabled={name === configA}>
-                    {name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-
-        {/* Loading */}
-        {loading && (
-          <div className="flex items-center justify-center py-16">
-            <Loader2 className="h-6 w-6 animate-spin text-emerald-400" />
-          </div>
-        )}
-
-        {/* Error */}
-        {error && !loading && (
-          <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center">
-            <p className="mb-1 text-red-400">Comparison failed</p>
-            <p className="text-white/40" style={{ fontSize: 13 }}>
+        {error && (
+          <div className="mb-6 rounded-xl border border-red-500/20 bg-red-500/5 p-4">
+            <p className="text-red-400" style={{ fontSize: 13 }}>
               {error}
             </p>
           </div>
         )}
 
-        {/* Empty state */}
-        {!loading && !error && !comparison && configA && configB && configA === configB && (
+        {allResults.length === 0 && !error && (
           <div className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center">
-            <p className="text-white/40">Please select two different configurations to compare.</p>
+            <p className="text-white/40">No evaluations available yet. Run an evaluation first.</p>
           </div>
         )}
 
-        {!loading && !error && !comparison && (!configA || !configB) && (
-          <div className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center">
-            <GitCompareArrows className="mx-auto mb-3 h-8 w-8 text-white/20" />
-            <p className="text-white/40">
-              Select two configurations above to see a side-by-side comparison.
-            </p>
-          </div>
-        )}
-
-        {/* Results */}
-        {comparison && !loading && (
-          <motion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            {/* Summary stats */}
-            <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
-                <div className="mb-1 flex items-center gap-2">
-                  <TrendingUp className="h-4 w-4 text-emerald-400" />
-                  <span className="text-white/40" style={{ fontSize: 12 }}>
-                    Avg Delta
-                  </span>
-                </div>
-                <span
-                  className={`${deltaColor(filteredSummary.avg_delta)}`}
-                  style={{
-                    fontFamily: "'JetBrains Mono', monospace",
-                    fontSize: 20,
-                  }}
-                >
-                  {formatDelta(filteredSummary.avg_delta)}
-                </span>
-              </div>
-              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
-                <div className="mb-1 flex items-center gap-2">
-                  <ArrowUpRight className="h-4 w-4 text-emerald-400" />
-                  <span className="text-white/40" style={{ fontSize: 12 }}>
-                    Improved
-                  </span>
-                </div>
-                <span
-                  className="text-emerald-400"
-                  style={{
-                    fontFamily: "'JetBrains Mono', monospace",
-                    fontSize: 20,
-                  }}
-                >
-                  {filteredSummary.improved}
-                </span>
-              </div>
-              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
-                <div className="mb-1 flex items-center gap-2">
-                  <ArrowDownRight className="h-4 w-4 text-red-400" />
-                  <span className="text-white/40" style={{ fontSize: 12 }}>
-                    Regressed
-                  </span>
-                </div>
-                <span
-                  className="text-red-400"
-                  style={{
-                    fontFamily: "'JetBrains Mono', monospace",
-                    fontSize: 20,
-                  }}
-                >
-                  {filteredSummary.regressed}
-                </span>
-              </div>
-              <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4">
-                <div className="mb-1 flex items-center gap-2">
-                  <Equal className="h-4 w-4 text-white/30" />
-                  <span className="text-white/40" style={{ fontSize: 12 }}>
-                    Unchanged
-                  </span>
-                </div>
-                <span
-                  className="text-white/50"
-                  style={{
-                    fontFamily: "'JetBrains Mono', monospace",
-                    fontSize: 20,
-                  }}
-                >
-                  {filteredSummary.unchanged}
-                </span>
-              </div>
-            </div>
-
-            {/* Filter controls */}
-            <div className="mb-4 flex flex-wrap items-center gap-3">
-              <Filter className="h-4 w-4 text-white/30" />
-              <Select value={filterService} onValueChange={setFilterService}>
-                <SelectTrigger className="w-40 border-white/10 bg-white/[0.03] text-white" size="sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
-                  <SelectItem value="all">All Services</SelectItem>
-                  {filterValues.services.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {s}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Select value={filterLanguage} onValueChange={setFilterLanguage}>
-                <SelectTrigger className="w-40 border-white/10 bg-white/[0.03] text-white" size="sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="border-white/10 bg-[#1a1a2e] text-white">
-                  <SelectItem value="all">All Languages</SelectItem>
-                  {filterValues.languages.map((l) => (
-                    <SelectItem key={l} value={l}>
-                      {l}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {(filterLanguage !== "all" || filterService !== "all") && (
+        {allResults.length > 0 && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[400px_1fr]">
+            {/* Left column: groups + chart toggles */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-white/80" style={{ ...mono, fontSize: 14 }}>
+                  Groups ({groups.length})
+                </h2>
                 <button
-                  onClick={() => {
-                    setFilterLanguage("all");
-                    setFilterService("all");
-                  }}
-                  className="rounded-md px-2 py-1 text-white/40 transition-colors hover:bg-white/5 hover:text-white/60"
+                  onClick={addGroup}
+                  className="inline-flex items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-emerald-300 transition-colors hover:bg-emerald-500/20"
                   style={{ fontSize: 12 }}
                 >
-                  Clear filters
+                  <Plus className="h-3.5 w-3.5" /> Add group
                 </button>
+              </div>
+
+              {groups.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-white/10 bg-white/[0.02] p-6 text-center">
+                  <p className="mb-3 text-white/50" style={{ fontSize: 13 }}>
+                    No groups yet. Add one to start comparing.
+                  </p>
+                  <button
+                    onClick={addGroup}
+                    className="inline-flex items-center gap-1 rounded-md bg-emerald-500/20 px-3 py-1.5 text-emerald-300 hover:bg-emerald-500/30"
+                    style={{ fontSize: 12 }}
+                  >
+                    <Plus className="h-3.5 w-3.5" /> Create first group
+                  </button>
+                </div>
+              ) : (
+                groups.map((g) => (
+                  <GroupBuilder
+                    key={g.id}
+                    group={g}
+                    catalog={catalog}
+                    matchCount={namedMetrics.find((nm) => nm.group.id === g.id)?.metrics.count ?? 0}
+                    totalCount={allResults.length}
+                    onChange={(next) => updateGroup(g.id, next)}
+                    onRemove={() => removeGroup(g.id)}
+                  />
+                ))
               )}
-              <span className="ml-auto text-white/30" style={{ fontSize: 12 }}>
-                {filteredDiffs.length} prompt{filteredDiffs.length !== 1 ? "s" : ""}
-              </span>
+
+              {/* Chart toggles */}
+              <div className="rounded-xl border border-white/8 bg-white/[0.02] p-4">
+                <div className="mb-3 flex items-center gap-2">
+                  <Settings2 className="h-4 w-4 text-white/40" />
+                  <h3 className="text-white/70" style={{ ...mono, fontSize: 13 }}>
+                    Visualizations
+                  </h3>
+                </div>
+                <div className="space-y-2">
+                  {CHART_OPTIONS.map((c) => {
+                    const on = charts.includes(c.id);
+                    return (
+                      <label
+                        key={c.id}
+                        className="flex cursor-pointer items-start gap-2 rounded-md p-1 hover:bg-white/[0.02]"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={on}
+                          onChange={() => toggleChart(c.id)}
+                          aria-label={c.label}
+                          className="mt-0.5 h-3.5 w-3.5 accent-emerald-400"
+                        />
+                        <span className="flex-1">
+                          <span className="block text-white/80" style={{ fontSize: 12 }}>
+                            {c.label}
+                          </span>
+                          <span className="block text-white/40" style={{ fontSize: 11 }}>
+                            {c.description}
+                          </span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
 
-            {/* Comparison table */}
-            <div className="overflow-hidden rounded-xl border border-white/8 bg-white/[0.02]">
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/8 hover:bg-transparent">
-                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      Prompt
-                    </TableHead>
-                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      {comparison.label_a}
-                    </TableHead>
-                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      {comparison.label_b}
-                    </TableHead>
-                    <TableHead className="text-white/50" style={{ fontSize: 12 }}>
-                      Delta (B − A)
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredDiffs.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={4} className="py-8 text-center text-white/30">
-                        No prompts match the current filters.
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    filteredDiffs.map((d) => (
-                      <PromptDiffRow key={d.prompt_id} diff={d} />
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+            {/* Right column: comparison output */}
+            <div className="space-y-6">
+              <ComparisonOutput groups={groups} metrics={namedMetrics} charts={charts} />
             </div>
-          </motion.div>
+          </div>
         )}
       </div>
     </div>
+  );
+}
+
+// ── Comparison output ────────────────────────────────────────────────
+
+function ComparisonOutput({
+  groups,
+  metrics,
+  charts,
+}: {
+  groups: ComparisonGroup[];
+  metrics: NamedMetrics[];
+  charts: ChartId[];
+}) {
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center">
+        <GitCompareArrows className="mx-auto mb-3 h-8 w-8 text-white/20" />
+        <p className="text-white/40">Add a comparison group to begin.</p>
+      </div>
+    );
+  }
+
+  const counts = metrics.map((m) => m.metrics.count);
+  const allEmpty = counts.every((c) => c === 0);
+  const someEmpty = counts.some((c) => c === 0);
+  const uneven =
+    counts.length > 1 &&
+    Math.max(...counts) > 0 &&
+    Math.min(...counts) / Math.max(...counts) < 0.5;
+
+  return (
+    <>
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {metrics.map(({ group, metrics: m }) => (
+          <SummaryCard key={group.id} group={group} metrics={m} />
+        ))}
+      </div>
+
+      {/* Notices */}
+      {groups.length === 1 && (
+        <div
+          className="rounded-md border border-sky-400/30 bg-sky-500/5 px-3 py-2 text-sky-200"
+          style={{ fontSize: 12 }}
+        >
+          Only one group defined — add another to see side-by-side comparisons.
+        </div>
+      )}
+      {allEmpty && (
+        <div
+          className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-amber-200"
+          style={{ fontSize: 12 }}
+        >
+          None of the defined groups match any evals. Adjust filters to see comparisons.
+        </div>
+      )}
+      {!allEmpty && someEmpty && (
+        <div
+          className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-amber-200"
+          style={{ fontSize: 12 }}
+        >
+          Some groups have no matching evals. Their bars are hidden from charts.
+        </div>
+      )}
+      {!allEmpty && !someEmpty && uneven && (
+        <div
+          className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-white/50"
+          style={{ fontSize: 12 }}
+        >
+          Groups have uneven eval counts ({counts.join(" / ")}). Pass-rate and average-score charts
+          are normalized, but raw counts vary — interpret with care.
+        </div>
+      )}
+
+      {/* Charts */}
+      {charts.length === 0 ? (
+        <div
+          className="rounded-xl border border-dashed border-white/10 bg-white/[0.02] p-6 text-center text-white/40"
+          style={{ fontSize: 13 }}
+        >
+          No visualizations selected. Pick at least one from the Visualizations panel.
+        </div>
+      ) : (
+        charts.map((c) => <ChartPanel key={c} chartId={c} metrics={metrics} />)
+      )}
+    </>
+  );
+}
+
+function SummaryCard({ group, metrics: m }: { group: ComparisonGroup; metrics: GroupMetrics }) {
+  return (
+    <div className="rounded-xl border border-white/8 bg-white/[0.03] p-4" data-testid="summary-card">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="h-2.5 w-2.5 rounded-full" style={{ background: group.color }} />
+        <span className="truncate text-white" style={{ ...mono, fontSize: 13 }}>
+          {group.name}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <Metric label="Pass rate" value={pct(m.pass_rate)} mono />
+        <Metric label="Avg score" value={pct(m.avg_score)} mono />
+        <Metric label="Evals" value={String(m.count)} mono />
+        <Metric label="Avg duration" value={`${m.avg_duration.toFixed(1)}s`} mono />
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value, mono: useMono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="text-white/40" style={{ fontSize: 11 }}>
+        {label}
+      </div>
+      <div className="text-white" style={useMono ? { ...mono, fontSize: 16 } : { fontSize: 16 }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// ── Chart panels ────────────────────────────────────────────────────
+
+interface ChartRow {
+  name: string;
+  [groupId: string]: string | number;
+}
+
+const tooltipStyle = {
+  background: "#1a1a2e",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: 8,
+  color: "#fff",
+  fontSize: 13,
+};
+
+function ChartPanel({ chartId, metrics }: { chartId: ChartId; metrics: NamedMetrics[] }) {
+  const opt = CHART_OPTIONS.find((c) => c.id === chartId)!;
+  const populated = metrics.filter((m) => m.metrics.count > 0);
+
+  let chart: React.ReactNode = null;
+  if (populated.length === 0) {
+    chart = (
+      <div className="flex h-32 items-center justify-center text-white/30" style={{ fontSize: 12 }}>
+        No data — none of the groups match any evals.
+      </div>
+    );
+  } else if (chartId === "pass_rate") {
+    chart = renderSingleMetricBar(populated, (m) => m.pass_rate * 100, "Pass %", true);
+  } else if (chartId === "avg_score") {
+    chart = renderSingleMetricBar(populated, (m) => m.avg_score * 100, "Score %", true);
+  } else if (chartId === "eval_count") {
+    chart = renderSingleMetricBar(populated, (m) => m.count, "Evals", false);
+  } else if (chartId === "by_service") {
+    chart = renderBreakdown(populated, "by_service");
+  } else if (chartId === "by_language") {
+    chart = renderBreakdown(populated, "by_language");
+  } else if (chartId === "score_distribution") {
+    chart = renderDistribution(populated);
+  }
+
+  return (
+    <div
+      className="rounded-xl border border-white/8 bg-white/[0.03] p-5"
+      data-testid={`chart-${chartId}`}
+    >
+      <h3 className="mb-1 text-white" style={{ ...mono, fontSize: 14 }}>
+        {opt.label}
+      </h3>
+      <p className="mb-4 text-white/40" style={{ fontSize: 12 }}>
+        {opt.description}
+      </p>
+      {chart}
+    </div>
+  );
+}
+
+function renderSingleMetricBar(
+  populated: NamedMetrics[],
+  selector: (m: GroupMetrics) => number,
+  label: string,
+  percent: boolean
+) {
+  const data = populated.map((m) => ({
+    name: m.group.name,
+    value: Number(selector(m.metrics).toFixed(2)),
+    color: m.group.color,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
+        <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+        <XAxis
+          dataKey="name"
+          tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          domain={percent ? [0, 100] : ["auto", "auto"]}
+          tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <Tooltip
+          contentStyle={tooltipStyle}
+          formatter={(v: number) => (percent ? `${v.toFixed(1)}%` : String(v))}
+        />
+        <Bar dataKey="value" name={label} radius={[6, 6, 0, 0]}>
+          {data.map((d, i) => (
+            <Cell key={i} fill={d.color} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+// Grouped breakdown chart (pass-rate per category, with one series per group).
+function renderBreakdown(populated: NamedMetrics[], dim: "by_service" | "by_language") {
+  const cats = new Set<string>();
+  for (const m of populated) for (const k of Object.keys(m.metrics[dim])) cats.add(k);
+  const sortedCats = Array.from(cats).sort();
+
+  const data: ChartRow[] = sortedCats.map((cat) => {
+    const row: ChartRow = { name: cat };
+    for (const m of populated) {
+      const stat = m.metrics[dim][cat];
+      row[m.group.id] = stat ? Number(((stat.passed / stat.total) * 100).toFixed(1)) : 0;
+    }
+    return row;
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(260, sortedCats.length * 36)}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 8 }} layout="vertical">
+        <CartesianGrid stroke="rgba(255,255,255,0.05)" horizontal={false} />
+        <XAxis
+          type="number"
+          domain={[0, 100]}
+          tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={120}
+        />
+        <Tooltip contentStyle={tooltipStyle} formatter={(v: number) => `${v.toFixed(1)}%`} />
+        <Legend wrapperStyle={{ color: "rgba(255,255,255,0.6)", fontSize: 12 }} />
+        {populated.map((m) => (
+          <Bar
+            key={m.group.id}
+            dataKey={m.group.id}
+            name={m.group.name}
+            fill={m.group.color}
+            radius={[0, 4, 4, 0]}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function renderDistribution(populated: NamedMetrics[]) {
+  const bins = [
+    "0–10%",
+    "10–20%",
+    "20–30%",
+    "30–40%",
+    "40–50%",
+    "50–60%",
+    "60–70%",
+    "70–80%",
+    "80–90%",
+    "90–100%",
+  ];
+  const data: ChartRow[] = bins.map((label, i) => {
+    const row: ChartRow = { name: label };
+    for (const m of populated) row[m.group.id] = m.metrics.score_distribution[i];
+    return row;
+  });
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
+        <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+        <XAxis
+          dataKey="name"
+          tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 10 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          allowDecimals={false}
+        />
+        <Tooltip contentStyle={tooltipStyle} />
+        <Legend wrapperStyle={{ color: "rgba(255,255,255,0.6)", fontSize: 12 }} />
+        {populated.map((m) => (
+          <Bar
+            key={m.group.id}
+            dataKey={m.group.id}
+            name={m.group.name}
+            fill={m.group.color}
+            radius={[4, 4, 0, 0]}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
   );
 }

--- a/site/src/app/components/group-builder.tsx
+++ b/site/src/app/components/group-builder.tsx
@@ -1,0 +1,177 @@
+// GroupBuilder — UI for creating/editing a single ComparisonGroup.
+//
+// Shows a name input, a color swatch, and a multi-select chip cluster for each
+// filter dimension. Empty selection in a dimension means "match all".
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, X, Trash2 } from "lucide-react";
+import {
+  type ComparisonGroup,
+  type FilterCatalog,
+  type FilterDimension,
+  FILTER_DIMENSIONS,
+  GROUP_COLORS,
+  describeFilters,
+} from "../lib/comparison-groups";
+
+interface Props {
+  group: ComparisonGroup;
+  catalog: FilterCatalog;
+  matchCount: number;
+  totalCount: number;
+  onChange: (next: ComparisonGroup) => void;
+  onRemove: () => void;
+}
+
+export function GroupBuilder({ group, catalog, matchCount, totalCount, onChange, onRemove }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  function setName(name: string) {
+    onChange({ ...group, name });
+  }
+  function setColor(color: string) {
+    onChange({ ...group, color });
+  }
+  function toggleValue(dim: FilterDimension, value: string) {
+    const current = group.filters[dim] ?? [];
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+    onChange({ ...group, filters: { ...group.filters, [dim]: next } });
+  }
+  function clearDim(dim: FilterDimension) {
+    const next = { ...group.filters };
+    delete next[dim];
+    onChange({ ...group, filters: next });
+  }
+
+  const empty = matchCount === 0;
+
+  return (
+    <div
+      className="rounded-xl border bg-white/[0.02] p-4"
+      style={{ borderColor: empty ? "rgba(245, 158, 11, 0.4)" : "rgba(255,255,255,0.08)" }}
+      data-testid="group-card"
+    >
+      {/* Header row */}
+      <div className="flex items-center gap-3">
+        <div
+          className="h-3 w-3 shrink-0 rounded-full"
+          style={{ background: group.color }}
+          aria-label={`Group color ${group.color}`}
+        />
+        <input
+          aria-label="Group name"
+          value={group.name}
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1 rounded-md border border-white/10 bg-white/[0.03] px-2 py-1 text-white outline-none focus:border-emerald-400/40"
+          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13 }}
+        />
+        <span
+          className={`rounded-md px-2 py-1 ${empty ? "bg-amber-500/10 text-amber-300" : "bg-white/5 text-white/50"}`}
+          style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11 }}
+          title={empty ? "No evals match this group's filters" : "Matching evals out of total"}
+        >
+          {matchCount} / {totalCount}
+        </span>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          aria-label={expanded ? "Collapse group" : "Expand group"}
+          className="rounded-md p-1 text-white/40 hover:bg-white/5 hover:text-white/80"
+        >
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </button>
+        <button
+          onClick={onRemove}
+          aria-label="Remove group"
+          className="rounded-md p-1 text-white/40 hover:bg-red-500/10 hover:text-red-400"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Filter summary line — visible when collapsed */}
+      {!expanded && (
+        <p className="mt-2 text-white/40" style={{ fontSize: 12 }}>
+          {describeFilters(group)}
+        </p>
+      )}
+
+      {/* Filter editors */}
+      {expanded && (
+        <div className="mt-4 space-y-3">
+          {/* Color picker */}
+          <div className="flex items-center gap-2">
+            <span className="text-white/40" style={{ fontSize: 11 }}>
+              Color
+            </span>
+            <div className="flex gap-1.5">
+              {GROUP_COLORS.map((c) => (
+                <button
+                  key={c}
+                  onClick={() => setColor(c)}
+                  aria-label={`Pick color ${c}`}
+                  className={`h-5 w-5 rounded-full transition-transform hover:scale-110 ${
+                    c === group.color ? "ring-2 ring-white/50 ring-offset-2 ring-offset-[#0a0a0f]" : ""
+                  }`}
+                  style={{ background: c }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {FILTER_DIMENSIONS.map((dim) => {
+            const values = catalog[dim.key];
+            const selected = group.filters[dim.key] ?? [];
+            if (values.length === 0) return null;
+            return (
+              <div key={dim.key}>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="text-white/50" style={{ fontSize: 12 }}>
+                    {dim.label}
+                    {selected.length > 0 && (
+                      <span className="ml-1.5 text-white/30">({selected.length})</span>
+                    )}
+                  </span>
+                  {selected.length > 0 && (
+                    <button
+                      onClick={() => clearDim(dim.key)}
+                      className="text-white/30 transition-colors hover:text-white/60"
+                      style={{ fontSize: 11 }}
+                    >
+                      <X className="inline h-3 w-3" /> Clear
+                    </button>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {values.map((v) => {
+                    const isOn = selected.includes(v);
+                    return (
+                      <button
+                        key={v}
+                        onClick={() => toggleValue(dim.key, v)}
+                        aria-pressed={isOn}
+                        className={`rounded-md border px-2 py-0.5 transition-colors ${
+                          isOn
+                            ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+                            : "border-white/10 bg-white/[0.03] text-white/50 hover:border-white/20 hover:text-white/80"
+                        }`}
+                        style={{ fontSize: 11, fontFamily: "'JetBrains Mono', monospace" }}
+                      >
+                        {v}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+
+          {empty && (
+            <p className="rounded-md bg-amber-500/5 px-3 py-2 text-amber-300" style={{ fontSize: 12 }}>
+              No evals match these filters. Loosen a dimension or pick different values.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/app/lib/comparison-groups.ts
+++ b/site/src/app/lib/comparison-groups.ts
@@ -1,0 +1,278 @@
+// Group-based comparison model and pure helpers.
+//
+// A ComparisonGroup is a named, filtered subset of evaluation results.
+// Users define multiple groups and the comparison page renders configurable
+// visualizations comparing metrics across those groups.
+//
+// All functions here are pure — they take RunSummary[] (already loaded by
+// the page) and produce derived data. No fetching, no React.
+
+import type { RunSummary, EvalResult } from "../data/types";
+
+export type FilterDimension =
+  | "configs"
+  | "services"
+  | "languages"
+  | "planes"
+  | "categories"
+  | "difficulties";
+
+export const FILTER_DIMENSIONS: { key: FilterDimension; label: string }[] = [
+  { key: "configs", label: "Config" },
+  { key: "services", label: "Service" },
+  { key: "languages", label: "Language" },
+  { key: "planes", label: "Plane" },
+  { key: "categories", label: "Category" },
+  { key: "difficulties", label: "Difficulty" },
+];
+
+export type GroupFilters = Partial<Record<FilterDimension, string[]>>;
+
+export interface ComparisonGroup {
+  id: string;
+  name: string;
+  color: string;
+  filters: GroupFilters;
+}
+
+export type ChartId =
+  | "pass_rate"
+  | "avg_score"
+  | "by_service"
+  | "by_language"
+  | "score_distribution"
+  | "eval_count";
+
+export const CHART_OPTIONS: { id: ChartId; label: string; description: string }[] = [
+  { id: "pass_rate", label: "Pass Rate", description: "Percent of evals where pass=true." },
+  { id: "avg_score", label: "Average Score", description: "Mean review score (0–100%)." },
+  { id: "by_service", label: "Pass Rate by Service", description: "Pass rate broken down per service." },
+  { id: "by_language", label: "Pass Rate by Language", description: "Pass rate broken down per language." },
+  { id: "score_distribution", label: "Score Distribution", description: "Histogram of eval scores in 10% bins." },
+  { id: "eval_count", label: "Eval Count", description: "Number of matching evals per group." },
+];
+
+// Visually distinct accent palette. Cycled when more groups than colors.
+export const GROUP_COLORS = [
+  "#10b981", // emerald
+  "#38bdf8", // sky
+  "#a78bfa", // violet
+  "#f59e0b", // amber
+  "#f472b6", // pink
+  "#22d3ee", // cyan
+  "#fb7185", // rose
+  "#84cc16", // lime
+];
+
+export function nextGroupColor(existing: ComparisonGroup[]): string {
+  return GROUP_COLORS[existing.length % GROUP_COLORS.length];
+}
+
+// ── Catalog extraction ─────────────────────────────────────────────
+
+export interface FilterCatalog {
+  configs: string[];
+  services: string[];
+  languages: string[];
+  planes: string[];
+  categories: string[];
+  difficulties: string[];
+}
+
+export function flattenResults(runs: RunSummary[]): EvalResult[] {
+  const out: EvalResult[] = [];
+  for (const run of runs) {
+    if (!run.results) continue;
+    for (const r of run.results) out.push(r);
+  }
+  return out;
+}
+
+export function buildCatalog(results: EvalResult[]): FilterCatalog {
+  const configs = new Set<string>();
+  const services = new Set<string>();
+  const languages = new Set<string>();
+  const planes = new Set<string>();
+  const categories = new Set<string>();
+  const difficulties = new Set<string>();
+
+  for (const r of results) {
+    if (r.config_name) configs.add(r.config_name);
+    const m = r.prompt_metadata;
+    if (m?.service) services.add(m.service);
+    if (m?.language) languages.add(m.language);
+    if (m?.plane) planes.add(m.plane);
+    if (m?.category) categories.add(m.category);
+    if (m?.difficulty) difficulties.add(m.difficulty);
+  }
+  const sort = (s: Set<string>) => Array.from(s).sort();
+  return {
+    configs: sort(configs),
+    services: sort(services),
+    languages: sort(languages),
+    planes: sort(planes),
+    categories: sort(categories),
+    difficulties: sort(difficulties),
+  };
+}
+
+// ── Group filtering ────────────────────────────────────────────────
+
+function passesFilter(values: string[] | undefined, candidate: string | undefined): boolean {
+  if (!values || values.length === 0) return true; // empty filter = match-all
+  if (!candidate) return false;
+  return values.includes(candidate);
+}
+
+export function evalMatchesGroup(r: EvalResult, group: ComparisonGroup): boolean {
+  const f = group.filters;
+  if (!passesFilter(f.configs, r.config_name)) return false;
+  const m = r.prompt_metadata;
+  if (!passesFilter(f.services, m?.service)) return false;
+  if (!passesFilter(f.languages, m?.language)) return false;
+  if (!passesFilter(f.planes, m?.plane)) return false;
+  if (!passesFilter(f.categories, m?.category)) return false;
+  if (!passesFilter(f.difficulties, m?.difficulty)) return false;
+  return true;
+}
+
+export function filterGroup(results: EvalResult[], group: ComparisonGroup): EvalResult[] {
+  return results.filter((r) => evalMatchesGroup(r, group));
+}
+
+// ── Metric computation ─────────────────────────────────────────────
+
+function safeScore(r: EvalResult): number {
+  const m = r.review?.max_score ?? 0;
+  if (!m) return 0;
+  return r.review.overall_score / m;
+}
+
+export interface GroupMetrics {
+  count: number;
+  pass_count: number;
+  pass_rate: number; // 0..1
+  avg_score: number; // 0..1
+  avg_duration: number; // seconds
+  by_service: Record<string, { total: number; passed: number }>;
+  by_language: Record<string, { total: number; passed: number }>;
+  score_distribution: number[]; // length 10, bins 0–10%, …, 90–100%
+}
+
+export function computeMetrics(results: EvalResult[]): GroupMetrics {
+  const byService: Record<string, { total: number; passed: number }> = {};
+  const byLanguage: Record<string, { total: number; passed: number }> = {};
+  const dist = new Array(10).fill(0) as number[];
+
+  let scoreSum = 0;
+  let durationSum = 0;
+  let passCount = 0;
+
+  for (const r of results) {
+    const score = safeScore(r);
+    scoreSum += score;
+    durationSum += r.duration_seconds || 0;
+    if (r.success) passCount++;
+
+    const svc = r.prompt_metadata?.service || "unknown";
+    const lang = r.prompt_metadata?.language || "unknown";
+    byService[svc] ??= { total: 0, passed: 0 };
+    byService[svc].total++;
+    if (r.success) byService[svc].passed++;
+    byLanguage[lang] ??= { total: 0, passed: 0 };
+    byLanguage[lang].total++;
+    if (r.success) byLanguage[lang].passed++;
+
+    // Histogram bin 0..9. Score 1.0 falls in last bin.
+    let bin = Math.floor(score * 10);
+    if (bin < 0) bin = 0;
+    if (bin > 9) bin = 9;
+    dist[bin]++;
+  }
+
+  const n = results.length;
+  return {
+    count: n,
+    pass_count: passCount,
+    pass_rate: n > 0 ? passCount / n : 0,
+    avg_score: n > 0 ? scoreSum / n : 0,
+    avg_duration: n > 0 ? durationSum / n : 0,
+    by_service: byService,
+    by_language: byLanguage,
+    score_distribution: dist,
+  };
+}
+
+// ── Persistence ────────────────────────────────────────────────────
+
+export const STORAGE_KEY = "hyoka:comparison:v1";
+
+export interface PersistedState {
+  groups: ComparisonGroup[];
+  charts: ChartId[];
+}
+
+export function loadState(storage: Storage = safeLocalStorage()): PersistedState | null {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedState;
+    if (!parsed || !Array.isArray(parsed.groups) || !Array.isArray(parsed.charts)) return null;
+    // Lightweight shape validation; drop anything malformed.
+    const groups = parsed.groups.filter(
+      (g) =>
+        g &&
+        typeof g.id === "string" &&
+        typeof g.name === "string" &&
+        typeof g.color === "string" &&
+        g.filters &&
+        typeof g.filters === "object"
+    );
+    return { groups, charts: parsed.charts.filter((c) => typeof c === "string") as ChartId[] };
+  } catch {
+    return null;
+  }
+}
+
+export function saveState(state: PersistedState, storage: Storage = safeLocalStorage()): void {
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Quota / privacy mode — silently ignore. Comparison still works in-memory.
+  }
+}
+
+function safeLocalStorage(): Storage {
+  if (typeof window === "undefined" || !window.localStorage) {
+    // Test/SSR fallback: an in-memory shim.
+    const store = new Map<string, string>();
+    return {
+      getItem: (k) => store.get(k) ?? null,
+      setItem: (k, v) => void store.set(k, v),
+      removeItem: (k) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  }
+  return window.localStorage;
+}
+
+// ── ID helpers ─────────────────────────────────────────────────────
+
+export function newGroupId(): string {
+  return `g-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function describeFilters(g: ComparisonGroup): string {
+  const parts: string[] = [];
+  for (const dim of FILTER_DIMENSIONS) {
+    const vals = g.filters[dim.key];
+    if (vals && vals.length > 0) {
+      parts.push(`${dim.label}: ${vals.join(", ")}`);
+    }
+  }
+  return parts.length > 0 ? parts.join(" · ") : "No filters (matches all evals)";
+}


### PR DESCRIPTION
Closes #365 (WI-047).

## Summary

Replaces the static A vs B config picker with a configurable, group-based comparison tool inspired by the devex-reviews site. Users define named comparison groups by filtering on any prompt or config attribute, choose which visualizations to render, and have those definitions persisted across reloads via localStorage.

## What's new

**Group model** (`site/src/app/lib/comparison-groups.ts`)
- `ComparisonGroup`: id, name, color, filters across configs / services / languages / planes / categories / difficulties
- Filter semantics: values within a dimension are OR-combined; dimensions are AND-combined; an empty dimension means "match all"
- Catalog auto-built from real eval data via `fetchRuns()` — only attribute values that actually appear in any run are offered as filter chips
- Pure helpers: `buildCatalog`, `filterGroup`, `computeMetrics`, `loadState`, `saveState`

**GroupBuilder UI** (`site/src/app/components/group-builder.tsx`)
- Inline name editor + color swatch picker
- Chip-cluster multi-select per filter dimension with selected count + clear-dimension button
- Match-count badge (e.g. `12 / 247`); turns amber when zero
- Collapse/expand + remove

**ComparisonPage** (`site/src/app/components/comparison-page.tsx`)
- Two-column layout: groups + visualization toggles on the left, summary cards + charts on the right
- Per-group summary card: pass rate, avg score, eval count, avg duration
- Configurable charts (toggle on/off):
  - Pass Rate (vertical bar, group-colored)
  - Average Score (vertical bar, group-colored)
  - Eval Count (vertical bar, group-colored)
  - Pass Rate by Service (horizontal grouped bar, one series per group)
  - Pass Rate by Language (horizontal grouped bar)
  - Score Distribution (histogram, 10% bins)
- Edge-case notices: single-group hint, all-empty warning, partial-empty warning, uneven-counts caveat

**Persistence**
- `localStorage` key `hyoka:comparison:v1`
- Shape-validated on load — malformed entries silently dropped, page falls back to defaults

## Acceptance criteria

- [x] Group-based comparison system
- [x] Group builder UI
- [x] Configurable chart selection
- [x] Groups persisted to localStorage
- [x] `cd site && npm run build && npm test` passes (99/99 tests, build clean in 6.13s)

## Test coverage

- `comparison-groups.test.ts` (21 tests) — pure-function lib coverage: catalog extraction, filter semantics (AND/OR/empty), metric correctness, score-distribution boundary (1.0 → bin 9), persistence round-trip + malformed-data handling
- `comparison-page.test.tsx` (10 tests) — page heading, loading, empty state, add/remove group, computed metrics for filtered group (50% pass / 65% avg / 2 evals), single-group hint, no-match warning, chart toggling, localStorage rehydration

## Notes for reviewers

- The legacy `fetchCompareConfigs` API client method is left in `api.ts` for now — no other components reference it but I didn't want to widen scope by removing the backend endpoint. Happy to clean that up in a follow-up if Morpheus or Switch want.
- jsdom in this project doesn't expose a working `localStorage` (some node flag interaction); the page test installs a per-test in-memory shim via `Object.defineProperty`. The production code uses real `window.localStorage` and gracefully no-ops when unavailable.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>