### PR TITLE
feat(#597): Tool versioning and custom fetchers

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -273,3 +273,39 @@ Design:
 Added optional top-level `group` frontmatter field. Backwards compatible (empty = ungrouped). Kebab-case validation: `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`, max 64 chars. Enforced in both `validate.ValidatePromptStruct` (struct path) and `validate.validatePrompt` (CLI path — these two paths exist in parallel; remember to keep them in sync). Propagated to reports via `EvalReport.PromptMeta["group"]` (no schema bump). Tests in `prompt/group_test.go` and `validate/group_test.go`. Site work deferred to Trinity (#600). Decision: `.squad/decisions/inbox/neo-issue-599-group-property.md`.
 
 **Note:** parser.go, types.go, validate.go in this codebase are not gofmt-clean (no leading whitespace on body code). Resisted the urge to gofmt — kept PR diff focused on the issue. If we ever decide to gofmt the codebase, do it as a separate PR.
+### Session 2026-04-21 (#597 — WI-027 Tool Versioning & Custom Fetcher)
+
+**Status:** COMPLETE
+**Branch:** `ronniegeraghty/issue-597-tool-versioning`
+**PR:** (filed against phase-6)
+
+Built on WI-026 (#334) cache infrastructure. Added pluggable `tool.Fetcher`
+interface in `internal/config/tool/`, process-wide `DefaultRegistry` preloaded
+with the existing npx behavior wrapped as `npxFetcher`, and a
+`tool_version_override` map at the ConfigFile level.
+
+**Key files:**
+- `hyoka/internal/config/tool/fetcher.go` (new) — Fetcher interface, Registry,
+  npxFetcher, ValidateFetchers
+- `hyoka/internal/config/tool/resolve.go` — FetchRemote rewritten to dispatch
+  through the registry (one-line lookup + delegation)
+- `hyoka/internal/config/tool/entry.go` — added `Version` field
+- `hyoka/internal/config/config.go` — `ToolVersionOverride map`,
+  `ApplyVersionOverrides()`, called from `Load`; LoadDir merges with
+  conflict-detection
+- `hyoka/cmd/run.go` — `tool.ValidateFetchers` pre-flight before session start
+- Tests: `fetcher_test.go` (registry, custom fetcher runtime invocation,
+  error propagation, version path); `version_override_test.go` (per-entry
+  precedence, idempotency, YAML parse)
+- `docs/configuration.md` — new "Tool Versioning & Custom Fetchers" section
+
+**#587-trap guard:** `TestCustomFetcherInvokedAtRuntime` registers a real
+mock against the real DefaultRegistry, calls ResolveSkills, asserts call
+count == 1 and the version the fetcher saw matches what was configured.
+Wiring is observable, not just parseable.
+
+**Backward compat:** zero behavior change without explicit config. Default
+fetcher matches every remote skill same as before; only diff is cache path
+now segments by version (`.skills-cache/default/...`).
+
+**Tests:** `go test -race ./hyoka/... -timeout 3m` clean. Vet clean.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,67 @@ max_turns: 40             # Allow more back-and-forth turns
 
 Prompts with unset limit fields fall through to config > CLI > default, ensuring backward compatibility.
 
+## Tool Versioning & Custom Fetchers
+
+Remote skills (and other future remote tools) are pinned and fetched through hyoka's pluggable **Fetcher** system. By default, hyoka uses an `npx skills add`-backed fetcher that follows the repo's default branch.
+
+### Pinning versions
+
+Use `tool_version_override` at the top of any config file to pin tools by `name`:
+
+```yaml
+tool_version_override:
+  azure-sdk-java: "v1.4.2"      # git tag
+  copilot-knowledge: "main"      # branch
+  azsdk-samples: "abc123def"     # commit SHA
+
+configs:
+  - name: baseline/sonnet
+    generator:
+      model: claude-sonnet-4.5
+      tools:
+        - name: azure-sdk-java
+          type: skill
+          source: remote
+          repo: Azure/azure-sdk-skills
+        - name: pinned-by-entry
+          type: skill
+          source: remote
+          repo: x/y
+          version: "v2.0.0"      # per-entry version always wins
+```
+
+**Resolution order:** per-entry `version:` field > `tool_version_override` map > fetcher default (latest).
+
+The version is forwarded to the fetcher; the default `npx` fetcher appends it as a git ref (`repo@version`) and caches each version under a separate directory (`.skills-cache/<version>/<repo>/<name>/`) so toggling pins doesn't poison the cache.
+
+`tool_version_override` maps are scoped to the config file they live in. Conflicting values across files in a directory load are an error.
+
+### Custom fetchers
+
+The `tool.Fetcher` interface (in `hyoka/internal/config/tool/`) lets embedders register additional fetchers — useful for internal mirror caches, alternate package managers, or custom version-pinning rules:
+
+```go
+import "github.com/ronniegeraghty/hyoka/hyoka/internal/config/tool"
+
+type artifactoryFetcher struct{ /* ... */ }
+
+func (artifactoryFetcher) Name() string { return "artifactory" }
+func (artifactoryFetcher) CanFetch(e tool.Entry) bool {
+    return e.ResolvedType() == tool.TypeSkill && e.Source == "remote" &&
+           strings.HasPrefix(e.Repo, "internal/")
+}
+func (artifactoryFetcher) Fetch(ctx context.Context, req tool.FetchRequest) (tool.FetchResult, error) {
+    // download from internal Artifactory, return FetchResult{Dir, Version}
+}
+
+func init() { _ = tool.Register(artifactoryFetcher{}) }
+```
+
+**Lookup order:** custom fetchers are consulted before the built-in `npx` default; the first whose `CanFetch` returns true wins. This means custom fetchers can shadow the default for specific entries while leaving everything else on the default path.
+
+Hyoka calls `tool.ValidateFetchers(...)` at the start of every run, so any remote skill without a matching registered fetcher fails fast — before a session is spawned.
+
 ## Multiple Config Files
 
 Place multiple `.yaml` files in the config directory. All are loaded automatically. Use `--config <name>` to select specific configs, or `--all-configs` to run all.

--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -10,6 +10,7 @@ import (
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/config/tool"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/eval"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/pairwise"
 	"github.com/ronniegeraghty/hyoka/hyoka/internal/prompt"
@@ -254,6 +255,21 @@ func runCmd() *cobra.Command {
 
 			// Resolve relative skill_directories in configs to absolute paths
 			resolveConfigSkillDirs(configs, f.prompts)
+
+			// Pre-flight: every remote skill needs a registered Fetcher.
+			// Failing here gives a fast, clear error before any session starts.
+			var allEntries [][]tool.Entry
+			for _, c := range configs {
+				if c.Generator != nil {
+					allEntries = append(allEntries, c.Generator.Tools)
+				}
+				if c.Reviewer != nil {
+					allEntries = append(allEntries, c.Reviewer.Tools)
+				}
+			}
+			if err := tool.ValidateFetchers(allEntries); err != nil {
+				return fmt.Errorf("tool fetcher validation: %w", err)
+			}
 
 			// Install declared skills and plugins (npx skills add)
 			if err := config.InstallSkillsAndPlugins(configs); err != nil {

--- a/hyoka/internal/config/config.go
+++ b/hyoka/internal/config/config.go
@@ -160,8 +160,42 @@ type ConfigFile struct {
 	// discovery (.hyoka/prompts → ./prompts → ../prompts). When set in a
 	// config YAML loaded from disk, relative paths are resolved against the
 	// containing config file's directory by Load/LoadDir.
-	PromptDirectory string       `yaml:"prompt_directory,omitempty" json:"prompt_directory,omitempty"`
-	Configs         []ToolConfig `yaml:"configs"`
+	PromptDirectory string `yaml:"prompt_directory,omitempty" json:"prompt_directory,omitempty"`
+	// ToolVersionOverride pins specific tool entries (matched by Entry.Name)
+	// to a given version. The version is forwarded to the registered Fetcher
+	// (for the default npx fetcher, it becomes a git ref). Per-entry
+	// `version:` set directly on a tool entry takes precedence over this map.
+	// Empty map (or absent field) means "no overrides" — fetcher defaults
+	// are used everywhere.
+	ToolVersionOverride map[string]string `yaml:"tool_version_override,omitempty" json:"tool_version_override,omitempty"`
+	Configs             []ToolConfig      `yaml:"configs"`
+}
+
+// ApplyVersionOverrides applies cf.ToolVersionOverride to every tool entry
+// in every config (Generator and Reviewer). Entries with a non-empty
+// Version field are left untouched (per-entry pin wins). Idempotent.
+func (cf *ConfigFile) ApplyVersionOverrides() {
+	if cf == nil || len(cf.ToolVersionOverride) == 0 {
+		return
+	}
+	apply := func(entries []ToolEntry) {
+		for i := range entries {
+			if entries[i].Version != "" {
+				continue
+			}
+			if v, ok := cf.ToolVersionOverride[entries[i].Name]; ok && v != "" {
+				entries[i].Version = v
+			}
+		}
+	}
+	for i := range cf.Configs {
+		if cf.Configs[i].Generator != nil {
+			apply(cf.Configs[i].Generator.Tools)
+		}
+		if cf.Configs[i].Reviewer != nil {
+			apply(cf.Configs[i].Reviewer.Tools)
+		}
+	}
 }
 
 // Load reads and parses a configuration file from the given path.
@@ -178,6 +212,7 @@ func Load(path string) (*ConfigFile, error) {
 	if err := cfg.ExpandPlugins(resolvePluginsDir()); err != nil {
 		return nil, fmt.Errorf("expanding plugins: %w", err)
 	}
+	cfg.ApplyVersionOverrides()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -228,6 +263,17 @@ func LoadDir(dir string) (*ConfigFile, error) {
 			nameSource[c.Name] = e.Name()
 		}
 		merged.Configs = append(merged.Configs, cf.Configs...)
+		// Merge tool_version_override maps. Conflicting values across files
+		// are an error — silently last-write-wins would be a footgun.
+		for k, v := range cf.ToolVersionOverride {
+			if merged.ToolVersionOverride == nil {
+				merged.ToolVersionOverride = make(map[string]string)
+			}
+			if existing, ok := merged.ToolVersionOverride[k]; ok && existing != v {
+				return nil, fmt.Errorf("conflicting tool_version_override for %q: %q vs %q (in %s)", k, existing, v, e.Name())
+			}
+			merged.ToolVersionOverride[k] = v
+		}
 	}
 
 	if len(merged.Configs) == 0 {

--- a/hyoka/internal/config/tool/entry.go
+++ b/hyoka/internal/config/tool/entry.go
@@ -25,6 +25,12 @@ type Entry struct {
 	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
 	Repo     string `yaml:"repo,omitempty" json:"repo,omitempty"`
 	SkillDir bool   `yaml:"skill_dir,omitempty" json:"skill_dir,omitempty"` // true = path is a directory of skills, false = path is a single skill
+	// Version pins a remote skill to a specific git ref (branch, tag, or
+	// commit). Empty means "default" (whatever the fetcher's default is —
+	// for the npx fetcher, that's the repo's default branch). Can be set on
+	// the entry directly or via tool_version_override at the top of a
+	// config file.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 // ResolvedType returns the normalized entry type ("tool" by default).

--- a/hyoka/internal/config/tool/fetcher.go
+++ b/hyoka/internal/config/tool/fetcher.go
@@ -1,0 +1,247 @@
+package tool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// FetchRequest carries the data a Fetcher needs to materialize a remote tool
+// (typically a skill) on disk.
+type FetchRequest struct {
+	// Entry is the tool entry being fetched (already version-overridden).
+	Entry Entry
+	// BaseDir is the per-eval working directory; fetchers should keep their
+	// per-tool cache scoped beneath this directory unless they have a strong
+	// reason to use a global cache.
+	BaseDir string
+	// Version is the resolved version pin. Empty string means "default" —
+	// fetchers should treat this as latest / the user's normal default.
+	Version string
+}
+
+// FetchResult is what a Fetcher returns once a tool is on disk.
+type FetchResult struct {
+	// Dir is the absolute path to the tool's installed directory (for skills,
+	// the directory containing SKILL.md).
+	Dir string
+	// Version is the version actually installed. Defaults to "default" when
+	// unspecified. Surfaced in logs so users can tell what they got.
+	Version string
+}
+
+// Fetcher resolves a remote tool entry into a directory on disk. Hyoka ships
+// with a default npx-based implementation; users can register additional
+// fetchers via Register to add support for new sources, mirror caches, or pin
+// versions in custom ways. The first fetcher whose CanFetch returns true (in
+// registration order, defaults last) wins.
+//
+// The contract is intentionally narrow:
+//   - Name must be unique within a process — used for diagnostics and to
+//     detect double-registration.
+//   - CanFetch must be a pure check on the entry; it must not perform I/O.
+//   - Fetch must be safe to call concurrently for distinct entries; fetchers
+//     that share on-disk state must serialize internally.
+//   - Fetch must honor ctx cancellation when its work is non-trivial.
+type Fetcher interface {
+	Name() string
+	CanFetch(entry Entry) bool
+	Fetch(ctx context.Context, req FetchRequest) (FetchResult, error)
+}
+
+// Registry holds the active set of Fetchers. The zero value is not usable —
+// always construct via NewRegistry. The default package-level registry
+// (DefaultRegistry) is preloaded with the npx fetcher.
+type Registry struct {
+	mu       sync.RWMutex
+	fetchers []Fetcher
+	names    map[string]struct{}
+}
+
+// NewRegistry returns an empty registry. Most callers want DefaultRegistry.
+func NewRegistry() *Registry {
+	return &Registry{names: make(map[string]struct{})}
+}
+
+// Register adds a fetcher. Custom fetchers are consulted before the built-in
+// default (which always lives at the tail of the list), so a user-registered
+// fetcher can shadow the default when its CanFetch matches.
+//
+// Returns an error if a fetcher with the same Name is already registered.
+func (r *Registry) Register(f Fetcher) error {
+	if f == nil {
+		return fmt.Errorf("nil fetcher")
+	}
+	name := f.Name()
+	if name == "" {
+		return fmt.Errorf("fetcher must have a non-empty Name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.names[name]; ok {
+		return fmt.Errorf("fetcher %q already registered", name)
+	}
+	r.names[name] = struct{}{}
+	// Insert before any fetcher with name == defaultFetcherName so the default
+	// remains last. This keeps lookup deterministic regardless of registration
+	// order.
+	insertAt := len(r.fetchers)
+	for i, ex := range r.fetchers {
+		if ex.Name() == defaultFetcherName {
+			insertAt = i
+			break
+		}
+	}
+	r.fetchers = append(r.fetchers, nil)
+	copy(r.fetchers[insertAt+1:], r.fetchers[insertAt:])
+	r.fetchers[insertAt] = f
+	return nil
+}
+
+// Unregister removes a fetcher by name. Primarily useful in tests.
+func (r *Registry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.names, name)
+	out := r.fetchers[:0]
+	for _, f := range r.fetchers {
+		if f.Name() != name {
+			out = append(out, f)
+		}
+	}
+	r.fetchers = out
+}
+
+// Lookup returns the first fetcher that CanFetch the entry, or nil if none
+// matches (which should be impossible while the npx default is registered).
+func (r *Registry) Lookup(entry Entry) Fetcher {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, f := range r.fetchers {
+		if f.CanFetch(entry) {
+			return f
+		}
+	}
+	return nil
+}
+
+// Names returns registered fetcher names in lookup order. Used by diagnostics.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, len(r.fetchers))
+	for i, f := range r.fetchers {
+		out[i] = f.Name()
+	}
+	return out
+}
+
+// DefaultRegistry is the process-wide registry consulted by ResolveSkills.
+// It is preloaded with the built-in npx fetcher.
+var DefaultRegistry = func() *Registry {
+	r := NewRegistry()
+	_ = r.Register(&npxFetcher{})
+	return r
+}()
+
+// Register adds a fetcher to the default registry. Convenience wrapper around
+// DefaultRegistry.Register for users who don't need their own registry.
+func Register(f Fetcher) error { return DefaultRegistry.Register(f) }
+
+// LookupFetcher returns the fetcher that would handle the given entry under
+// the default registry.
+func LookupFetcher(entry Entry) Fetcher { return DefaultRegistry.Lookup(entry) }
+
+// ValidateFetchers checks that every remote skill entry across the given
+// configs has a registered fetcher willing to handle it. Returns the first
+// missing-fetcher error encountered. Intended to be called by the eval
+// engine before any session starts so users get a fast, clear failure
+// instead of a mid-eval surprise.
+func ValidateFetchers(configs [][]Entry) error {
+	for _, entries := range configs {
+		for _, e := range entries {
+			if e.ResolvedType() != TypeSkill || e.SkillSource() != SourceRemote {
+				continue
+			}
+			if LookupFetcher(e) == nil {
+				return fmt.Errorf("no fetcher registered for remote skill %q (repo=%q)", e.Name, e.Repo)
+			}
+		}
+	}
+	return nil
+}
+
+// --- built-in npx fetcher --------------------------------------------------
+
+const defaultFetcherName = "npx"
+
+// npxFetcher is the built-in Fetcher backed by `npx skills add`. It preserves
+// the historical behavior of FetchRemote: caches under <baseDir>/.skills-cache/
+// and shells out to npx. When a Version is supplied it is appended to the repo
+// arg as `repo@version`, which `npx skills add` (and the underlying git fetch)
+// interprets as a branch/tag/commit ref.
+type npxFetcher struct{}
+
+func (npxFetcher) Name() string { return defaultFetcherName }
+
+// CanFetch returns true for any remote skill entry. The default fetcher is the
+// last-resort handler; custom fetchers can pre-empt it via their own CanFetch.
+func (npxFetcher) CanFetch(entry Entry) bool {
+	return entry.ResolvedType() == TypeSkill && entry.SkillSource() == SourceRemote
+}
+
+func (npxFetcher) Fetch(ctx context.Context, req FetchRequest) (FetchResult, error) {
+	entry := req.Entry
+	// Version-aware install path: keeps different versions in distinct dirs
+	// so switching the override doesn't poison the cache.
+	versionSegment := req.Version
+	if versionSegment == "" {
+		versionSegment = "default"
+	}
+	installDir := filepath.Join(req.BaseDir, ".skills-cache", versionSegment, entry.Repo)
+	if entry.Name != "" {
+		installDir = filepath.Join(installDir, entry.Name)
+	}
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return FetchResult{}, fmt.Errorf("creating skill install dir: %w", err)
+	}
+
+	repoArg := entry.Repo
+	if req.Version != "" {
+		repoArg = entry.Repo + "@" + req.Version
+	}
+	args := []string{"skills", "add", repoArg, "--directory", installDir}
+	if entry.Name != "" {
+		args = append(args, "--name", entry.Name)
+	}
+
+	fmt.Printf("Fetching remote skill: %s (repo: %s, version: %s)\n", entry.Name, entry.Repo, versionSegment)
+	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo, "version", versionSegment, "fetcher", defaultFetcherName)
+
+	cmd := exec.CommandContext(ctx, "npx", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return FetchResult{}, fmt.Errorf("npx skills add: %w", err)
+	}
+
+	abs, absErr := filepath.Abs(installDir)
+	if absErr != nil {
+		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
+		abs = installDir
+	}
+	return FetchResult{Dir: abs, Version: versionSegment}, nil
+}
+
+// SortedFetcherNames returns registered fetcher names sorted alphabetically.
+// Useful for stable diagnostic output.
+func SortedFetcherNames() []string {
+	names := DefaultRegistry.Names()
+	sort.Strings(names)
+	return names
+}

--- a/hyoka/internal/config/tool/fetcher_test.go
+++ b/hyoka/internal/config/tool/fetcher_test.go
@@ -1,0 +1,216 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// mockFetcher is a Fetcher used in tests to verify the registry actually
+// dispatches custom fetchers at runtime — guarding against the #587 trap
+// where config wiring exists but never reaches execution.
+type mockFetcher struct {
+	name      string
+	matchRepo string
+	calls     atomic.Int64
+	lastReq   atomic.Pointer[FetchRequest]
+	dir       string
+	err       error
+}
+
+func (m *mockFetcher) Name() string { return m.name }
+
+func (m *mockFetcher) CanFetch(e Entry) bool {
+	if e.ResolvedType() != TypeSkill || e.SkillSource() != SourceRemote {
+		return false
+	}
+	return m.matchRepo == "" || e.Repo == m.matchRepo
+}
+
+func (m *mockFetcher) Fetch(_ context.Context, req FetchRequest) (FetchResult, error) {
+	m.calls.Add(1)
+	r := req
+	m.lastReq.Store(&r)
+	if m.err != nil {
+		return FetchResult{}, m.err
+	}
+	return FetchResult{Dir: m.dir, Version: req.Version}, nil
+}
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(&npxFetcher{}); err != nil {
+		t.Fatalf("register npx: %v", err)
+	}
+	custom := &mockFetcher{name: "custom", matchRepo: "owner/repo"}
+	if err := r.Register(custom); err != nil {
+		t.Fatalf("register custom: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		entry   Entry
+		wantFet string
+	}{
+		{
+			name:    "custom matches its repo first",
+			entry:   Entry{Type: TypeSkill, Source: SourceRemote, Repo: "owner/repo"},
+			wantFet: "custom",
+		},
+		{
+			name:    "default falls through for other repos",
+			entry:   Entry{Type: TypeSkill, Source: SourceRemote, Repo: "other/repo"},
+			wantFet: "npx",
+		},
+		{
+			name:    "local skill — no remote fetcher matches",
+			entry:   Entry{Type: TypeSkill, Source: SourceLocal, Path: "/tmp/x"},
+			wantFet: "",
+		},
+		{
+			name:    "non-skill entry — no fetcher",
+			entry:   Entry{Type: TypeMCP, Name: "x"},
+			wantFet: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.Lookup(tc.entry)
+			if tc.wantFet == "" {
+				if got != nil {
+					t.Fatalf("expected no fetcher, got %q", got.Name())
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected fetcher %q, got nil", tc.wantFet)
+			}
+			if got.Name() != tc.wantFet {
+				t.Errorf("got fetcher %q, want %q", got.Name(), tc.wantFet)
+			}
+		})
+	}
+}
+
+func TestRegistry_DefaultStaysLast(t *testing.T) {
+	r := NewRegistry()
+	// Register default first, then custom — custom must still come before
+	// default in lookup order so it can shadow it.
+	if err := r.Register(&npxFetcher{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(&mockFetcher{name: "custom"}); err != nil {
+		t.Fatal(err)
+	}
+	names := r.Names()
+	if len(names) != 2 || names[0] != "custom" || names[1] != defaultFetcherName {
+		t.Errorf("expected [custom, npx], got %v", names)
+	}
+}
+
+func TestRegistry_DuplicateNameRejected(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(&mockFetcher{name: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(&mockFetcher{name: "x"}); err == nil {
+		t.Errorf("expected duplicate-name error")
+	}
+}
+
+func TestRegistry_RejectsNilAndUnnamed(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(nil); err == nil {
+		t.Errorf("expected error for nil fetcher")
+	}
+	if err := r.Register(&mockFetcher{name: ""}); err == nil {
+		t.Errorf("expected error for empty Name")
+	}
+}
+
+// TestCustomFetcherInvokedAtRuntime is the #587-trap guard: it verifies that
+// when ResolveSkills is asked to handle a remote skill, a registered custom
+// fetcher actually runs — not just that the config plumbing accepts it.
+func TestCustomFetcherInvokedAtRuntime(t *testing.T) {
+	mock := &mockFetcher{name: "test-runtime", matchRepo: "acme/widgets", dir: t.TempDir()}
+	if err := DefaultRegistry.Register(mock); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() { DefaultRegistry.Unregister(mock.name) })
+
+	dirs, err := ResolveSkills([]Entry{
+		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/widgets", Name: "widget", Version: "v1.2.3"},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolveSkills: %v", err)
+	}
+	if got := mock.calls.Load(); got != 1 {
+		t.Fatalf("expected mock.Fetch to be called exactly once, got %d", got)
+	}
+	got := mock.lastReq.Load()
+	if got == nil {
+		t.Fatalf("no FetchRequest captured")
+	}
+	if got.Version != "v1.2.3" {
+		t.Errorf("custom fetcher saw version %q, want %q", got.Version, "v1.2.3")
+	}
+	if got.Entry.Repo != "acme/widgets" {
+		t.Errorf("custom fetcher saw repo %q, want %q", got.Entry.Repo, "acme/widgets")
+	}
+	if len(dirs) != 1 || dirs[0] != mock.dir {
+		t.Errorf("ResolveSkills returned %v, want [%s]", dirs, mock.dir)
+	}
+}
+
+func TestCustomFetcherErrorPropagates(t *testing.T) {
+	wantErr := errors.New("mock fetch failure")
+	mock := &mockFetcher{name: "test-err", matchRepo: "acme/fail", err: wantErr}
+	if err := DefaultRegistry.Register(mock); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() { DefaultRegistry.Unregister(mock.name) })
+
+	_, err := ResolveSkills([]Entry{
+		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/fail", Name: "x"},
+	}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "mock fetch failure") {
+		t.Errorf("expected wrapped fetch error, got %v", err)
+	}
+}
+
+func TestValidateFetchers(t *testing.T) {
+	// Local skills and non-skill entries always pass — fetcher unrelated.
+	if err := ValidateFetchers([][]Entry{{
+		{Type: TypeSkill, Source: SourceLocal, Path: "/tmp/x"},
+		{Type: TypeMCP, Name: "mcp"},
+	}}); err != nil {
+		t.Errorf("local-only validation: %v", err)
+	}
+	// Remote skill is OK because the default npx fetcher always matches.
+	if err := ValidateFetchers([][]Entry{{
+		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/x"},
+	}}); err != nil {
+		t.Errorf("remote with default fetcher: %v", err)
+	}
+}
+
+// TestNpxFetcher_VersionInPath verifies that the default fetcher writes
+// different versions to different cache subdirectories — so toggling a
+// version override doesn't poison the cache.
+func TestNpxFetcher_VersionInPath(t *testing.T) {
+	f := npxFetcher{}
+	if !f.CanFetch(Entry{Type: TypeSkill, Source: SourceRemote, Repo: "x/y"}) {
+		t.Fatal("npx must accept remote skill")
+	}
+	if f.CanFetch(Entry{Type: TypeSkill, Source: SourceLocal, Path: "/x"}) {
+		t.Fatal("npx must reject local skill")
+	}
+	if f.CanFetch(Entry{Type: TypeMCP}) {
+		t.Fatal("npx must reject non-skill")
+	}
+	if f.Name() != defaultFetcherName {
+		t.Errorf("name mismatch: %q", f.Name())
+	}
+}

--- a/hyoka/internal/config/tool/resolve.go
+++ b/hyoka/internal/config/tool/resolve.go
@@ -1,10 +1,10 @@
 package tool
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -16,7 +16,7 @@ import (
 //   - source: local, skill_dir: false → path points to a single skill (must contain SKILL.md)
 //   - source: local, skill_dir: true  → path is a directory of skills (subdirs contain SKILL.md)
 //   - source: local with glob         → each glob match is treated as a single skill directory
-//   - source: remote                  → fetches from GitHub repo via "npx skills add"
+//   - source: remote                  → dispatched to the registered Fetcher (default: npx)
 func ResolveSkills(entries []Entry, baseDir string) ([]string, error) {
 	var dirs []string
 	for _, entry := range entries {
@@ -159,37 +159,24 @@ func resolveSkillDir(dir string) ([]string, error) {
 	return dirs, nil
 }
 
-// FetchRemote fetches a remote skill from a GitHub repo using npx skills add.
-// Returns the directory where the skill was installed.
+// FetchRemote fetches a remote skill via the registered Fetcher (default: npx).
+// Returns the directory where the skill was installed. The fetcher is chosen
+// from DefaultRegistry; users can register custom fetchers via Register to
+// override or extend this behavior. Honors entry.Version (which may have been
+// set by ApplyVersionOverrides) and falls back to the fetcher's default when
+// empty.
 func FetchRemote(entry Entry, baseDir string) (string, error) {
-	// Determine install directory: use a skills cache dir under baseDir
-	installDir := filepath.Join(baseDir, ".skills-cache", entry.Repo)
-	if entry.Name != "" {
-		installDir = filepath.Join(installDir, entry.Name)
+	f := LookupFetcher(entry)
+	if f == nil {
+		return "", fmt.Errorf("no fetcher registered for remote skill %q (repo=%q)", entry.Name, entry.Repo)
 	}
-
-	if err := os.MkdirAll(installDir, 0755); err != nil {
-		return "", fmt.Errorf("creating skill install dir: %w", err)
+	res, err := f.Fetch(context.Background(), FetchRequest{
+		Entry:   entry,
+		BaseDir: baseDir,
+		Version: entry.Version,
+	})
+	if err != nil {
+		return "", err
 	}
-
-	// Use npx skills add to fetch the skill
-	args := []string{"skills", "add", entry.Repo, "--directory", installDir}
-	if entry.Name != "" {
-		args = append(args, "--name", entry.Name)
-	}
-
-	fmt.Printf("Fetching remote skill: %s (repo: %s)\n", entry.Name, entry.Repo)
-	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo)
-	cmd := exec.Command("npx", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("npx skills add: %w", err)
-	}
-
-	abs, absErr := filepath.Abs(installDir)
-	if absErr != nil {
-		slog.Warn("Failed to resolve absolute install path", "path", installDir, "error", absErr)
-	}
-	return abs, nil
+	return res.Dir, nil
 }

--- a/hyoka/internal/config/version_override_test.go
+++ b/hyoka/internal/config/version_override_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestApplyVersionOverrides_PinsByName(t *testing.T) {
+	cf := &ConfigFile{
+		ToolVersionOverride: map[string]string{
+			"my-mcp":   "v2.0.0",
+			"my-skill": "v1.5.0",
+		},
+		Configs: []ToolConfig{{
+			Name: "c1",
+			Generator: &GeneratorConfig{
+				Tools: []ToolEntry{
+					{Name: "my-mcp", Type: "mcp", Command: "npx"},
+					{Name: "untouched", Type: "skill", Source: "remote", Repo: "x/y"},
+				},
+			},
+			Reviewer: &ReviewerConfig{
+				Tools: []ToolEntry{
+					{Name: "my-skill", Type: "skill", Source: "remote", Repo: "x/my-skill"},
+				},
+			},
+		}},
+	}
+
+	cf.ApplyVersionOverrides()
+
+	if got := cf.Configs[0].Generator.Tools[0].Version; got != "v2.0.0" {
+		t.Errorf("generator[0] version: got %q, want v2.0.0", got)
+	}
+	if got := cf.Configs[0].Generator.Tools[1].Version; got != "" {
+		t.Errorf("generator[1] should be untouched, got version %q", got)
+	}
+	if got := cf.Configs[0].Reviewer.Tools[0].Version; got != "v1.5.0" {
+		t.Errorf("reviewer[0] version: got %q, want v1.5.0", got)
+	}
+}
+
+func TestApplyVersionOverrides_PerEntryWinsOverMap(t *testing.T) {
+	cf := &ConfigFile{
+		ToolVersionOverride: map[string]string{"my-skill": "v1.0.0"},
+		Configs: []ToolConfig{{
+			Name: "c1",
+			Generator: &GeneratorConfig{
+				Tools: []ToolEntry{
+					{Name: "my-skill", Type: "skill", Source: "remote", Repo: "x/y", Version: "v9.9.9"},
+				},
+			},
+		}},
+	}
+	cf.ApplyVersionOverrides()
+	if got := cf.Configs[0].Generator.Tools[0].Version; got != "v9.9.9" {
+		t.Errorf("per-entry version should win: got %q, want v9.9.9", got)
+	}
+}
+
+func TestApplyVersionOverrides_NoMapNoOp(t *testing.T) {
+	cf := &ConfigFile{
+		Configs: []ToolConfig{{
+			Name: "c1",
+			Generator: &GeneratorConfig{
+				Tools: []ToolEntry{{Name: "x", Type: "skill", Source: "remote", Repo: "a/b"}},
+			},
+		}},
+	}
+	cf.ApplyVersionOverrides()
+	if got := cf.Configs[0].Generator.Tools[0].Version; got != "" {
+		t.Errorf("no override map → version should stay empty, got %q", got)
+	}
+}
+
+func TestApplyVersionOverrides_Idempotent(t *testing.T) {
+	cf := &ConfigFile{
+		ToolVersionOverride: map[string]string{"x": "v1"},
+		Configs: []ToolConfig{{
+			Name: "c1",
+			Generator: &GeneratorConfig{
+				Tools: []ToolEntry{{Name: "x", Type: "skill", Source: "remote", Repo: "a/b"}},
+			},
+		}},
+	}
+	cf.ApplyVersionOverrides()
+	cf.ApplyVersionOverrides()
+	if got := cf.Configs[0].Generator.Tools[0].Version; got != "v1" {
+		t.Errorf("idempotent apply should keep v1, got %q", got)
+	}
+}
+
+func TestParseConfig_ToolVersionOverride(t *testing.T) {
+	yaml := []byte(`
+tool_version_override:
+  my-skill: "v2.0.0"
+configs:
+  - name: c1
+    generator:
+      model: gpt-5.2
+      tools:
+        - name: my-skill
+          type: skill
+          source: remote
+          repo: acme/my-skill
+`)
+	cf, err := Parse(yaml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cf.ToolVersionOverride["my-skill"] != "v2.0.0" {
+		t.Errorf("override map not parsed: %v", cf.ToolVersionOverride)
+	}
+	// Parse does not call ApplyVersionOverrides (Load does); ensure the API works
+	// when invoked explicitly.
+	cf.ApplyVersionOverrides()
+	if got := cf.Configs[0].Generator.Tools[0].Version; got != "v2.0.0" {
+		t.Errorf("post-apply version: got %q, want v2.0.0", got)
+	}
+}


### PR DESCRIPTION
Closes #597. Builds on #334 (WI-026 cache isolation).

## What changed

- **`tool.Fetcher` interface** in `hyoka/internal/config/tool/` — narrow contract (`Name`, `CanFetch`, `Fetch`), backed by a process-wide `DefaultRegistry`.
- **Built-in `npxFetcher`** wraps the existing `FetchRemote` behavior. It always lives at the tail of the registry so user-registered fetchers can shadow it per-entry.
- **`Version` field** on `Entry` plus a top-level **`tool_version_override: { name: version }`** map on `ConfigFile`. Per-entry pin always wins over the map.
- **`ApplyVersionOverrides`** runs from `Load` (and `LoadDir`, which merges per-file maps with conflict detection).
- **Pre-flight `tool.ValidateFetchers`** in `cmd/run.go` fails fast before any session starts when a remote skill has no matching fetcher.
- **Cache segments by version** (`.skills-cache/<version>/<repo>/<name>/`) so toggling pins doesn't poison the cache.
- **Docs:** new \"Tool Versioning & Custom Fetchers\" section in `docs/configuration.md`.

## Backward compatibility

Zero behavior change without explicit configuration. The default `npx` fetcher is preloaded and matches every remote skill exactly as before. Only user-visible diff: cache path now segments by version, so existing caches will trigger a one-time re-fetch on first run after upgrade.

## Tests

- `fetcher_test.go` — registry table-driven (Lookup, ordering, dedup, nil/empty rejection), error propagation.
- **`TestCustomFetcherInvokedAtRuntime`** — the **#587-trap guard**: registers a real mock against the real `DefaultRegistry`, calls `ResolveSkills`, asserts the mock's call counter == 1 *and* the version it received matches the configured pin. Wiring is observable, not just parseable.
- `version_override_test.go` — per-entry precedence, idempotency, YAML parse round-trip, no-op when map empty.
- `go test -race ./hyoka/... -timeout 3m` clean. `go vet` clean.

## Design notes

Decision doc with the interface contract, alternatives considered, and migration story is at `.squad/decisions/inbox/neo-issue-597-tool-versioning.md`.

cc @ronniegeraghty (Switch 🤍 / Morpheus 🕶️ for review)