### PR TITLE
test(#608): MultiSelectFilter toggle/onChange/aria/inside-click coverage

### DIFF
--- a/site/src/__tests__/multi-select-filter.test.tsx
+++ b/site/src/__tests__/multi-select-filter.test.tsx
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MultiSelectFilter } from "../app/components/ui/multi-select-filter";
 
 const OPTIONS = [
   { value: "a", label: "Alpha" },
   { value: "b", label: "Beta" },
+  { value: "c", label: "Gamma" },
 ];
 
 function openDropdown(label = "Config") {
@@ -68,5 +71,234 @@ describe("MultiSelectFilter", () => {
     expect(listbox).toHaveTextContent("No options");
     // Confirm no option rows render when the list is empty.
     expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+
+  describe("toggle / onChange", () => {
+    it("calls onChange with the value added when an unselected option is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["a"]}
+          onChange={onChange}
+        />,
+      );
+
+      openDropdown();
+      await user.click(screen.getByRole("option", { name: /Beta/ }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(["a", "b"]);
+    });
+
+    it("calls onChange with the value removed when a selected option is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["a", "b"]}
+          onChange={onChange}
+        />,
+      );
+
+      openDropdown();
+      await user.click(screen.getByRole("option", { name: /Alpha/ }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(["b"]);
+    });
+
+    it("preserves multi-select across multiple clicks (controlled wrapper)", async () => {
+      const user = userEvent.setup();
+      const onChangeSpy = vi.fn();
+
+      function Wrapper() {
+        const [sel, setSel] = useState<string[]>([]);
+        return (
+          <MultiSelectFilter
+            label="Config"
+            options={OPTIONS}
+            selected={sel}
+            onChange={(next) => {
+              onChangeSpy(next);
+              setSel(next);
+            }}
+          />
+        );
+      }
+
+      render(<Wrapper />);
+      openDropdown();
+
+      await user.click(screen.getByRole("option", { name: /Alpha/ }));
+      await user.click(screen.getByRole("option", { name: /Beta/ }));
+      await user.click(screen.getByRole("option", { name: /Gamma/ }));
+
+      expect(onChangeSpy).toHaveBeenNthCalledWith(1, ["a"]);
+      expect(onChangeSpy).toHaveBeenNthCalledWith(2, ["a", "b"]);
+      expect(onChangeSpy).toHaveBeenNthCalledWith(3, ["a", "b", "c"]);
+
+      // After three clicks, all three options should report aria-selected=true.
+      for (const name of [/Alpha/, /Beta/, /Gamma/]) {
+        expect(screen.getByRole("option", { name })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+      }
+
+      // Click Beta again to deselect; the surviving selection is preserved.
+      await user.click(screen.getByRole("option", { name: /Beta/ }));
+      expect(onChangeSpy).toHaveBeenNthCalledWith(4, ["a", "c"]);
+    });
+  });
+
+  describe("summary text", () => {
+    it("shows the empty label when nothing is selected", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={[]}
+          onChange={vi.fn()}
+          emptyLabel="Any"
+        />,
+      );
+
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveTextContent(/Config:\s*Any/);
+    });
+
+    it("respects a custom empty label", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={[]}
+          onChange={vi.fn()}
+          emptyLabel="All configs"
+        />,
+      );
+
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveTextContent(/Config:\s*All configs/);
+    });
+
+    it("shows the single selected value when exactly one is selected", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["a"]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      // Note: the component renders selected[0] (the value), not the label.
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveTextContent(/Config:\s*a/);
+    });
+
+    it("shows 'N selected' when more than one is selected", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["a", "b"]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveTextContent(/Config:\s*2 selected/);
+    });
+
+    it("scales the 'N selected' summary as more values are added (overflow branch)", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["a", "b", "c"]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveTextContent(/Config:\s*3 selected/);
+    });
+  });
+
+  describe("ARIA", () => {
+    it("toggles aria-expanded on the trigger when opened and closed", async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={[]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const trigger = screen.getByRole("button", { name: "Filter by Config" });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("sets aria-selected on each option to match the selected state", () => {
+      render(
+        <MultiSelectFilter
+          label="Config"
+          options={OPTIONS}
+          selected={["b"]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      openDropdown();
+
+      expect(
+        screen.getByRole("option", { name: /Alpha/ }),
+      ).toHaveAttribute("aria-selected", "false");
+      expect(
+        screen.getByRole("option", { name: /Beta/ }),
+      ).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByRole("option", { name: /Gamma/ }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  it("keeps the dropdown open when clicking inside the listbox", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectFilter
+        label="Config"
+        options={OPTIONS}
+        selected={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    openDropdown();
+    const listbox = screen.getByRole("listbox", { name: "Config" });
+    expect(listbox).toBeInTheDocument();
+
+    // Click an option inside the listbox — the dropdown must remain open
+    // (counterpart to the outside-click test above). The mousedown handler
+    // should treat clicks inside `ref` as not-outside.
+    await user.click(screen.getByRole("option", { name: /Alpha/ }));
+
+    expect(
+      screen.getByRole("listbox", { name: "Config" }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Follow-up to PR #609 — addresses the deferred test gaps Switch flagged in his review of Trinity's `MultiSelectFilter` tests, recorded in `.squad/decisions/2026-04-21-phase6-polish-nits-deferred.md`.

## Gaps addressed

All four items from Switch's review of #609:

| # | Gap | Coverage added |
|---|-----|----------------|
| 1 | **Toggle / `onChange` behavior** (highest-value miss) | 3 tests in `describe("toggle / onChange")` — drives selection through `userEvent.click` (not `fireEvent`) and asserts the `onChange` payload: add-to-selection, remove-from-selection, and a stateful 4-click sequence proving multi-select is preserved and a deselect doesn't drop siblings. |
| 2 | **Summary-text branches** (single / multi / overflow) | 5 tests in `describe("summary text")` — empty (default + custom `emptyLabel`), single (renders `selected[0]` value, not the label), multi (`N selected`), and a 3-value scaling case. |
| 3 | **`aria-expanded` / `aria-selected`** | 2 tests in `describe("ARIA")` — `aria-expanded` toggles on the trigger when opened/closed; `aria-selected` per `role="option"` matches the selected state. |
| 4 | **Inside-click keeps open** (counterpart to outside-click) | 1 test — clicking an option inside the listbox keeps the dropdown open, complementing the existing outside-click closes-it test. |

## Out of scope (intentionally)

Per Switch's review: keyboard listbox navigation is a **product gap** for the component, not a test gap. Not covered in this PR — routes separately as a Trinity (frontend) ticket.

## Conventions followed

- New interaction tests use `@testing-library/user-event` (per Switch's note). The pre-existing outside-click test still uses `fireEvent.mouseDown` intentionally — the component listens on `mousedown`, not `click`.
- Accessible-role queries (`getByRole("option", { name: /Alpha/ })`, `getByRole("button", { name: "Filter by Config" })`) match the existing file's style.
- Component is **not** modified — this is test-only.

## Test count

| | Before | After |
|--|--------|-------|
| `site/src/__tests__/multi-select-filter.test.tsx` | 3 | 14 |
| `site` total | 122 | 133 |

```
Test Files  15 passed (15)
     Tests  133 passed (133)
```

## Refs

- Issue #608 (Phase 6 polish)
- Follows up on PR #609 (Switch's review)
- Decision: `.squad/decisions/2026-04-21-phase6-polish-nits-deferred.md`
