### PR TITLE
test(#608): group property coverage (#606 polish)

### DIFF
--- a/hyoka/internal/eval/engine_group_wiring_test.go
+++ b/hyoka/internal/eval/engine_group_wiring_test.go
@@ -1,0 +1,93 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/config"
+	"github.com/ronniegeraghty/hyoka/hyoka/internal/prompt"
+)
+
+// TestPromptGroupPropagatesToEvalReport is an observable-wiring test
+// (#587 trap) for PR #606. It proves that a prompt's `group` frontmatter
+// field actually reaches the EvalReport.PromptMeta["group"] runtime payload
+// that reports and the site consume.
+//
+// The wire-up point is hyoka/internal/eval/engine_eval.go:78-80 — if a
+// future refactor drops that block, unit tests on the parser/validator
+// would still pass while the site-visible grouping silently breaks.
+//
+// This runs the full engine.Run pipeline with a StubRunner so we hit the
+// real PromptMeta construction, then asserts on the exact runtime payload.
+func TestPromptGroupPropagatesToEvalReport(t *testing.T) {
+	tests := []struct {
+		name      string
+		group     string
+		wantKey   bool   // should "group" key exist in PromptMeta?
+		wantValue string // expected value if key exists
+	}{
+		{
+			name:      "group set propagates to PromptMeta",
+			group:     "crud-operations",
+			wantKey:   true,
+			wantValue: "crud-operations",
+		},
+		{
+			name:    "empty group omitted from PromptMeta",
+			group:   "",
+			wantKey: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			engine := NewEngine(&StubRunner{}, quietOpts(EngineOptions{
+				Workers:   1,
+				OutputDir: outputDir,
+			}))
+
+			prompts := []*prompt.Prompt{{
+				ID:    "group-wiring-check",
+				Group: tt.group,
+				Properties: map[string]string{
+					"service":  "storage",
+					"language": "python",
+					"plane":    "data-plane",
+					"category": "crud",
+				},
+			}}
+			configs := []config.ToolConfig{{
+				Name:      "test-config",
+				Generator: &config.GeneratorConfig{Model: "gpt-4"},
+			}}
+
+			summary, err := engine.Run(context.Background(), prompts, configs)
+			if err != nil {
+				t.Fatalf("engine.Run: %v", err)
+			}
+			if len(summary.Results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(summary.Results))
+			}
+			r := summary.Results[0]
+			if r.PromptMeta == nil {
+				t.Fatalf("PromptMeta is nil — wiring is dead")
+			}
+
+			got, ok := r.PromptMeta["group"]
+			if tt.wantKey {
+				if !ok {
+					t.Fatalf(`PromptMeta["group"] missing — frontmatter group %q never reached the engine wiring point (engine_eval.go:78-80)`, tt.group)
+				}
+				gotStr, _ := got.(string)
+				if gotStr != tt.wantValue {
+					t.Errorf(`PromptMeta["group"] = %q, want %q`, gotStr, tt.wantValue)
+				}
+			} else {
+				if ok {
+					t.Errorf(`PromptMeta["group"] = %v, want key absent for empty Group`, got)
+				}
+			}
+		})
+	}
+}

--- a/hyoka/internal/prompt/group_json_test.go
+++ b/hyoka/internal/prompt/group_json_test.go
@@ -1,0 +1,86 @@
+package prompt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPromptGroupJSONOmitempty verifies that the `group` field on
+// prompt.Prompt honors `json:"group,omitempty"`:
+//   - When Group is empty, the JSON output must NOT contain a "group" key.
+//   - When Group is non-empty, the JSON output must round-trip cleanly.
+//
+// This guards against accidental removal of the omitempty tag, which would
+// pollute every ungrouped prompt's JSON payload with an empty string and
+// break downstream "is this prompt grouped?" checks in the site/report
+// layer (#606 polish, #608).
+func TestPromptGroupJSONOmitempty(t *testing.T) {
+	t.Run("empty group is omitted", func(t *testing.T) {
+		p := &Prompt{
+			ID:         "test-dp-python-sample",
+			PromptText: "do the thing",
+			Properties: map[string]string{"service": "storage"},
+			// Group intentionally zero-valued.
+		}
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(raw), `"group"`) {
+			t.Errorf(`empty Group should be omitted via omitempty; got JSON containing "group": %s`, raw)
+		}
+	})
+
+	t.Run("non-empty group round-trips", func(t *testing.T) {
+		in := &Prompt{
+			ID:         "test-dp-python-sample",
+			PromptText: "do the thing",
+			Group:      "crud-operations",
+			Properties: map[string]string{"service": "storage"},
+		}
+		raw, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if !strings.Contains(string(raw), `"group":"crud-operations"`) {
+			t.Errorf(`expected "group":"crud-operations" in JSON; got: %s`, raw)
+		}
+
+		var out Prompt
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if out.Group != in.Group {
+			t.Errorf("Group round-trip mismatch: got %q, want %q", out.Group, in.Group)
+		}
+	})
+
+	t.Run("absent group unmarshals as empty", func(t *testing.T) {
+		raw := []byte(`{"id":"x","prompt_text":"y","properties":{"service":"s"}}`)
+		var out Prompt
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if out.Group != "" {
+			t.Errorf("absent group should unmarshal to empty string; got %q", out.Group)
+		}
+	})
+
+	t.Run("explicit empty group also omitted on remarshal", func(t *testing.T) {
+		// Simulates: load a prompt that had group:"x", clear it, re-marshal.
+		p := &Prompt{
+			ID:         "test-dp-python-sample",
+			PromptText: "do the thing",
+			Group:      "",
+			Properties: map[string]string{"service": "storage"},
+		}
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(raw), `"group"`) {
+			t.Errorf(`cleared Group should still be omitted via omitempty; got: %s`, raw)
+		}
+	})
+}

