### PR TITLE
ci(#608): embedded-asset-freshness automation (Makefile + CI check)

### DIFF
--- a/.github/workflows/site-embed-freshness.yml
+++ b/.github/workflows/site-embed-freshness.yml
@@ -1,0 +1,44 @@
+name: Site Embed Freshness
+
+# Enforces that hyoka/internal/serve/site/ (the go:embed'd bundle) is kept
+# in sync with site/src/**. Rebuilds the site on the PR branch and fails if
+# the committed embedded tree differs from a fresh build.
+#
+# See .squad/skills/embedded-asset-freshness/SKILL.md.
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'site/**'
+      - 'hyoka/internal/serve/site/**'
+      - 'hyoka/internal/serve/embed.go'
+      - 'Makefile'
+      - '.github/workflows/site-embed-freshness.yml'
+  push:
+    branches:
+      - main
+      - phase-6
+      - ronniegeraghty/dev
+
+jobs:
+  verify-embedded-bundle:
+    name: Verify embedded site bundle is fresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install site dependencies
+        run: make site-install
+
+      - name: Verify embedded bundle matches fresh build
+        run: make verify-embed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# hyoka — developer convenience targets.
+#
+# The canonical build system for hyoka is `go build`. This Makefile wraps the
+# multi-step workflows that can't be expressed as a single `go` invocation,
+# starting with refreshing the embedded site bundle.
+#
+# Usage:
+#   make site-embed     # rebuild site/ and copy dist/ into the embedded tree
+#   make site-build     # rebuild site/ only (output stays in site/dist/)
+#   make site-install   # install site/ node_modules (npm ci)
+#   make verify-embed   # fail if the embedded bundle is out of date
+#
+# See .squad/skills/embedded-asset-freshness/SKILL.md for the rationale.
+
+SITE_DIR  := site
+EMBED_DIR := hyoka/internal/serve/site
+
+.PHONY: help site-install site-build site-embed verify-embed
+
+help:
+	@echo "hyoka Makefile targets:"
+	@echo "  site-install   Install site/ dependencies (npm ci)"
+	@echo "  site-build     Run 'npm run build' in site/"
+	@echo "  site-embed     Rebuild site/ and refresh $(EMBED_DIR)/"
+	@echo "  verify-embed   Rebuild and verify $(EMBED_DIR)/ matches site/dist/"
+
+site-install:
+	cd $(SITE_DIR) && npm ci
+
+site-build:
+	cd $(SITE_DIR) && npm run build
+
+# site-embed is idempotent: rerunning with no source changes leaves the
+# embedded tree byte-identical (vite content-hashes filenames deterministically).
+site-embed: site-build
+	rm -rf $(EMBED_DIR)/assets
+	mkdir -p $(EMBED_DIR)
+	cp -R $(SITE_DIR)/dist/. $(EMBED_DIR)/
+	@echo "[site-embed] refreshed $(EMBED_DIR)/ from $(SITE_DIR)/dist/"
+
+# verify-embed is the CI gate: rebuild and diff. Non-zero exit if the
+# committed embedded bundle drifted from what site/src/** currently produces.
+verify-embed: site-embed
+	@if ! git diff --quiet -- $(EMBED_DIR); then \
+		echo ""; \
+		echo "ERROR: embedded site bundle is stale."; \
+		echo "  site/src/** has changes that were not copied into $(EMBED_DIR)/."; \
+		echo "  Run 'make site-embed' and commit the result."; \
+		echo ""; \
+		echo "Diff:"; \
+		git --no-pager diff --stat -- $(EMBED_DIR); \
+		exit 1; \
+	fi
+	@echo "[verify-embed] $(EMBED_DIR)/ is up to date."

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ go test -race ./...
 # Test site (frontend)
 cd site && npm test
 
+# Rebuild the site AND refresh the embedded bundle that `hyoka serve` ships.
+# Required whenever you change anything under site/src/** — a CI check
+# (site-embed-freshness) will fail the PR otherwise.
+make site-embed
+
 # Test with a live eval (fastest feedback)
 go run ./hyoka run --prompt-id key-vault-dp-python-crud \
   --config baseline/claude-opus-4.6


### PR DESCRIPTION
Closes #608.

Systemic fix for the blocker caught during the #607 Phase 6 rollup review: six site-touching PRs landed without refreshing ``hyoka/internal/serve/site/``, so the merged binary shipped the previous UI while all CI stayed green. This PR adds **two layers of defense** so that can't happen again.

## Layer A — ``make site-embed``

New top-level ``Makefile`` with:

- ``site-install`` — ``npm ci`` in ``site/``
- ``site-build`` — ``npm run build`` in ``site/``
- ``site-embed`` — builds the site then copies ``site/dist/*`` into ``hyoka/internal/serve/site/``. **Idempotent**: rerunning with no source changes leaves the embedded tree byte-identical because vite content-hashes filenames deterministically.
- ``verify-embed`` — rebuild + ``git diff --exit-code`` on the embed dir. Emits a clear actionable error if the tree is stale.

``README.md`` now points developers at ``make site-embed`` in the quick-development-loop section, so it's discoverable from the first doc a new contributor reads.

## Layer B — CI freshness check

``.github/workflows/site-embed-freshness.yml`` runs ``make verify-embed`` on every PR that touches ``site/**``, ``hyoka/internal/serve/site/**``, ``hyoka/internal/serve/embed.go``, or the Makefile itself. Hash-diff approach (per the skill's preference): rebuild on the PR branch and fail if the freshly-built bundle diverges from what's committed — catches ""I forgot to commit the rebuild"" precisely.

The existing ``ci.yml`` (Go build/vet/test + site build/test) is untouched. The new workflow is a net addition.

## Verification performed

- ``make site-embed`` on a clean tree → no git diff (idempotent ✓).
- Edited ``site/src/main.tsx`` with a ``console.log`` probe → ``make verify-embed`` exits non-zero with a diff summary ✓.
- Reverted probe → tree clean, ``go build ./hyoka/...`` passes ✓.
- ``yaml.safe_load`` on the new workflow file → valid ✓.

## References

- Issue #608
- Skill: [``.squad/skills/embedded-asset-freshness/SKILL.md``](.squad/skills/embedded-asset-freshness/SKILL.md) — which called out exactly these two Phase-7 candidate fixes (``make`` target + CI hash-diff).
- Original catch: PR #607 rollup review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>