### PR TITLE
test(#608): MultiSelectFilter outside-click / Escape / empty-options coverage

### DIFF
--- a/site/src/__tests__/multi-select-filter.test.tsx
+++ b/site/src/__tests__/multi-select-filter.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MultiSelectFilter } from "../app/components/ui/multi-select-filter";
+
+const OPTIONS = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+];
+
+function openDropdown(label = "Config") {
+  fireEvent.click(screen.getByRole("button", { name: `Filter by ${label}` }));
+}
+
+describe("MultiSelectFilter", () => {
+  it("closes the dropdown when clicking outside", () => {
+    render(
+      <div>
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={[]}
+          onChange={vi.fn()}
+        />
+        <button type="button">outside</button>
+      </div>,
+    );
+
+    openDropdown();
+    expect(screen.getByRole("listbox", { name: "Config" })).toBeInTheDocument();
+
+    // The component listens to "mousedown" on document, so dispatch that.
+    fireEvent.mouseDown(screen.getByText("outside"));
+
+    expect(screen.queryByRole("listbox", { name: "Config" })).not.toBeInTheDocument();
+  });
+
+  it("closes the dropdown when pressing Escape", () => {
+    render(
+      <MultiSelectFilter
+        label="Config"
+        options={OPTIONS}
+        selected={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    openDropdown();
+    expect(screen.getByRole("listbox", { name: "Config" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox", { name: "Config" })).not.toBeInTheDocument();
+  });
+
+  it("renders a 'No options' message when options list is empty", () => {
+    render(
+      <MultiSelectFilter
+        label="Config"
+        options={[]}
+        selected={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    openDropdown();
+
+    const listbox = screen.getByRole("listbox", { name: "Config" });
+    expect(listbox).toHaveTextContent("No options");
+    // Confirm no option rows render when the list is empty.
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Phase 6 polish task from #608 — review follow-up for PR #604 (run-level filter system, #600).

Adds component tests for `MultiSelectFilter` covering the three gaps flagged in review:

- **Outside-click dismissal** — `mousedown` on an element outside the component closes the dropdown.
- **Escape key dismissal** — `keydown` with `Escape` closes the dropdown.
- **Empty-options state rendering** — when `options=[]`, the listbox renders a "No options" placeholder and no option rows.

## Verification

- `cd site && npm test -- --run` → **122/122 green** (3 new tests in `src/__tests__/multi-select-filter.test.tsx`).
- Uses the existing vitest + `@testing-library/react` `fireEvent` pattern already in use across the test suite (e.g. `runs-page.test.tsx`, `comparison-page.test.tsx`).
- No production code changes.

Targets `phase-6` (Phase 6 integration branch; not yet merged to `dev`).

Refs #608.