### PR TITLE
feat(#600): Run-level filter system on site

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -283,3 +283,17 @@ Implemented all requirements from R155 (docs page observations) for Phase 5 on b
 - **Empty-state messaging deserves design time.** Five distinct edge cases: 0 groups, 1 group, all-empty, partial-empty, uneven counts. Each gets its own banner with appropriate severity color (sky / amber / grey). This is the difference between a tool that "works" and one users trust.
 - **Skill captured:** `.squad/skills/group-based-comparison-ui/SKILL.md` documents the pattern for any future N-way comparison UI in this codebase.
 - **Decision filed:** `.squad/decisions/inbox/trinity-issue-365-compare.md` for Scribe.
+
+### Session 2026-04-21 (#600 — R146/R147 Run-Level Filter System)
+
+Built the filter UI for the runs page. PR targets `phase-6` from worktree `hyoka-600`.
+
+- **Run-level filtering, not eval-level.** The runs page lists runs; flattening it into eval cards would change its identity. So a run matches when each active filter dimension finds at least one matching eval inside it. The run-detail page still does its own per-eval filtering — that's the right surface for that.
+- **Filter semantics inherited from `group-based-comparison-ui`.** OR within a dimension, AND across dimensions, empty = match-all. Documenting this once in the skill saves re-litigating it per page.
+- **Status precedence: errors > failing > passing.** A run with both errors and failures is `errors` only. This avoids double-counting in the Status filter and matches how users think ("show me the broken runs").
+- **URL is the source of truth, not React state.** `useSearchParams` + `setSearchParams(..., { replace: true })` so reload/share both work and history doesn't fill up with intermediate filter states. Keys: `config`, `lang`, `status` (comma-joined).
+- **Reusable `MultiSelectFilter` primitive** at `components/ui/multi-select-filter.tsx` — outside-click + Escape close, ARIA listbox roles, "N selected" summary when >1. Other pages (prompts, dashboard) can adopt without copying state machinery.
+- **Pure-function lib pattern again.** All matching logic in `lib/run-filters.ts`. 16 lib tests + extended runs-page DOM tests = 25 total new tests. Lib tests run in milliseconds with no React tree.
+- **Catalog built from real data.** `buildCatalog` walks every run's `results[]` and only surfaces statuses that actually appear. No phantom filter chips.
+- **Tests gotcha:** When asserting filter results in the DOM, the timestamp text (`Mar 28, 2026`) is the most stable identifier per card — `run_id` doesn't appear in the run card UI.
+- **Decision filed:** `.squad/decisions/inbox/trinity-issue-600-filters.md`.

--- a/site/src/__tests__/run-filters.test.ts
+++ b/site/src/__tests__/run-filters.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyFilters,
+  applyFiltersToSearchParams,
+  buildCatalog,
+  deriveFacets,
+  deriveStatus,
+  EMPTY_FILTERS,
+  filtersFromSearchParams,
+  hasActiveFilters,
+  runMatches,
+  toggleValue,
+} from "../app/lib/run-filters";
+import type { RunSummary, EvalResult } from "../app/data/types";
+
+function evalResult(opts: {
+  config?: string;
+  language?: string;
+  success?: boolean;
+}): EvalResult {
+  return {
+    prompt_id: "p",
+    config_name: opts.config ?? "baseline/claude-opus-4.6",
+    success: opts.success ?? true,
+    review: { overall_score: 0, max_score: 0, summary: "" },
+    duration_seconds: 0,
+    prompt_metadata: {
+      service: "identity",
+      plane: "data-plane",
+      language: opts.language ?? "python",
+      category: "auth",
+      difficulty: "easy",
+    },
+  };
+}
+
+function run(opts: {
+  id: string;
+  passed?: number;
+  failed?: number;
+  errors?: number;
+  results?: EvalResult[];
+}): RunSummary {
+  const results = opts.results ?? [];
+  return {
+    run_id: opts.id,
+    timestamp: "2026-04-01T00:00:00Z",
+    total_evaluations: results.length,
+    passed: opts.passed ?? results.length,
+    failed: opts.failed ?? 0,
+    errors: opts.errors ?? 0,
+    duration_seconds: 1,
+    results,
+  };
+}
+
+describe("deriveStatus", () => {
+  it("flags errors before failures", () => {
+    expect(deriveStatus(run({ id: "a", failed: 1, errors: 1 }))).toBe("errors");
+  });
+  it("returns failing when any failed and no errors", () => {
+    expect(deriveStatus(run({ id: "a", passed: 1, failed: 1 }))).toBe("failing");
+  });
+  it("returns passing when no failures or errors", () => {
+    expect(deriveStatus(run({ id: "a", passed: 2 }))).toBe("passing");
+  });
+});
+
+describe("deriveFacets", () => {
+  it("collects unique configs and languages from results", () => {
+    const r = run({
+      id: "a",
+      results: [
+        evalResult({ config: "c1", language: "python" }),
+        evalResult({ config: "c2", language: "go" }),
+        evalResult({ config: "c1", language: "python" }),
+      ],
+    });
+    const f = deriveFacets(r);
+    expect([...f.configs].sort()).toEqual(["c1", "c2"]);
+    expect([...f.languages].sort()).toEqual(["go", "python"]);
+  });
+
+  it("handles missing results array", () => {
+    const r: RunSummary = {
+      run_id: "x",
+      timestamp: "",
+      total_evaluations: 0,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      duration_seconds: 0,
+      results: undefined as unknown as EvalResult[],
+    };
+    const f = deriveFacets(r);
+    expect(f.configs.size).toBe(0);
+    expect(f.languages.size).toBe(0);
+  });
+});
+
+describe("buildCatalog", () => {
+  it("returns sorted unique values across runs and only present statuses", () => {
+    const runs = [
+      run({
+        id: "a",
+        passed: 1,
+        results: [evalResult({ config: "c2", language: "python" })],
+      }),
+      run({
+        id: "b",
+        passed: 0,
+        failed: 1,
+        results: [evalResult({ config: "c1", language: "go", success: false })],
+      }),
+    ];
+    const cat = buildCatalog(runs);
+    expect(cat.configs).toEqual(["c1", "c2"]);
+    expect(cat.languages).toEqual(["go", "python"]);
+    expect(cat.statuses).toEqual(["passing", "failing"]);
+  });
+});
+
+describe("runMatches & applyFilters", () => {
+  const runs = [
+    run({
+      id: "py-pass",
+      results: [evalResult({ config: "baseline", language: "python" })],
+    }),
+    run({
+      id: "go-fail",
+      passed: 0,
+      failed: 1,
+      results: [evalResult({ config: "azure-mcp", language: "go", success: false })],
+    }),
+    run({
+      id: "mixed",
+      passed: 1,
+      failed: 1,
+      results: [
+        evalResult({ config: "baseline", language: "python" }),
+        evalResult({ config: "azure-mcp", language: "dotnet", success: false }),
+      ],
+    }),
+  ];
+
+  it("returns all runs when no filters set", () => {
+    expect(applyFilters(runs, EMPTY_FILTERS)).toHaveLength(3);
+  });
+
+  it("filters by language with OR semantics within dimension", () => {
+    const out = applyFilters(runs, { ...EMPTY_FILTERS, languages: ["go", "dotnet"] });
+    expect(out.map((r) => r.run_id)).toEqual(["go-fail", "mixed"]);
+  });
+
+  it("ANDs across dimensions: config AND status", () => {
+    const out = applyFilters(runs, {
+      configs: ["baseline"],
+      languages: [],
+      statuses: ["passing"],
+    });
+    expect(out.map((r) => r.run_id)).toEqual(["py-pass"]);
+  });
+
+  it("matches when run contains at least one eval per dimension", () => {
+    // mixed has both a baseline+python eval AND an azure-mcp+dotnet eval.
+    // Filtering for baseline + dotnet matches because each dimension matches
+    // at the run level (any-of), even though no single eval has both.
+    expect(
+      runMatches(runs[2], {
+        configs: ["baseline"],
+        languages: ["dotnet"],
+        statuses: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("excludes runs whose status doesn't match", () => {
+    const out = applyFilters(runs, {
+      configs: [],
+      languages: [],
+      statuses: ["failing"],
+    });
+    expect(out.map((r) => r.run_id)).toEqual(["go-fail", "mixed"]);
+  });
+});
+
+describe("hasActiveFilters & toggleValue", () => {
+  it("hasActiveFilters reports correctly", () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false);
+    expect(hasActiveFilters({ ...EMPTY_FILTERS, configs: ["x"] })).toBe(true);
+  });
+  it("toggleValue adds and removes", () => {
+    expect(toggleValue<string>([], "a")).toEqual(["a"]);
+    expect(toggleValue<string>(["a", "b"], "a")).toEqual(["b"]);
+  });
+});
+
+describe("URL serialization", () => {
+  it("round-trips filters through URLSearchParams", () => {
+    const original = {
+      configs: ["baseline/claude-opus-4.6", "azure-mcp/claude-opus-4.6"],
+      languages: ["python"],
+      statuses: ["failing"] as const,
+    };
+    const params = applyFiltersToSearchParams(new URLSearchParams(), {
+      ...original,
+      statuses: [...original.statuses],
+    });
+    const decoded = filtersFromSearchParams(params);
+    expect(decoded.configs).toEqual(original.configs);
+    expect(decoded.languages).toEqual(original.languages);
+    expect(decoded.statuses).toEqual(["failing"]);
+  });
+
+  it("removes empty dimensions from URL", () => {
+    const params = new URLSearchParams("config=x&lang=python&status=passing");
+    applyFiltersToSearchParams(params, EMPTY_FILTERS);
+    expect(params.toString()).toBe("");
+  });
+
+  it("ignores unknown statuses", () => {
+    const params = new URLSearchParams("status=failing,bogus");
+    const decoded = filtersFromSearchParams(params);
+    expect(decoded.statuses).toEqual(["failing"]);
+  });
+});

--- a/site/src/__tests__/runs-page.test.tsx
+++ b/site/src/__tests__/runs-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { RunsPage } from "../app/components/runs-page";
 
@@ -8,6 +8,23 @@ vi.mock("../app/data/api", () => ({
 }));
 
 import { fetchRuns } from "../app/data/api";
+
+function evalRow(opts: { config: string; language: string; success: boolean }) {
+  return {
+    prompt_id: "p",
+    config_name: opts.config,
+    success: opts.success,
+    review: { overall_score: 0, max_score: 0, summary: "" },
+    duration_seconds: 0,
+    prompt_metadata: {
+      service: "identity",
+      plane: "data-plane",
+      language: opts.language,
+      category: "auth",
+      difficulty: "easy",
+    },
+  };
+}
 
 const mockRuns = [
   {
@@ -18,7 +35,7 @@ const mockRuns = [
     failed: 1,
     errors: 1,
     duration_seconds: 120.5,
-    results: [],
+    results: [evalRow({ config: "baseline/claude-opus-4.6", language: "python", success: true })],
   },
   {
     run_id: "run-def456",
@@ -28,7 +45,7 @@ const mockRuns = [
     failed: 0,
     errors: 0,
     duration_seconds: 55.3,
-    results: [],
+    results: [evalRow({ config: "azure-mcp/claude-opus-4.6", language: "go", success: true })],
   },
 ];
 
@@ -137,5 +154,82 @@ describe("RunsPage", () => {
     expect(unknownElements.length).toBeGreaterThanOrEqual(1);
     // Pass rate should show 0.0% (not NaN%)
     expect(screen.getByText("0.0%")).toBeInTheDocument();
+  });
+
+  it("renders filter bar populated from run data", async () => {
+    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+
+    render(
+      <MemoryRouter>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Filter by Config")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Filter by Language")).toBeInTheDocument();
+    expect(screen.getByLabelText("Filter by Status")).toBeInTheDocument();
+    // Initially shows total run count
+    expect(screen.getByText("2 runs")).toBeInTheDocument();
+  });
+
+  it("filters runs when a language is selected and shows reset", async () => {
+    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+
+    render(
+      <MemoryRouter>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("2 runs")).toBeInTheDocument());
+
+    // Open the language dropdown and select "go"
+    fireEvent.click(screen.getByLabelText("Filter by Language"));
+    const listbox = await screen.findByRole("listbox", { name: "Language" });
+    fireEvent.click(within(listbox).getByRole("option", { name: "go" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 of 2")).toBeInTheDocument();
+    });
+    // run-def456 is the go run; abc123 (python) should be hidden
+    expect(screen.getByText(/Mar 28, 2026/)).toBeInTheDocument();
+    expect(screen.queryByText(/Mar 29, 2026/)).not.toBeInTheDocument();
+
+    // Reset button should clear filters
+    fireEvent.click(screen.getByLabelText("Reset filters"));
+    await waitFor(() => expect(screen.getByText("2 runs")).toBeInTheDocument());
+  });
+
+  it("shows no-matches empty state when filters exclude every run", async () => {
+    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+
+    render(
+      <MemoryRouter initialEntries={["/runs?lang=rust"]}>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No runs match the current filters/)).toBeInTheDocument();
+    });
+  });
+
+  it("hydrates filters from URL query params", async () => {
+    vi.mocked(fetchRuns).mockResolvedValue(mockRuns as any);
+
+    render(
+      <MemoryRouter initialEntries={["/runs?lang=python&status=failing"]}>
+        <RunsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // python + failing matches run-abc123 (has 1 fail + 1 error → status=errors? No, errors take precedence)
+      // run-abc123 has errors=1, so its status is "errors", not "failing".
+      // Therefore the filter should match nothing → empty state.
+      expect(screen.getByText(/No runs match the current filters/)).toBeInTheDocument();
+    });
   });
 });