--- a/hyoka/internal/validate/group_test.go
+++ b/hyoka/internal/validate/group_test.go
@@ -29,6 +29,44 @@ func TestIsValidGroupName(t *testing.T) {
 		{"slash/group", false},
 		{strings.Repeat("a", 65), false},
 		{strings.Repeat("a", 64), true},
+		// Boundary conditions (#608 polish):
+		{strings.Repeat("a", 63), true},                    // one under max
+		{"ab" + strings.Repeat("-c", 31), true},            // 64-char hyphenated
+		{"ab" + strings.Repeat("-c", 31) + "d", false},     // 65-char hyphenated
+		{" ", false},                                       // whitespace only
+		{"   ", false},                                     // multi whitespace
+		{"\t", false},                                      // tab
+		{"\n", false},                                      // newline
+		{"a\nb", false},                                    // embedded newline
+		{"leading space", false},
+		{" leading-space", false},                          // leading actual space
+		{"trailing-space ", false},
+		{"-", false},                                       // hyphen only
+		{"--", false},                                      // only hyphens
+		{"a-", false},                                      // trailing hyphen after letter
+		{"-a", false},                                      // leading hyphen before letter
+		{"a--b", false},                                    // consecutive hyphens mid
+		{"a---b", false},                                   // triple consecutive hyphens
+		{"a-b-c-d-e-f", true},                              // many single hyphens
+		{"a1", true},                                       // letter + digit
+		{"a-1", true},                                      // letter-digit segment
+		{"a-1b", true},                                     // mixed alphanumeric segment
+		{"1", false},                                       // single digit
+		{"1a", false},                                      // starts with digit
+		{"0-abc", false},                                   // starts with digit + hyphen
+		{"abc.def", false},                                 // dot separator
+		{"abc_def", false},                                 // underscore
+		{"abc+def", false},                                 // plus
+		{"abc def", false},                                 // internal space
+		{"abc@def", false},                                 // at sign
+		{"abc#def", false},                                 // hash
+		{"abc!def", false},                                 // bang
+		{"ABC", false},                                     // all uppercase
+		{"aBc", false},                                     // mixed case
+		{"ñoño", false},                                    // non-ASCII lowercase
+		{"café", false},                                    // accented lowercase
+		{"emoji🙂", false},                                  // emoji
+		{"null\x00byte", false},                            // embedded null
 	}
 	for _, c := range cases {
 		if got := IsValidGroupName(c.in); got != c.want {


### PR DESCRIPTION
Phase 6 polish for PR #606 (group property). Test-only additions closing three coverage gaps Morpheus called out in review.

## What's added

1. **Observable-wiring test** — `hyoka/internal/eval/engine_group_wiring_test.go`
   Runs the full `engine.Run` pipeline with `StubRunner` and asserts a prompt's frontmatter `group` field reaches `EvalReport.PromptMeta["group"]` at the wire-up point (engine_eval.go:78–80). #587-trap pattern: catches silent regressions where the wire goes dead but unit tests stay green. Covers both propagation (group set → present) and the empty-group-omitted case.

2. **Regex boundary rows** — `hyoka/internal/validate/group_test.go`

3. **JSON omitempty round-trip** — `hyoka/internal/prompt/group_json_test.go`
   Marshals `prompt.Prompt` with and without `Group`, asserts the `group` key is absent from JSON when empty, present and correct when set, and that unmarshal → remarshal is stable in both directions.

## Verification

`go test -race ./hyoka/... -timeout 3m` → all packages PASS.

Test-only changes. No production code modified.

Refs #608, #606.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>