### PR TITLE
chore(#608): site-embed freshness CI hardening (concurrency, untracked detection, prune)

### DIFF
--- a/.github/workflows/site-embed-freshness.yml
+++ b/.github/workflows/site-embed-freshness.yml
@@ -5,6 +5,14 @@ name: Site Embed Freshness
 # the committed embedded tree differs from a fresh build.
 #
 # See .squad/skills/embedded-asset-freshness/SKILL.md.
+#
+# Deliberate duplication note: this workflow's `npm ci && npm run build`
+# overlaps with ci.yml's `site-build-and-test` job (~1–2 min/run). The
+# duplication is intentional — keeping freshness as a discrete required
+# check gives a clear, named status on PRs ("Verify embedded site bundle is
+# fresh") that reviewers can gate on without reading into a generic site
+# CI job. Reconsider folding into ci.yml only if CI minute pressure
+# materially outweighs the signal clarity.
 
 on:
   pull_request:
@@ -17,10 +25,16 @@ on:
       - 'Makefile'
       - '.github/workflows/site-embed-freshness.yml'
   push:
+    # phase-6 was a temporary integration branch and was removed once it
+    # merged into ronniegeraghty/dev. Add it back only if a similar
+    # short-lived integration line is reopened.
     branches:
       - main
-      - phase-6
       - ronniegeraghty/dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify-embedded-bundle:

--- a/Makefile
+++ b/Makefile
@@ -32,22 +32,37 @@ site-build:
 
 # site-embed is idempotent: rerunning with no source changes leaves the
 # embedded tree byte-identical (vite content-hashes filenames deterministically).
+#
+# Cleanup assumption: vite's output under site/dist/ is a flat tree of
+# `assets/` plus root-level files (currently `index.html`; future builds may
+# emit favicons, manifests, etc.). We wipe $(EMBED_DIR)/* wholesale before
+# copy so stale root-level files are pruned alongside hashed asset files.
+# There are no hand-maintained files (e.g. .gitkeep) inside $(EMBED_DIR);
+# embed.go points at the directory itself, not at a sentinel.
 site-embed: site-build
-	rm -rf $(EMBED_DIR)/assets
+	rm -rf $(EMBED_DIR)/*
 	mkdir -p $(EMBED_DIR)
 	cp -R $(SITE_DIR)/dist/. $(EMBED_DIR)/
 	@echo "[site-embed] refreshed $(EMBED_DIR)/ from $(SITE_DIR)/dist/"
 
 # verify-embed is the CI gate: rebuild and diff. Non-zero exit if the
 # committed embedded bundle drifted from what site/src/** currently produces.
+#
+# We use `git status --porcelain` rather than `git diff --quiet` so that
+# NEW files inside $(EMBED_DIR)/ (untracked by git) also trip the gate.
+# `git diff` only sees modifications to tracked files and would silently
+# pass a build that introduced a new asset filename.
 verify-embed: site-embed
-	@if ! git diff --quiet -- $(EMBED_DIR); then \
+	@if [ -n "$$(git status --porcelain -- $(EMBED_DIR))" ]; then \
 		echo ""; \
 		echo "ERROR: embedded site bundle is stale."; \
 		echo "  site/src/** has changes that were not copied into $(EMBED_DIR)/."; \
 		echo "  Run 'make site-embed' and commit the result."; \
 		echo ""; \
-		echo "Diff:"; \
+		echo "Status:"; \
+		git status --porcelain -- $(EMBED_DIR); \
+		echo ""; \
+		echo "Diff (tracked files only):"; \
 		git --no-pager diff --stat -- $(EMBED_DIR); \
 		exit 1; \
 	fi


### PR DESCRIPTION
Follow-up to Neo's review of #611. Addresses the deferred nits captured in [`.squad/decisions/2026-04-21-phase6-polish-nits-deferred.md`](.squad/decisions/2026-04-21-phase6-polish-nits-deferred.md) (the four CI/Makefile items under *From PR #611*).

## Fixes

### `.github/workflows/site-embed-freshness.yml`
- **Concurrency:** Added `concurrency:` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so superseded PR runs cancel.
- **Prune `phase-6` from `push` triggers:** It was a temporary integration branch; `main` and `ronniegeraghty/dev` remain. Comment notes the rationale.
- **Document deliberate duplication with `ci.yml`:** One-paragraph header comment explaining why the discrete required check is worth the ~1–2 min/run `npm ci && npm run build` overlap. **Not** collapsing into `site-build-and-test` per the deferred-nits decision — discrete signal has value.

### `Makefile`
- **`site-embed` cleanup:** Replaced `rm -rf $(EMBED_DIR)/assets` with `rm -rf $(EMBED_DIR)/*` so stale root-level files (future favicons, manifests, etc.) are pruned alongside hashed asset files. Grounded in vite's actual output shape (`site/dist/` = `assets/` + `index.html`); no hand-maintained files live in the embed dir. Assumption documented inline.
- **`verify-embed` detection:** Switched from `git diff --quiet` to `git status --porcelain` so NEW untracked files inside the embed dir also trip the gate. The plain-diff version silently passed builds that introduced new asset filenames.

## Verification

```
$ make site-embed && make site-embed && git status --porcelain hyoka/internal/serve/site/
(empty — idempotent ✅)

$ touch hyoka/internal/serve/site/stale.txt
$ if [ -n "$(git status --porcelain -- hyoka/internal/serve/site/)" ]; then echo DETECTED; fi
DETECTED ✅

$ go build ./hyoka/...   # clean
$ go test -race ./hyoka/... -timeout 3m   # all packages pass
```

Refs #608. Targets `phase-6`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>