--- a/site/src/app/components/runs-page.tsx
+++ b/site/src/app/components/runs-page.tsx
@@ -1,9 +1,22 @@
-import { Link } from "react-router";
-import { useState, useEffect } from "react";
+import { Link, useSearchParams } from "react-router";
+import { useState, useEffect, useMemo } from "react";
 import { fetchRuns } from "../data/api";
 import type { RunSummary } from "../data/types";
-import { CheckCircle2, XCircle, AlertTriangle, Clock, ChevronRight, Loader2 } from "lucide-react";
+import { CheckCircle2, XCircle, AlertTriangle, Clock, ChevronRight, Loader2, X } from "lucide-react";
 import { motion } from "motion/react";
+import { MultiSelectFilter } from "./ui/multi-select-filter";
+import {
+  EMPTY_FILTERS,
+  STATUS_LABEL,
+  activeFilterCount,
+  applyFilters,
+  applyFiltersToSearchParams,
+  buildCatalog,
+  filtersFromSearchParams,
+  hasActiveFilters,
+  type RunFilters,
+  type RunStatus,
+} from "../lib/run-filters";
 
 function formatDuration(s: number | undefined | null): string {
   if (s == null || isNaN(s)) return "N/A";
@@ -31,6 +44,7 @@ export function RunsPage() {
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     fetchRuns()
@@ -38,6 +52,24 @@ export function RunsPage() {
       .catch(e => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
+
+  // Filters live in the URL so reload + share preserves state.
+  const filters: RunFilters = useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams],
+  );
+  const catalog = useMemo(() => buildCatalog(runs), [runs]);
+  const filteredRuns = useMemo(() => applyFilters(runs, filters), [runs, filters]);
+
+  function updateFilters(next: RunFilters) {
+    const params = new URLSearchParams(searchParams);
+    applyFiltersToSearchParams(params, next);
+    setSearchParams(params, { replace: true });
+  }
+
+  function resetFilters() {
+    updateFilters(EMPTY_FILTERS);
+  }
 
   if (loading) {
     return (
@@ -75,8 +107,32 @@ export function RunsPage() {
             <p className="text-white/40">No runs found.</p>
           </div>
         ) : (
-          <div className="space-y-4">
-            {runs.map((run, i) => {
+          <>
+            <FilterBar
+              catalog={catalog}
+              filters={filters}
+              onChange={updateFilters}
+              onReset={resetFilters}
+              filteredCount={filteredRuns.length}
+              totalCount={runs.length}
+            />
+            {filteredRuns.length === 0 ? (
+              <div
+                role="status"
+                className="rounded-xl border border-white/8 bg-white/[0.03] p-8 text-center"
+              >
+                <p className="mb-2 text-white/60">No runs match the current filters.</p>
+                <button
+                  onClick={resetFilters}
+                  className="text-emerald-400 hover:text-emerald-300"
+                  style={{ fontSize: 13 }}
+                >
+                  Reset filters
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {filteredRuns.map((run, i) => {
               const passed = run.passed ?? 0;
               const total = run.total_evaluations ?? 0;
               const rate = total > 0 ? ((passed / total) * 100).toFixed(1) : "0.0";
@@ -140,8 +196,78 @@ export function RunsPage() {
                 </motion.div>
               );
             })}
-          </div>
+              </div>
+            )}
+          </>
         )}
+      </div>
+    </div>
+  );
+}
+
+interface FilterBarProps {
+  catalog: ReturnType<typeof buildCatalog>;
+  filters: RunFilters;
+  onChange: (next: RunFilters) => void;
+  onReset: () => void;
+  filteredCount: number;
+  totalCount: number;
+}
+
+function FilterBar({
+  catalog,
+  filters,
+  onChange,
+  onReset,
+  filteredCount,
+  totalCount,
+}: FilterBarProps) {
+  const active = hasActiveFilters(filters);
+  const count = activeFilterCount(filters);
+  return (
+    <div className="mb-5 rounded-xl border border-white/8 bg-white/[0.02] p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <MultiSelectFilter
+          label="Config"
+          options={catalog.configs.map((c) => ({ value: c, label: c }))}
+          selected={filters.configs}
+          onChange={(configs) => onChange({ ...filters, configs })}
+        />
+        <MultiSelectFilter
+          label="Language"
+          options={catalog.languages.map((l) => ({ value: l, label: l }))}
+          selected={filters.languages}
+          onChange={(languages) => onChange({ ...filters, languages })}
+        />
+        <MultiSelectFilter
+          label="Status"
+          options={catalog.statuses.map((s) => ({ value: s, label: STATUS_LABEL[s] }))}
+          selected={filters.statuses}
+          onChange={(values) =>
+            onChange({ ...filters, statuses: values as RunStatus[] })
+          }
+        />
+
+        <div className="ml-auto flex items-center gap-3">
+          <span
+            className="text-white/40"
+            style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 12 }}
+          >
+            {active ? `${filteredCount} of ${totalCount}` : `${totalCount} runs`}
+          </span>
+          {active && (
+            <button
+              type="button"
+              onClick={onReset}
+              aria-label="Reset filters"
+              className="flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-white/70 transition hover:border-white/20 hover:text-white"
+              style={{ fontSize: 12 }}
+            >
+              <X className="h-3 w-3" />
+              Reset{count > 0 ? ` (${count})` : ""}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/site/src/app/components/ui/multi-select-filter.tsx
+++ b/site/src/app/components/ui/multi-select-filter.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface MultiSelectFilterProps {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  emptyLabel?: string;
+}
+
+// Compact dropdown with checkbox-style multi-select. Closes on outside click
+// and on Escape. Designed to sit in a horizontal filter bar on the runs page.
+export function MultiSelectFilter({
+  label,
+  options,
+  selected,
+  onChange,
+  emptyLabel = "Any",
+}: MultiSelectFilterProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  function toggle(value: string) {
+    onChange(
+      selected.includes(value)
+        ? selected.filter((v) => v !== value)
+        : [...selected, value],
+    );
+  }
+
+  const summary =
+    selected.length === 0
+      ? emptyLabel
+      : selected.length === 1
+        ? selected[0]
+        : `${selected.length} selected`;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Filter by ${label}`}
+        className={`flex items-center gap-2 rounded-lg border px-3 py-1.5 transition ${
+          selected.length > 0
+            ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+            : "border-white/10 bg-white/5 text-white/70 hover:border-white/20"
+        }`}
+        style={{ fontSize: 12 }}
+      >
+        <span className="text-white/40" style={{ fontSize: 11 }}>
+          {label}:
+        </span>
+        <span>{summary}</span>
+        <ChevronDown className="h-3 w-3" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label={label}
+          className="absolute left-0 z-20 mt-1 max-h-72 w-56 overflow-y-auto rounded-lg border border-white/10 bg-[#13131a] p-1 shadow-xl"
+        >
+          {options.length === 0 ? (
+            <div className="px-3 py-2 text-white/40" style={{ fontSize: 12 }}>
+              No options
+            </div>
+          ) : (
+            options.map((opt) => {
+              const isSelected = selected.includes(opt.value);
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => toggle(opt.value)}
+                  className={`flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left transition ${
+                    isSelected
+                      ? "bg-emerald-500/15 text-emerald-300"
+                      : "text-white/70 hover:bg-white/5"
+                  }`}
+                  style={{ fontSize: 12 }}
+                >
+                  <span className="truncate">{opt.label}</span>
+                  {isSelected && <Check className="h-3 w-3 shrink-0" />}
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/app/lib/run-filters.ts
+++ b/site/src/app/lib/run-filters.ts
@@ -1,0 +1,171 @@
+// Pure model + helpers for the run-level filter system on the runs page.
+//
+// A RunFilters value is a multi-select per dimension (configs, languages,
+// statuses). Each RunSummary is annotated with the union of its evals'
+// configs/languages plus an aggregate status, and matches a filter when it
+// has at least one matching eval per dimension.
+//
+// Selection semantics (matches group-based-comparison-ui skill):
+//   - Empty array for a dimension = match-all for that dimension.
+//   - Within a dimension, values OR together (any match counts).
+//   - Across dimensions, results AND together (all dimensions must match).
+//
+// All functions in this module are pure and side-effect free so they can be
+// unit-tested without rendering React.
+
+import type { RunSummary } from "../data/types";
+
+export type RunStatus = "passing" | "failing" | "errors";
+
+export const ALL_STATUSES: RunStatus[] = ["passing", "failing", "errors"];
+
+export const STATUS_LABEL: Record<RunStatus, string> = {
+  passing: "All passing",
+  failing: "Has failures",
+  errors: "Has errors",
+};
+
+export interface RunFilters {
+  configs: string[];
+  languages: string[];
+  statuses: RunStatus[];
+}
+
+export const EMPTY_FILTERS: RunFilters = {
+  configs: [],
+  languages: [],
+  statuses: [],
+};
+
+export interface RunFilterCatalog {
+  configs: string[];
+  languages: string[];
+  statuses: RunStatus[];
+}
+
+export interface RunFacets {
+  configs: Set<string>;
+  languages: Set<string>;
+  status: RunStatus;
+}
+
+export function deriveStatus(run: RunSummary): RunStatus {
+  const errors = run.errors ?? 0;
+  if (errors > 0) return "errors";
+  const failed = run.failed ?? 0;
+  if (failed > 0) return "failing";
+  return "passing";
+}
+
+export function deriveFacets(run: RunSummary): RunFacets {
+  const configs = new Set<string>();
+  const languages = new Set<string>();
+  for (const r of run.results || []) {
+    if (r.config_name) configs.add(r.config_name);
+    const lang = r.prompt_metadata?.language;
+    if (lang) languages.add(lang);
+  }
+  return { configs, languages, status: deriveStatus(run) };
+}
+
+export function buildCatalog(runs: RunSummary[]): RunFilterCatalog {
+  const configs = new Set<string>();
+  const languages = new Set<string>();
+  const statuses = new Set<RunStatus>();
+  for (const run of runs) {
+    const facets = deriveFacets(run);
+    for (const c of facets.configs) configs.add(c);
+    for (const l of facets.languages) languages.add(l);
+    statuses.add(facets.status);
+  }
+  return {
+    configs: Array.from(configs).sort(),
+    languages: Array.from(languages).sort(),
+    statuses: ALL_STATUSES.filter((s) => statuses.has(s)),
+  };
+}
+
+function dimensionPasses(selected: string[], present: Set<string>): boolean {
+  if (selected.length === 0) return true;
+  for (const v of selected) if (present.has(v)) return true;
+  return false;
+}
+
+export function runMatches(run: RunSummary, filters: RunFilters): boolean {
+  const facets = deriveFacets(run);
+  if (!dimensionPasses(filters.configs, facets.configs)) return false;
+  if (!dimensionPasses(filters.languages, facets.languages)) return false;
+  if (filters.statuses.length > 0 && !filters.statuses.includes(facets.status)) {
+    return false;
+  }
+  return true;
+}
+
+export function applyFilters(runs: RunSummary[], filters: RunFilters): RunSummary[] {
+  if (!hasActiveFilters(filters)) return runs;
+  return runs.filter((r) => runMatches(r, filters));
+}
+
+export function hasActiveFilters(filters: RunFilters): boolean {
+  return (
+    filters.configs.length > 0 ||
+    filters.languages.length > 0 ||
+    filters.statuses.length > 0
+  );
+}
+
+export function activeFilterCount(filters: RunFilters): number {
+  return filters.configs.length + filters.languages.length + filters.statuses.length;
+}
+
+export function toggleValue<T extends string>(values: T[], value: T): T[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+}
+
+// ── URL serialization ──────────────────────────────────────────────
+// Filters round-trip through URLSearchParams as comma-separated lists, e.g.
+// ?config=baseline%2Fclaude-opus-4.6,azure-mcp%2Fclaude-opus-4.6&lang=python&status=failing
+
+const PARAM_KEYS = {
+  configs: "config",
+  languages: "lang",
+  statuses: "status",
+} as const;
+
+function splitList(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw.split(",").map((v) => v.trim()).filter(Boolean);
+}
+
+export function filtersFromSearchParams(params: URLSearchParams): RunFilters {
+  const rawStatuses = splitList(params.get(PARAM_KEYS.statuses));
+  const statuses = rawStatuses.filter((s): s is RunStatus =>
+    ALL_STATUSES.includes(s as RunStatus),
+  );
+  return {
+    configs: splitList(params.get(PARAM_KEYS.configs)),
+    languages: splitList(params.get(PARAM_KEYS.languages)),
+    statuses,
+  };
+}
+
+// Mutates `params` in place: sets keys for non-empty dimensions, removes them
+// otherwise. Returns the same object for convenience when building a URL.
+export function applyFiltersToSearchParams(
+  params: URLSearchParams,
+  filters: RunFilters,
+): URLSearchParams {
+  const entries: [string, string[]][] = [
+    [PARAM_KEYS.configs, filters.configs],
+    [PARAM_KEYS.languages, filters.languages],
+    [PARAM_KEYS.statuses, filters.statuses],
+  ];
+  for (const [key, values] of entries) {
+    if (values.length === 0) {
+      params.delete(key);
+    } else {
+      params.set(key, values.join(","));
+    }
+  }
+  return params;
+}


### PR DESCRIPTION
Resolves #600 (R146/R147 — Run-level Filter System on Site).

## What

Interactive filter bar on the runs page (`/runs`) with multi-select dropdowns for **Config**, **Language**, and **Status**. Filters persist to URL query params (`?config=…&lang=…&status=…`) so reload and link-sharing both preserve state.

## Acceptance criteria

- [x] Filter sidebar/panel on runs page (configs, languages, statuses)
- [x] Catalog extracted from real run JSON (no phantom chips)
- [x] Multi-select state management (`useSearchParams` is the source of truth)
- [x] Filter eval cards — OR within dimension, AND across dimensions
- [x] Reset button + visual indicator (`Reset (N)`) of active filters
- [x] URL persistence — survives reload, shareable links
- [x] Tests for filter logic and component rendering (25 new tests)
- [x] Existing responsive layout preserved

## Architecture

- `site/src/app/lib/run-filters.ts` — pure-function model: catalog extraction, run matching, URL ser/deserialize. Inherits the `group-based-comparison-ui` skill (OR within / AND across, empty = match-all).
- `site/src/app/components/ui/multi-select-filter.tsx` — reusable chip-dropdown primitive (outside-click + Escape close, ARIA listbox roles).
- `site/src/app/components/runs-page.tsx` — `<FilterBar>` + empty-match state with one-click reset.

## Status precedence

`errors > failing > passing`. A run with both errors and failures appears only under `errors` so the Status filter doesn't double-count.

## Filter semantics

A run matches when each active dimension finds at least one matching eval inside it. Run-level (not eval-level) filtering preserves the page's identity as a list of runs — per-eval filtering already lives on the run-detail page.

## Tests

```
Test Files  14 passed (14)
     Tests  119 passed (119)
```

25 new tests across:
- `run-filters.test.ts` — 16 lib tests (status precedence, OR/AND semantics, URL round-trip, malformed-data tolerance, unknown status rejection)
- `runs-page.test.tsx` — 5 new DOM tests (filter bar render, language filter + reset, no-matches empty state, URL hydration)

`npm run build` clean.

## Notes for reviewers

- @switch — focus on the test suite. Filter logic is in pure functions for fast tests; DOM tests cover user-visible flows including the empty-match state.
- @morpheus — architecture: extracted the run-level filter model into a lib (mirrors `comparison-groups.ts`). `MultiSelectFilter` is a new primitive other pages (prompts, dashboard) can adopt. Decision filed at `.squad/decisions/inbox/trinity-issue-600-filters.md`.

Targets `phase-6` per phase-6 branch policy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>