### PR TITLE
refactor(#608): fetcher cleanups and test coverage (#605 polish)

### DIFF
--- a/hyoka/cmd/run.go
+++ b/hyoka/cmd/run.go
@@ -258,13 +258,13 @@ func runCmd() *cobra.Command {
 
 			// Pre-flight: every remote skill needs a registered Fetcher.
 			// Failing here gives a fast, clear error before any session starts.
-			var allEntries [][]tool.Entry
+			var allEntries []tool.Entry
 			for _, c := range configs {
 				if c.Generator != nil {
-					allEntries = append(allEntries, c.Generator.Tools)
+					allEntries = append(allEntries, c.Generator.Tools...)
 				}
 				if c.Reviewer != nil {
-					allEntries = append(allEntries, c.Reviewer.Tools)
+					allEntries = append(allEntries, c.Reviewer.Tools...)
 				}
 			}
 			if err := tool.ValidateFetchers(allEntries); err != nil {

--- a/hyoka/internal/config/tool/fetcher.go
+++ b/hyoka/internal/config/tool/fetcher.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"sync"
 )
 
@@ -157,20 +156,19 @@ func Register(f Fetcher) error { return DefaultRegistry.Register(f) }
 // the default registry.
 func LookupFetcher(entry Entry) Fetcher { return DefaultRegistry.Lookup(entry) }
 
-// ValidateFetchers checks that every remote skill entry across the given
-// configs has a registered fetcher willing to handle it. Returns the first
+// ValidateFetchers checks that every remote skill entry in the given slice
+// has a registered fetcher willing to handle it. Returns the first
 // missing-fetcher error encountered. Intended to be called by the eval
 // engine before any session starts so users get a fast, clear failure
-// instead of a mid-eval surprise.
-func ValidateFetchers(configs [][]Entry) error {
-	for _, entries := range configs {
-		for _, e := range entries {
-			if e.ResolvedType() != TypeSkill || e.SkillSource() != SourceRemote {
-				continue
-			}
-			if LookupFetcher(e) == nil {
-				return fmt.Errorf("no fetcher registered for remote skill %q (repo=%q)", e.Name, e.Repo)
-			}
+// instead of a mid-eval surprise. Non-remote and non-skill entries are
+// ignored.
+func ValidateFetchers(entries []Entry) error {
+	for _, e := range entries {
+		if e.ResolvedType() != TypeSkill || e.SkillSource() != SourceRemote {
+			continue
+		}
+		if LookupFetcher(e) == nil {
+			return fmt.Errorf("no fetcher registered for remote skill %q (repo=%q)", e.Name, e.Repo)
 		}
 	}
 	return nil
@@ -220,7 +218,6 @@ func (npxFetcher) Fetch(ctx context.Context, req FetchRequest) (FetchResult, err
 		args = append(args, "--name", entry.Name)
 	}
 
-	fmt.Printf("Fetching remote skill: %s (repo: %s, version: %s)\n", entry.Name, entry.Repo, versionSegment)
 	slog.Info("Fetching remote skill", "skill", entry.Name, "repo", entry.Repo, "version", versionSegment, "fetcher", defaultFetcherName)
 
 	cmd := exec.CommandContext(ctx, "npx", args...)
@@ -236,12 +233,4 @@ func (npxFetcher) Fetch(ctx context.Context, req FetchRequest) (FetchResult, err
 		abs = installDir
 	}
 	return FetchResult{Dir: abs, Version: versionSegment}, nil
-}
-
-// SortedFetcherNames returns registered fetcher names sorted alphabetically.
-// Useful for stable diagnostic output.
-func SortedFetcherNames() []string {
-	names := DefaultRegistry.Names()
-	sort.Strings(names)
-	return names
 }

--- a/hyoka/internal/config/tool/fetcher_test.go
+++ b/hyoka/internal/config/tool/fetcher_test.go
@@ -140,7 +140,7 @@ func TestCustomFetcherInvokedAtRuntime(t *testing.T) {
 	}
 	t.Cleanup(func() { DefaultRegistry.Unregister(mock.name) })
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/widgets", Name: "widget", Version: "v1.2.3"},
 	}, t.TempDir())
 	if err != nil {
@@ -172,7 +172,7 @@ func TestCustomFetcherErrorPropagates(t *testing.T) {
 	}
 	t.Cleanup(func() { DefaultRegistry.Unregister(mock.name) })
 
-	_, err := ResolveSkills([]Entry{
+	_, err := ResolveSkills(context.Background(), []Entry{
 		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/fail", Name: "x"},
 	}, t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "mock fetch failure") {
@@ -182,24 +182,39 @@ func TestCustomFetcherErrorPropagates(t *testing.T) {
 
 func TestValidateFetchers(t *testing.T) {
 	// Local skills and non-skill entries always pass — fetcher unrelated.
-	if err := ValidateFetchers([][]Entry{{
+	if err := ValidateFetchers([]Entry{
 		{Type: TypeSkill, Source: SourceLocal, Path: "/tmp/x"},
 		{Type: TypeMCP, Name: "mcp"},
-	}}); err != nil {
+	}); err != nil {
 		t.Errorf("local-only validation: %v", err)
 	}
 	// Remote skill is OK because the default npx fetcher always matches.
-	if err := ValidateFetchers([][]Entry{{
+	if err := ValidateFetchers([]Entry{
 		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/x"},
-	}}); err != nil {
+	}); err != nil {
 		t.Errorf("remote with default fetcher: %v", err)
+	}
+	// No-fetcher branch: temporarily unregister the default npx fetcher so
+	// nothing in the registry matches a remote skill. ValidateFetchers must
+	// surface a clear error rather than silently passing.
+	DefaultRegistry.Unregister(defaultFetcherName)
+	t.Cleanup(func() { _ = DefaultRegistry.Register(&npxFetcher{}) })
+	err := ValidateFetchers([]Entry{
+		{Type: TypeSkill, Source: SourceRemote, Repo: "acme/orphan", Name: "x"},
+	})
+	if err == nil {
+		t.Fatal("expected error when no fetcher is registered for a remote skill")
+	}
+	if !strings.Contains(err.Error(), "no fetcher registered") ||
+		!strings.Contains(err.Error(), "acme/orphan") {
+		t.Errorf("error does not identify missing-fetcher cause or repo: %v", err)
 	}
 }
 
-// TestNpxFetcher_VersionInPath verifies that the default fetcher writes
-// different versions to different cache subdirectories — so toggling a
-// version override doesn't poison the cache.
-func TestNpxFetcher_VersionInPath(t *testing.T) {
+// TestNpxFetcher_CanFetchAndName verifies the default fetcher's interface
+// contract: it accepts remote skills, rejects local/non-skill entries, and
+// reports the canonical name used by the registry.
+func TestNpxFetcher_CanFetchAndName(t *testing.T) {
 	f := npxFetcher{}
 	if !f.CanFetch(Entry{Type: TypeSkill, Source: SourceRemote, Repo: "x/y"}) {
 		t.Fatal("npx must accept remote skill")
@@ -213,4 +228,54 @@ func TestNpxFetcher_VersionInPath(t *testing.T) {
 	if f.Name() != defaultFetcherName {
 		t.Errorf("name mismatch: %q", f.Name())
 	}
+}
+
+// TestFetchRemote_ContextPropagates verifies that the ctx passed to
+// FetchRemote reaches the fetcher's Fetch method — guards against silently
+// discarding the caller's cancellation/deadline.
+func TestFetchRemote_ContextPropagates(t *testing.T) {
+	type ctxKey string
+	const key ctxKey = "probe"
+
+	var seen context.Context
+	mock := &ctxProbeFetcher{
+		name:      "ctx-probe",
+		matchRepo: "acme/ctx",
+		onFetch:   func(c context.Context) { seen = c },
+		dir:       t.TempDir(),
+	}
+	if err := DefaultRegistry.Register(mock); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() { DefaultRegistry.Unregister(mock.name) })
+
+	ctx := context.WithValue(context.Background(), key, "hit")
+	if _, err := FetchRemote(ctx, Entry{Type: TypeSkill, Source: SourceRemote, Repo: "acme/ctx", Name: "x"}, t.TempDir()); err != nil {
+		t.Fatalf("FetchRemote: %v", err)
+	}
+	if seen == nil {
+		t.Fatal("fetcher was never called")
+	}
+	if v, _ := seen.Value(key).(string); v != "hit" {
+		t.Errorf("ctx value did not propagate to fetcher; got %q", v)
+	}
+}
+
+// ctxProbeFetcher captures the ctx its Fetch method is invoked with.
+type ctxProbeFetcher struct {
+	name      string
+	matchRepo string
+	onFetch   func(context.Context)
+	dir       string
+}
+
+func (c *ctxProbeFetcher) Name() string { return c.name }
+func (c *ctxProbeFetcher) CanFetch(e Entry) bool {
+	return e.ResolvedType() == TypeSkill && e.SkillSource() == SourceRemote && e.Repo == c.matchRepo
+}
+func (c *ctxProbeFetcher) Fetch(ctx context.Context, req FetchRequest) (FetchResult, error) {
+	if c.onFetch != nil {
+		c.onFetch(ctx)
+	}
+	return FetchResult{Dir: c.dir, Version: req.Version}, nil
 }

--- a/hyoka/internal/config/tool/resolve.go
+++ b/hyoka/internal/config/tool/resolve.go
@@ -17,7 +17,7 @@ import (
 //   - source: local, skill_dir: true  → path is a directory of skills (subdirs contain SKILL.md)
 //   - source: local with glob         → each glob match is treated as a single skill directory
 //   - source: remote                  → dispatched to the registered Fetcher (default: npx)
-func ResolveSkills(entries []Entry, baseDir string) ([]string, error) {
+func ResolveSkills(ctx context.Context, entries []Entry, baseDir string) ([]string, error) {
 	var dirs []string
 	for _, entry := range entries {
 		if entry.ResolvedType() != TypeSkill {
@@ -32,7 +32,7 @@ func ResolveSkills(entries []Entry, baseDir string) ([]string, error) {
 			slog.Debug("Resolved local skill", "path", entry.Path, "skill_dir", entry.SkillDir, "resolved_count", len(resolved))
 			dirs = append(dirs, resolved...)
 		case SourceRemote:
-			dir, err := FetchRemote(entry, baseDir)
+			dir, err := FetchRemote(ctx, entry, baseDir)
 			if err != nil {
 				return nil, fmt.Errorf("fetching remote skill %s/%s: %w", entry.Repo, entry.Name, err)
 			}
@@ -164,13 +164,14 @@ func resolveSkillDir(dir string) ([]string, error) {
 // from DefaultRegistry; users can register custom fetchers via Register to
 // override or extend this behavior. Honors entry.Version (which may have been
 // set by ApplyVersionOverrides) and falls back to the fetcher's default when
-// empty.
-func FetchRemote(entry Entry, baseDir string) (string, error) {
+// empty. The provided context is passed to the fetcher so cancellation and
+// deadlines propagate into any HTTP/exec work it performs.
+func FetchRemote(ctx context.Context, entry Entry, baseDir string) (string, error) {
 	f := LookupFetcher(entry)
 	if f == nil {
 		return "", fmt.Errorf("no fetcher registered for remote skill %q (repo=%q)", entry.Name, entry.Repo)
 	}
-	res, err := f.Fetch(context.Background(), FetchRequest{
+	res, err := f.Fetch(ctx, FetchRequest{
 		Entry:   entry,
 		BaseDir: baseDir,
 		Version: entry.Version,

--- a/hyoka/internal/config/tool/resolve_test.go
+++ b/hyoka/internal/config/tool/resolve_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +17,7 @@ func TestResolveSkills_SingleSkill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: skillDir, Name: "local-skill"},
 	}, dir)
 	if err != nil {
@@ -38,7 +39,7 @@ func TestResolveSkills_SingleSkillMissingSKILLMD(t *testing.T) {
 	}
 	// No SKILL.md — should warn and return nothing
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: skillDir, Name: "local-skill"},
 	}, dir)
 	if err != nil {
@@ -67,7 +68,7 @@ func TestResolveSkills_SkillDir(t *testing.T) {
 		}
 	}
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: "skills/generator", Name: "gen-skills", SkillDir: true},
 	}, dir)
 	if err != nil {
@@ -88,7 +89,7 @@ func TestResolveSkills_SkillDirEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: emptyDir, Name: "empty-skills", SkillDir: true},
 	}, dir)
 	if err != nil {
@@ -113,7 +114,7 @@ func TestResolveSkills_GlobPattern(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "skills", "readme.txt"), []byte("hi"), 0644)
 	_ = f
 
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: filepath.Join(dir, "skills", "*"), Name: "local-skill"},
 	}, dir)
 	if err != nil {
@@ -126,7 +127,7 @@ func TestResolveSkills_GlobPattern(t *testing.T) {
 }
 
 func TestResolveSkills_EmptyEntries(t *testing.T) {
-	dirs, err := ResolveSkills(nil, ".")
+	dirs, err := ResolveSkills(context.Background(), nil, ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -136,7 +137,7 @@ func TestResolveSkills_EmptyEntries(t *testing.T) {
 }
 
 func TestResolveSkills_NonExistentDir(t *testing.T) {
-	dirs, err := ResolveSkills([]Entry{
+	dirs, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "local", Path: "/does/not/exist", Name: "missing"},
 	}, ".")
 	if err != nil {
@@ -186,7 +187,7 @@ func TestCountSkills_NilDirs(t *testing.T) {
 }
 
 func TestResolveSkills_InvalidType(t *testing.T) {
-	_, err := ResolveSkills([]Entry{
+	_, err := ResolveSkills(context.Background(), []Entry{
 		{Type: "skill", Source: "unknown", Path: "/some/path", Name: "bad-skill"},
 	}, ".")
 	if err == nil {

--- a/hyoka/internal/eval/copilot.go
+++ b/hyoka/internal/eval/copilot.go
@@ -163,7 +163,7 @@ func (e *CopilotPromptRunner) Run(ctx context.Context, p *prompt.Prompt, cfg *co
 	}
 	defer os.RemoveAll(configDir)
 
-	sessionCfg := e.buildSessionConfig(cfg, workDir, configDir, mergePromptProperties(p))
+	sessionCfg := e.buildSessionConfig(ctx, cfg, workDir, configDir, mergePromptProperties(p))
 
 	// Subscribe to events with detailed capture and debug logging.
 	// This MUST be set before CreateSession — the SDK reads OnEvent during
@@ -719,13 +719,13 @@ func mergePromptProperties(p *prompt.Prompt) map[string]string {
 	return make(map[string]string)
 }
 
-func (e *CopilotPromptRunner) buildSessionConfig(cfg *config.ToolConfig, workDir string, configDir string, promptProps map[string]string) *copilot.SessionConfig {
+func (e *CopilotPromptRunner) buildSessionConfig(ctx context.Context, cfg *config.ToolConfig, workDir string, configDir string, promptProps map[string]string) *copilot.SessionConfig {
 	// Resolve skill directories from Generator.Tools using the skills package.
 	// This handles glob patterns, validates directories exist and contain skills,
 	// and warns about empty/missing directories (#291).
 	var skillDirs []string
 	if cfg.Generator != nil {
-		resolved, err := tool.ResolveSkills(cfg.Generator.Tools, configDir)
+		resolved, err := tool.ResolveSkills(ctx, cfg.Generator.Tools, configDir)
 		if err != nil {
 			slog.Warn("Failed to resolve generator skill directories", "error", err)
 		} else {

--- a/hyoka/internal/eval/copilot_test.go
+++ b/hyoka/internal/eval/copilot_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestBuildSessionConfig_EmptyToolsIsNil(t *testing.T) {
 			ExcludedTools: []string{},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.AvailableTools != nil {
 		t.Errorf("expected AvailableTools nil (all tools), got %v", sc.AvailableTools)
 	}
@@ -33,7 +34,7 @@ func TestBuildSessionConfig_NilAvailableToolsIsNil(t *testing.T) {
 		Name:      "test",
 		Generator: &config.GeneratorConfig{Model: "gpt-4"},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.AvailableTools != nil {
 		t.Errorf("expected AvailableTools nil, got %v", sc.AvailableTools)
 	}
@@ -56,7 +57,7 @@ func TestBuildSessionConfig_PopulatedAvailableToolsPreserved(t *testing.T) {
 			ExcludedTools: []string{"web_fetch"},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if len(sc.AvailableTools) != 3 {
 		t.Errorf("expected 3 AvailableTools, got %d", len(sc.AvailableTools))
 	}
@@ -68,7 +69,7 @@ func TestBuildSessionConfig_PopulatedAvailableToolsPreserved(t *testing.T) {
 func TestBuildSessionConfig_WorkingDirectory(t *testing.T) {
 	e := &CopilotPromptRunner{}
 	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/eval-123", "", nil)
 	if sc.WorkingDirectory != "/workspace/eval-123" {
 		t.Errorf("expected WorkingDirectory '/workspace/eval-123', got %q", sc.WorkingDirectory)
 	}
@@ -77,7 +78,7 @@ func TestBuildSessionConfig_WorkingDirectory(t *testing.T) {
 func TestBuildSessionConfig_ConfigDir(t *testing.T) {
 	e := &CopilotPromptRunner{}
 	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-	sc := e.buildSessionConfig(cfg, "/workspace/eval-123", "/isolated/config", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/eval-123", "/isolated/config", nil)
 	if sc.ConfigDir != "/isolated/config" {
 		t.Errorf("expected ConfigDir '/isolated/config', got %q", sc.ConfigDir)
 	}
@@ -86,7 +87,7 @@ func TestBuildSessionConfig_ConfigDir(t *testing.T) {
 func TestBuildSessionConfig_PermissionHandler(t *testing.T) {
 	e := &CopilotPromptRunner{}
 	cfg := &config.ToolConfig{Name: "test", Generator: &config.GeneratorConfig{Model: "gpt-4"}}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.OnPermissionRequest == nil {
 		t.Error("expected OnPermissionRequest to be set (ApproveAll)")
 	}
@@ -108,7 +109,7 @@ func TestBuildSessionConfig_MCPServers(t *testing.T) {
 			},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if len(sc.MCPServers) != 1 {
 		t.Errorf("expected 1 MCP server, got %d", len(sc.MCPServers))
 	}
@@ -138,13 +139,13 @@ func TestBuildSessionConfig_ToolEntryResolution(t *testing.T) {
 	}
 
 	// Python prompt should get all 3 tools
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python", "service": "identity"})
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{"language": "python", "service": "identity"})
 	if len(sc.AvailableTools) != 3 {
 		t.Fatalf("expected 3 AvailableTools for python, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
 	}
 
 	// Dotnet prompt should get only 2 tools (azure_mcp excluded)
-	sc = e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
+	sc = e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
 	if len(sc.AvailableTools) != 2 {
 		t.Fatalf("expected 2 AvailableTools for dotnet, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
 	}
@@ -166,7 +167,7 @@ func TestBuildSessionConfig_ToolEntryAllConditionalNoneMatch(t *testing.T) {
 			},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{"language": "dotnet"})
 	if sc.AvailableTools != nil {
 		t.Errorf("expected nil AvailableTools when no tools match, got %v", sc.AvailableTools)
 	}
@@ -182,7 +183,7 @@ func TestBuildSessionConfig_ExcludedToolsWithToolEntries(t *testing.T) {
 			ExcludedTools: []string{"web_fetch"},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if len(sc.AvailableTools) != 2 {
 		t.Errorf("expected 2 AvailableTools, got %d", len(sc.AvailableTools))
 	}
@@ -249,7 +250,7 @@ func TestBuildSessionConfig_CustomSystemPrompt(t *testing.T) {
 			SystemPrompt: "You are a helpful code generator.",
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python"})
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{"language": "python"})
 
 	if sc.Model != "gpt-4" {
 		t.Errorf("expected model 'gpt-4', got %q", sc.Model)
@@ -265,7 +266,7 @@ func TestBuildSessionConfig_EmptySystemPrompt(t *testing.T) {
 			Model: "gpt-4",
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{})
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{})
 
 	if sc.Model != "gpt-4" {
 		t.Errorf("expected model 'gpt-4', got %q", sc.Model)
@@ -339,7 +340,7 @@ configs:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			props := mergePromptProperties(tt.prompt)
-			sc := e.buildSessionConfig(cfg, "/workspace/test", "", props)
+			sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", props)
 
 			if len(sc.AvailableTools) != len(tt.wantAvail) {
 				t.Fatalf("AvailableTools: got %v, want %v", sc.AvailableTools, tt.wantAvail)
@@ -375,7 +376,7 @@ func TestIntegration_DuplicateToolEntries(t *testing.T) {
 			},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", map[string]string{"language": "python"})
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", map[string]string{"language": "python"})
 	if len(sc.AvailableTools) != 2 {
 		t.Fatalf("expected 2 tools after dedup, got %d: %v", len(sc.AvailableTools), sc.AvailableTools)
 	}
@@ -393,7 +394,7 @@ func TestBuildSessionConfig_SystemPromptSet(t *testing.T) {
 			SystemPrompt: "You are a helpful Azure SDK assistant.",
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.SystemMessage == nil {
 		t.Fatal("expected SystemMessage to be set when generator.system_prompt is configured")
 	}
@@ -415,7 +416,7 @@ func TestBuildSessionConfig_SystemPromptEmpty(t *testing.T) {
 		Name:      "test",
 		Generator: &config.GeneratorConfig{Model: "gpt-4"},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	// With allowCloud=false (default), safety boundaries are appended even without system_prompt.
 	if sc.SystemMessage == nil {
 		t.Fatal("expected SystemMessage with safety boundaries when allowCloud=false")
@@ -434,7 +435,7 @@ func TestBuildSessionConfig_AllowCloudSkipsSafetyBoundaries(t *testing.T) {
 			SystemPrompt: "You are a helpful Azure SDK assistant.",
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.SystemMessage == nil {
 		t.Fatal("expected SystemMessage to be set when generator.system_prompt is configured")
 	}
@@ -452,7 +453,7 @@ func TestBuildSessionConfig_AllowCloudNoSystemPrompt(t *testing.T) {
 		Name:      "test",
 		Generator: &config.GeneratorConfig{Model: "gpt-4"},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if sc.SystemMessage != nil {
 		t.Errorf("expected SystemMessage nil when allowCloud=true and no system_prompt, got %+v", sc.SystemMessage)
 	}
@@ -504,7 +505,7 @@ func TestBuildSessionConfig_RemoteMCP(t *testing.T) {
 			},
 		},
 	}
-	sc := e.buildSessionConfig(cfg, "/workspace/test", "", nil)
+	sc := e.buildSessionConfig(context.Background(), cfg, "/workspace/test", "", nil)
 	if len(sc.MCPServers) != 1 {
 		t.Fatalf("expected 1 MCP server, got %d", len(sc.MCPServers))
 	}

--- a/hyoka/internal/eval/engine.go
+++ b/hyoka/internal/eval/engine.go
@@ -494,7 +494,7 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 	}
 
 	if e.opts.DryRun {
-		return e.dryRun(tasks)
+		return e.dryRun(ctx, tasks)
 	}
 
 	// Resource monitor (#45) — opt-in via --monitor-resources.
@@ -762,7 +762,7 @@ func (e *Engine) Run(ctx context.Context, prompts []*prompt.Prompt, configs []co
 	return summary, nil
 }
 
-func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
+func (e *Engine) dryRun(ctx context.Context, tasks []EvalTask) (*report.RunSummary, error) {
 	summary := &report.RunSummary{
 		RunID:        "dry-run",
 		Timestamp:    time.Now().UTC().Format(time.RFC3339),
@@ -792,7 +792,7 @@ func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
 		validatedConfigs[t.Config.Name] = true
 		if t.Config.Generator != nil {
 			entries := countSkillEntries(t.Config.Generator.Tools)
-			resolved, err := tool.ResolveSkills(t.Config.Generator.Tools, "")
+			resolved, err := tool.ResolveSkills(ctx, t.Config.Generator.Tools, "")
 			if err != nil {
 				slog.Warn("Failed to resolve generator skills", "config", t.Config.Name, "error", err)
 				continue
@@ -804,7 +804,7 @@ func (e *Engine) dryRun(tasks []EvalTask) (*report.RunSummary, error) {
 		}
 		if t.Config.Reviewer != nil {
 			entries := countSkillEntries(t.Config.Reviewer.Tools)
-			resolved, err := tool.ResolveSkills(t.Config.Reviewer.Tools, "")
+			resolved, err := tool.ResolveSkills(ctx, t.Config.Reviewer.Tools, "")
 			if err != nil {
 				slog.Warn("Failed to resolve reviewer skills", "config", t.Config.Name, "error", err)
 				continue

--- a/hyoka/internal/eval/engine_eval.go
+++ b/hyoka/internal/eval/engine_eval.go
@@ -250,7 +250,7 @@ func (e *Engine) runSingleEval(ctx context.Context, task EvalTask, runID string,
 	// Use ResolveSkillDirs for accurate directory resolution (#291).
 	var skillDirectories []string
 	if task.Config.Generator != nil {
-		resolved, err := tool.ResolveSkills(task.Config.Generator.Tools, "")
+		resolved, err := tool.ResolveSkills(ctx, task.Config.Generator.Tools, "")
 		if err != nil {
 			slog.Warn("Failed to resolve skill directories for report", "error", err)
 		} else {


### PR DESCRIPTION
Phase 6 polish — follow-ups from PR #605 review. Refs #608.

- [x] **TestValidateFetchers — no-fetcher branch.** Previously only the happy path was covered. Added a sub-case that unregisters the default \`npx\` fetcher and asserts \`ValidateFetchers\` surfaces a clear \"no fetcher registered\" error naming the offending repo.
- [x] **Renamed TestNpxFetcher_VersionInPath → TestNpxFetcher_CanFetchAndName.** The old name claimed a version-in-path assertion that the body never made; the body exercises \`CanFetch\` and \`Name\`.
- [x] **Deleted dead \`SortedFetcherNames\`.** Grep confirmed zero callers in the tree. Removed the function and the now-unused \`sort\` import.
- [x] **\`FetchRemote\` threads \`ctx\`.** Signature is now \`FetchRemote(ctx, entry, baseDir)\`; the ctx reaches \`Fetcher.Fetch\` (and thus \`exec.CommandContext\` in the npx fetcher). \`ResolveSkills\` also takes a ctx and plumbs it through. Callers in \`Engine.dryRun\`, \`runSingleEval\`, and \`CopilotPromptRunner.buildSessionConfig\` pass their real ctx. New \`TestFetchRemote_ContextPropagates\` registers a probe fetcher that captures the ctx it was invoked with and asserts a value set on the caller's ctx survives — locks the behavior in so it can't silently regress to \`context.Background()\`.
- [x] **\`npxFetcher\` double-output removed.** Dropped the \`fmt.Printf(\"Fetching remote skill: ...\")\` line; the structured \`slog.Info\` remains as the single source of truth.
- [x] **\`ValidateFetchers\` takes a flat \`[]Entry\`.** The previous \`[][]Entry\` was awkward — callers had to hand-build nested slices. Call site in \`cmd/run.go\` now appends all configs' generator/reviewer tool entries into one slice, which reads more naturally.

## Verification

\`\`\`
go build ./hyoka/...
go test -race ./hyoka/... -timeout 3m
\`\`\`

All 24 packages green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>